### PR TITLE
Improvements to treeView.writer.wrap().

### DIFF
--- a/src/treeview/writer.js
+++ b/src/treeview/writer.js
@@ -772,6 +772,12 @@ function wrapAttributeElement( wrapper, toWrap ) {
 	return true;
 }
 
+// Unwraps {@link engine.treeView.AttributeElement AttributeElement} from another by removing corresponding attributes,
+// classes and styles. All attributes, classes and styles from wrapper should be present inside element being unwrapped.
+//
+// @param {engine.treeView.AttributeElement} wrapper Wrapper AttributeElement.
+// @param {engine.treeView.AttributeElement} toUnwrap AttributeElement to unwrap using wrapper element.
+// @returns {Boolean} Returns `true` if elements are unwrapped.
 function unwrapAttributeElement( wrapper, toUnwrap ) {
 	// Can't unwrap if name or priority differs.
 	if ( wrapper.name !== toUnwrap.name || wrapper.priority !== toUnwrap.priority ) {
@@ -785,8 +791,8 @@ function unwrapAttributeElement( wrapper, toUnwrap ) {
 			continue;
 		}
 
-		// If some attributes are different we cannot unwrap.
-		if ( toUnwrap.hasAttribute( key ) && toUnwrap.getAttribute( key ) !== wrapper.getAttribute( key ) ) {
+		// If some attributes are missing or different we cannot unwrap.
+		if ( !toUnwrap.hasAttribute( key ) || toUnwrap.getAttribute( key ) !== wrapper.getAttribute( key ) ) {
 			return false;
 		}
 	}
@@ -798,7 +804,8 @@ function unwrapAttributeElement( wrapper, toUnwrap ) {
 
 	// Check if AttributeElement has all wrapper styles.
 	for ( let key of wrapper.getStyleNames() ) {
-		if ( toUnwrap.hasStyle( key ) && toUnwrap.getStyle( key ) !== wrapper.getStyle( key ) ) {
+		// If some styles are missing or different we cannot unwrap.
+		if ( !toUnwrap.hasStyle( key ) || toUnwrap.getStyle( key ) !== wrapper.getStyle( key ) ) {
 			return false;
 		}
 	}

--- a/tests/treecontroller/advanced-converters.js
+++ b/tests/treecontroller/advanced-converters.js
@@ -491,8 +491,6 @@ describe( 'custom attribute handling for given element', () => {
 
 		modelDispatcher.convertInsert( range );
 
-		// The expected value is different than in example or than what is really expected as it should be one link,
-		// but writer does not have merging feature yet.
 		expect( viewToString( viewRoot ) ).to.equal( '<div><a href="foo.html" title="Foo title">foo</a></div>' );
 
 		// Let's change link's attributes.

--- a/tests/treecontroller/advanced-converters.js
+++ b/tests/treecontroller/advanced-converters.js
@@ -16,7 +16,6 @@ import ModelRange from '/ckeditor5/engine/treemodel/range.js';
 import ModelPosition from '/ckeditor5/engine/treemodel/position.js';
 import ModelWalker from '/ckeditor5/engine/treemodel/treewalker.js';
 
-import ViewDocumentFragment from '/ckeditor5/engine/treeview/documentfragment.js';
 import ViewElement from '/ckeditor5/engine/treeview/element.js';
 import ViewContainerElement from '/ckeditor5/engine/treeview/containerelement.js';
 import ViewAttributeElement from '/ckeditor5/engine/treeview/attributeelement.js';
@@ -460,7 +459,6 @@ describe( 'custom attribute handling for given element', () => {
 		} );
 		modelDispatcher.on( 'removeAttribute:linkTitle:quote', modelChangeLinkAttrQuoteConverter );
 
-
 		// QUOTE VIEW TO MODEL CONVERTERS
 		viewDispatcher.on( 'element:blockquote', ( evt, data, consumable, conversionApi ) => {
 			if ( consumable.consume( data.input, { name: true } ) ) {
@@ -495,7 +493,7 @@ describe( 'custom attribute handling for given element', () => {
 
 		// The expected value is different than in example or than what is really expected as it should be one link,
 		// but writer does not have merging feature yet.
-		expect( viewToString( viewRoot ) ).to.equal( '<div><a title="Foo title"><a href="foo.html">foo</a></a></div>' );
+		expect( viewToString( viewRoot ) ).to.equal( '<div><a href="foo.html" title="Foo title">foo</a></div>' );
 
 		// Let's change link's attributes.
 		for ( let value of range ) {
@@ -505,7 +503,7 @@ describe( 'custom attribute handling for given element', () => {
 		modelDispatcher.convertAttribute( 'changeAttribute', range, 'linkHref', 'foo.html', 'bar.html' );
 		modelDispatcher.convertAttribute( 'changeAttribute', range, 'linkTitle', 'Foo title', 'Bar title' );
 
-		expect( viewToString( viewRoot ) ).to.equal( '<div><a title="Bar title"><a href="bar.html">foo</a></a></div>' );
+		expect( viewToString( viewRoot ) ).to.equal( '<div><a href="bar.html" title="Bar title">foo</a></div>' );
 
 		// Let's remove a letter from the link.
 		const removed = modelRoot.removeChildren( 0, 1 );
@@ -515,7 +513,7 @@ describe( 'custom attribute handling for given element', () => {
 			ModelRange.createFromElement( modelDoc.graveyard )
 		);
 
-		expect( viewToString( viewRoot ) ).to.equal( '<div><a title="Bar title"><a href="bar.html">oo</a></a></div>' );
+		expect( viewToString( viewRoot ) ).to.equal( '<div><a href="bar.html" title="Bar title">oo</a></div>' );
 
 		range = ModelRange.createFromElement( modelRoot );
 
@@ -591,7 +589,7 @@ describe( 'custom attribute handling for given element', () => {
 					'a',
 					{
 						href: 'foo.html',
-						title:'Foo source'
+						title: 'Foo source'
 					},
 					new ViewText( 'see source' )
 				)
@@ -661,7 +659,8 @@ it( 'default table view to model converter', () => {
 	let model = viewDispatcher.convert( viewTable );
 	let modelFragment = new ModelDocumentFragment( model );
 
-	expect( modelToString( modelFragment ) ).to.equal( '<paragraph>foo <$text linkHref="bar.html">bar</$text></paragraph><paragraph>abc</paragraph>' );
+	expect( modelToString( modelFragment ) )
+		.to.equal( '<paragraph>foo <$text linkHref="bar.html">bar</$text></paragraph><paragraph>abc</paragraph>' );
 } );
 
 // Model converter that converts any non-converted elements and attributes into view elements and attributes.

--- a/tests/treeview/writer/unwrap.js
+++ b/tests/treeview/writer/unwrap.js
@@ -710,7 +710,7 @@ describe( 'Writer', () => {
 
 		it( 'should unwrap single element by removing matching attributes', () => {
 			// <p>[<b foo="bar" baz="qux" >test</b>]</p>
-			// unwrap using <b baz="qux">test</b></p>
+			// unwrap using <b baz="qux"></b>
 			// <p>[<b foo="bar">test</b>]</p>
 			const text = new Text( 'test' );
 			const b = new AttributeElement( 'b', {
@@ -746,7 +746,7 @@ describe( 'Writer', () => {
 
 		it( 'should not unwrap single element when attributes are different', () => {
 			// <p>[<b foo="bar" baz="qux">test</b>]</p>
-			// unwrap using <b baz="qux" test="true">test</b></p>
+			// unwrap using <b baz="qux" test="true"></b>
 			// <p>[<b foo="bar" baz="qux">test</b>]</p>
 			const text = new Text( 'test' );
 			const b = new AttributeElement( 'b', {
@@ -783,7 +783,7 @@ describe( 'Writer', () => {
 
 		it( 'should unwrap single element by removing matching classes', () => {
 			// <p>[<b class="foo bar baz">test</b>]</p>
-			// unwrap using <b class="baz foo">test</b></p>
+			// unwrap using <b class="baz foo"></b>
 			// <p>[<b class="bar">test</b>]</p>
 			const text = new Text( 'test' );
 			const b = new AttributeElement( 'b', {
@@ -819,7 +819,7 @@ describe( 'Writer', () => {
 
 		it( 'should not unwrap single element when classes are different', () => {
 			// <p>[<b class="foo bar baz">test</b>]</p>
-			// unwrap using <b class="baz foo qux">test</b></p>
+			// unwrap using <b class="baz foo qux"></b>
 			// <p>[<b class="foo bar baz">test</b>]</p>
 			const text = new Text( 'test' );
 			const b = new AttributeElement( 'b', {
@@ -855,7 +855,7 @@ describe( 'Writer', () => {
 
 		it( 'should unwrap single element by removing matching styles', () => {
 			// <p>[<b style="color:red; position:absolute; top:10px;">test</b>]</p>
-			// unwrap using <b style="position: absolute;">test</b></p>
+			// unwrap using <b style="position: absolute;"></b>
 			// <p>[<b style="color:red; top:10px;">test</b>]</p>
 			const text = new Text( 'test' );
 			const b = new AttributeElement( 'b', {
@@ -891,7 +891,7 @@ describe( 'Writer', () => {
 
 		it( 'should not unwrap single element when styles are different', () => {
 			// <p>[<b style="color:red; position:absolute; top:10px;">test</b>]</p>
-			// unwrap using <b style="position: relative;">test</b></p>
+			// unwrap using <b style="position: relative;"></b>
 			// <p>[<b style="color:red; position:absolute; top:10px;">test</b>]</p>
 			const text = new Text( 'test' );
 			const b = new AttributeElement( 'b', {

--- a/tests/treeview/writer/unwrap.js
+++ b/tests/treeview/writer/unwrap.js
@@ -707,5 +707,222 @@ describe( 'Writer', () => {
 				]
 			} );
 		} );
+
+		it( 'should unwrap single element by removing matching attributes', () => {
+			// <p>[<b foo="bar" baz="qux" >test</b>]</p>
+			// unwrap using <b baz="qux">test</b></p>
+			// <p>[<b foo="bar">test</b>]</p>
+			const text = new Text( 'test' );
+			const b = new AttributeElement( 'b', {
+				foo: 'bar',
+				baz: 'qux'
+			}, text );
+			const p = new ContainerElement( 'p', null, b );
+			const wrapper = new AttributeElement( 'b', {
+				baz: 'qux'
+			} );
+			const range = Range.createFromParentsAndOffsets( p, 0, p, 1 );
+
+			const newRange = writer.unwrap( range, wrapper );
+			expect( b.getAttribute( 'foo' ) ).to.equal( 'bar' );
+			expect( b.hasAttribute( 'baz' ) ).to.be.false;
+			expect( b.parent ).to.equal( p );
+			test( writer, newRange, p, {
+				instanceof: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{
+						instanceof: AttributeElement,
+						name: 'b',
+						children: [
+							{ instanceof: Text, data: 'test' }
+						]
+					}
+				]
+			} );
+		} );
+
+		it( 'should not unwrap single element when attributes are different', () => {
+			// <p>[<b foo="bar" baz="qux">test</b>]</p>
+			// unwrap using <b baz="qux" test="true">test</b></p>
+			// <p>[<b foo="bar" baz="qux">test</b>]</p>
+			const text = new Text( 'test' );
+			const b = new AttributeElement( 'b', {
+				foo: 'bar',
+				baz: 'qux'
+			}, text );
+			const p = new ContainerElement( 'p', null, b );
+			const wrapper = new AttributeElement( 'b', {
+				baz: 'qux',
+				test: 'true'
+			} );
+			const range = Range.createFromParentsAndOffsets( p, 0, p, 1 );
+
+			const newRange = writer.unwrap( range, wrapper );
+			expect( b.getAttribute( 'foo' ) ).to.equal( 'bar' );
+			expect( b.getAttribute( 'baz' ) ).to.equal( 'qux' );
+			expect( b.parent ).to.equal( p );
+			test( writer, newRange, p, {
+				instanceof: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{
+						instanceof: AttributeElement,
+						name: 'b',
+						children: [
+							{ instanceof: Text, data: 'test' }
+						]
+					}
+				]
+			} );
+		} );
+
+		it( 'should unwrap single element by removing matching classes', () => {
+			// <p>[<b class="foo bar baz">test</b>]</p>
+			// unwrap using <b class="baz foo">test</b></p>
+			// <p>[<b class="bar">test</b>]</p>
+			const text = new Text( 'test' );
+			const b = new AttributeElement( 'b', {
+				class: 'foo bar baz'
+			}, text );
+			const p = new ContainerElement( 'p', null, b );
+			const wrapper = new AttributeElement( 'b', {
+				class: 'baz foo'
+			} );
+			const range = Range.createFromParentsAndOffsets( p, 0, p, 1 );
+
+			const newRange = writer.unwrap( range, wrapper );
+			expect( b.hasClass( 'bar' ) ).to.be.true;
+			expect( b.hasClass( 'foo' ) ).to.be.false;
+			expect( b.hasClass( 'baz' ) ).to.be.false;
+			expect( b.parent ).to.equal( p );
+			test( writer, newRange, p, {
+				instanceof: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{
+						instanceof: AttributeElement,
+						name: 'b',
+						children: [
+							{ instanceof: Text, data: 'test' }
+						]
+					}
+				]
+			} );
+		} );
+
+		it( 'should not unwrap single element when classes are different', () => {
+			// <p>[<b class="foo bar baz">test</b>]</p>
+			// unwrap using <b class="baz foo qux">test</b></p>
+			// <p>[<b class="foo bar baz">test</b>]</p>
+			const text = new Text( 'test' );
+			const b = new AttributeElement( 'b', {
+				class: 'foo bar baz'
+			}, text );
+			const p = new ContainerElement( 'p', null, b );
+			const wrapper = new AttributeElement( 'b', {
+				class: 'baz foo qux'
+			} );
+			const range = Range.createFromParentsAndOffsets( p, 0, p, 1 );
+
+			const newRange = writer.unwrap( range, wrapper );
+			expect( b.hasClass( 'bar' ) ).to.be.true;
+			expect( b.hasClass( 'foo' ) ).to.be.true;
+			expect( b.hasClass( 'baz' ) ).to.be.true;
+			expect( b.parent ).to.equal( p );
+			test( writer, newRange, p, {
+				instanceof: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{
+						instanceof: AttributeElement,
+						name: 'b',
+						children: [
+							{ instanceof: Text, data: 'test' }
+						]
+					}
+				]
+			} );
+		} );
+
+		it( 'should unwrap single element by removing matching styles', () => {
+			// <p>[<b style="color:red; position:absolute; top:10px;">test</b>]</p>
+			// unwrap using <b style="position: absolute;">test</b></p>
+			// <p>[<b style="color:red; top:10px;">test</b>]</p>
+			const text = new Text( 'test' );
+			const b = new AttributeElement( 'b', {
+				style: 'color:red; position:absolute; top:10px;'
+			}, text );
+			const p = new ContainerElement( 'p', null, b );
+			const wrapper = new AttributeElement( 'b', {
+				style: 'position: absolute;'
+			} );
+			const range = Range.createFromParentsAndOffsets( p, 0, p, 1 );
+
+			const newRange = writer.unwrap( range, wrapper );
+			expect( b.getStyle( 'color' ) ).to.equal( 'red' );
+			expect( b.getStyle( 'top' ) ).to.equal( '10px' );
+			expect( b.hasStyle( 'position' ) ).to.be.false;
+			expect( b.parent ).to.equal( p );
+			test( writer, newRange, p, {
+				instanceof: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{
+						instanceof: AttributeElement,
+						name: 'b',
+						children: [
+							{ instanceof: Text, data: 'test' }
+						]
+					}
+				]
+			} );
+		} );
+
+		it( 'should not unwrap single element when styles are different', () => {
+			// <p>[<b style="color:red; position:absolute; top:10px;">test</b>]</p>
+			// unwrap using <b style="position: relative;">test</b></p>
+			// <p>[<b style="color:red; position:absolute; top:10px;">test</b>]</p>
+			const text = new Text( 'test' );
+			const b = new AttributeElement( 'b', {
+				style: 'color:red; position:absolute; top:10px;'
+			}, text );
+			const p = new ContainerElement( 'p', null, b );
+			const wrapper = new AttributeElement( 'b', {
+				style: 'position: relative;'
+			} );
+			const range = Range.createFromParentsAndOffsets( p, 0, p, 1 );
+
+			const newRange = writer.unwrap( range, wrapper );
+			expect( b.getStyle( 'color' ) ).to.equal( 'red' );
+			expect( b.getStyle( 'top' ) ).to.equal( '10px' );
+			expect( b.getStyle( 'position' ) ).to.equal( 'absolute' );
+			expect( b.parent ).to.equal( p );
+			test( writer, newRange, p, {
+				instanceof: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{
+						instanceof: AttributeElement,
+						name: 'b',
+						children: [
+							{ instanceof: Text, data: 'test' }
+						]
+					}
+				]
+			} );
+		} );
 	} );
 } );

--- a/tests/treeview/writer/wrap.js
+++ b/tests/treeview/writer/wrap.js
@@ -551,5 +551,130 @@ describe( 'Writer', () => {
 				]
 			} );
 		} );
+
+		it( 'should wrap single element by joining attributes', () => {
+			// <p>[<b foo="bar" one="two"></b>]</p>
+			// wrap with <b baz="qux" one="two"></b>
+			// <p>[<b foo="bar" one="two" baz="qux"></b>]</p>
+			const b = new AttributeElement( 'b', {
+				foo: 'bar',
+				one: 'two'
+			} );
+			const p = new ContainerElement( 'p', null, b );
+			const range = Range.createFromParentsAndOffsets( p, 0, p, 1 );
+			const wrapper = new AttributeElement( 'b', {
+				baz: 'qux',
+				one: 'two'
+			} );
+
+			const newRange = writer.wrap( range, wrapper );
+			expect( b.getAttribute( 'foo' ) ).to.equal( 'bar' );
+			expect( b.getAttribute( 'baz' ) ).to.equal( 'qux' );
+			expect( b.getAttribute( 'one' ) ).to.equal( 'two' );
+
+			test( writer, newRange, p, {
+				instanceOf: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{ instanceOf: AttributeElement, name: 'b', children: [] }
+				]
+			} );
+		} );
+
+		it( 'should wrap single element by joining classes', () => {
+			// <p>[<b class="foo bar baz" ></b>]</p>
+			// wrap with <b class="foo bar qux jax"></b>
+			// <p>[<b class="foo bar baz qux jax"></b>]</p>
+			const b = new AttributeElement( 'b', {
+				class: 'foo bar baz'
+			} );
+			const p = new ContainerElement( 'p', null, b );
+			const range = Range.createFromParentsAndOffsets( p, 0, p, 1 );
+			const wrapper = new AttributeElement( 'b', {
+				class: 'foo bar qux jax'
+			} );
+
+			const newRange = writer.wrap( range, wrapper );
+			expect( b.hasClass( 'foo', 'bar', 'baz', 'qux', 'jax' ) ).to.be.true;
+			test( writer, newRange, p, {
+				instanceOf: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{ instanceOf: AttributeElement, name: 'b', children: [] }
+				]
+			} );
+		} );
+
+		it( 'should wrap single element by joining styles', () => {
+			// <p>[<b style="color:red; position: absolute;"></b>]</p>
+			// wrap with <b style="color:red; top: 20px;"></b>
+			// <p>[<b class="color:red; position: absolute; top:20px;"></b>]</p>
+			const b = new AttributeElement( 'b', {
+				style: 'color: red; position: absolute;'
+			} );
+			const p = new ContainerElement( 'p', null, b );
+			const range = Range.createFromParentsAndOffsets( p, 0, p, 1 );
+			const wrapper = new AttributeElement( 'b', {
+				style: 'color:red; top: 20px;'
+			} );
+
+			const newRange = writer.wrap( range, wrapper );
+			expect( b.getStyle( 'color' ) ).to.equal( 'red' );
+			expect( b.getStyle( 'position' ) ).to.equal( 'absolute' );
+			expect( b.getStyle( 'top' ) ).to.equal( '20px' );
+
+			test( writer, newRange, p, {
+				instanceOf: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{ instanceOf: AttributeElement, name: 'b', children: [] }
+				]
+			} );
+		} );
+
+		it( 'should be merged with outside element when wrapping all children', () => {
+			// <p><b foo="bar">[{foobar}<i>{baz}</i>]</b></p>
+			// wrap with <b baz="qux"></b>
+			// <p>[<b foo="bar" baz="qux">{foobar}</b>]</p>
+			const text1 = new Text( 'foobar' );
+			const text2 = new Text( 'baz' );
+			const i = new AttributeElement( 'i', null, text2 );
+			const b = new AttributeElement( 'b', { foo: 'bar' }, [ text1, i ] );
+			const p = new ContainerElement( 'p', null, [ b ] );
+			const wrapper = new AttributeElement( 'b', { baz: 'qux' } );
+			const range = Range.createFromParentsAndOffsets( b, 0, b, 2 );
+
+			const newRange = writer.wrap( range, wrapper );
+			expect( b.getAttribute( 'foo' ) ).to.equal( 'bar' );
+			expect( b.getAttribute( 'baz' ) ).to.equal( 'qux' );
+			test( writer, newRange, p, {
+				instanceOf: ContainerElement,
+				name: 'p',
+				rangeStart: 0,
+				rangeEnd: 1,
+				children: [
+					{
+						instanceof: AttributeElement,
+						name: 'b',
+						children: [
+							{ instanceOf: Text, data: 'foobar' },
+							{
+								instanceOf: AttributeElement,
+								name: 'i',
+								children: [
+									{ instanceOf: Text, data: 'baz' }
+								]
+							}
+						]
+					}
+				]
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
This PR contains improvements added to `treeView.writer.wrap()` method. Now it handles `AttributeElement` wrapping by merging attributes/styles/classes whenever possible, as described in #252.