### PR TITLE
Parsing empty document fragment in testing tools

### DIFF
--- a/src/view/node.js
+++ b/src/view/node.js
@@ -123,7 +123,7 @@ export default class Node {
 		const ancestors = [];
 		let parent = options.includeNode ? this : this.parent;
 
-		while ( parent !== null ) {
+		while ( parent ) {
 			ancestors[ options.parentFirst ? 'push' : 'unshift' ]( parent );
 			parent = parent.parent;
 		}

--- a/tests/_utils-tests/model.js
+++ b/tests/_utils-tests/model.js
@@ -301,6 +301,42 @@ describe( 'model test utils', () => {
 	} );
 
 	describe( 'parse', () => {
+		test( 'creates empty DocumentFragment from empty string', {
+			data: '',
+			check( fragment ) {
+				expect( fragment ).to.be.instanceOf( DocumentFragment );
+			}
+		} );
+
+		test( 'creates empty DocumentFragment with selection', {
+			data: '<selection />',
+			check( fragment, selection ) {
+				expect( fragment ).to.be.instanceOf( DocumentFragment );
+				expect( fragment.getChildCount() ).to.equal( 0 );
+				expect( selection.rangeCount ).to.equal( 1 );
+				expect( selection.getFirstRange().isEqual( Range.createFromParentsAndOffsets( fragment, 0, fragment, 0 ) ) ).to.be.true;
+			}
+		} );
+
+		test( 'returns Element if range is around single element', {
+			data: '<selection><a></a></selection>',
+			check( el, selection ) {
+				const fragment = el.parent;
+				expect( el ).to.be.instanceOf( Element );
+				expect( fragment ).to.be.instanceOf( DocumentFragment );
+				expect( selection.rangeCount ).to.equal( 1 );
+				expect( selection.getFirstRange().isEqual( Range.createFromParentsAndOffsets( fragment, 0, fragment, 1 ) ) ).to.be.true;
+			}
+		} );
+
+		test( 'returns DocumentFragment when multiple elements on root', {
+			data: '<a></a><b></b>',
+			check( fragment ) {
+				expect( fragment ).to.be.instanceOf( DocumentFragment );
+				expect( fragment.getChildCount() ).to.equal( 2 );
+			}
+		} );
+
 		test( 'creates elements', {
 			data: '<a></a><b><c></c></b>'
 		} );

--- a/tests/_utils-tests/view.js
+++ b/tests/_utils-tests/view.js
@@ -311,6 +311,39 @@ describe( 'view test utils', () => {
 	} );
 
 	describe( 'parse', () => {
+		it( 'should return empty DocumentFragment for empty string', () => {
+			const fragment = parse( '' );
+
+			expect( fragment ).to.be.instanceOf( DocumentFragment );
+			expect( fragment.getChildCount() ).to.equal( 0 );
+		} );
+
+		it( 'should return empty DocumentFragment and Selection for string containing range only', () => {
+			const { view, selection } = parse( '[]' );
+
+			expect( view ).to.be.instanceOf( DocumentFragment );
+			expect( selection.rangeCount ).to.equal( 1 );
+			expect( selection.getFirstRange().isEqual( Range.createFromParentsAndOffsets( view, 0, view, 0 ) ) ).to.be.true;
+		} );
+
+		it( 'should return Element if range is around single element', () => {
+			const { view, selection } = parse( '[<b>foobar</b>]' );
+			const parent = view.parent;
+
+			expect( view ).to.be.instanceOf( Element );
+			expect( parent ).to.be.instanceOf( DocumentFragment );
+			expect( selection.rangeCount ).to.equal( 1 );
+			expect( selection.getFirstRange().isEqual( Range.createFromParentsAndOffsets( parent, 0, parent, 1 ) ) ).to.be.true;
+		} );
+
+		it( 'should create DocumentFragment when multiple elements on root', () => {
+			const view = parse( '<b></b><i></i>' );
+			expect( view ).to.be.instanceOf( DocumentFragment );
+			expect( view.getChildCount() ).to.equal( 2 );
+			expect( view.getChild( 0 ).isSimilar( new Element( 'b' ) ) ).to.be.true;
+			expect( view.getChild( 1 ).isSimilar( new Element( 'i' ) ) ).to.be.true;
+		} );
+
 		it( 'should parse text', () => {
 			const text = parse( 'foobar' );
 			expect( text ).to.be.instanceOf( Text );
@@ -367,14 +400,6 @@ describe( 'view test utils', () => {
 			parsed1.isSimilar( attribute1 );
 			expect( parsed1.isSimilar( attribute1 ) ).to.be.true;
 			expect( parsed2.isSimilar( attribute2 ) ).to.be.true;
-		} );
-
-		it( 'should create DocumentFragment when multiple elements on root', () => {
-			const view = parse( '<b></b><i></i>' );
-			expect( view ).to.be.instanceOf( DocumentFragment );
-			expect( view.getChildCount() ).to.equal( 2 );
-			expect( view.getChild( 0 ).isSimilar( new Element( 'b' ) ) ).to.be.true;
-			expect( view.getChild( 1 ).isSimilar( new Element( 'i' ) ) ).to.be.true;
 		} );
 
 		it( 'should paste nested elements and texts', () => {
@@ -471,13 +496,6 @@ describe( 'view test utils', () => {
 			expect( ranges[ 2 ].isEqual( Range.createFromParentsAndOffsets( view, 0, view, 1 ) ) ).to.be.true;
 			expect( selection.anchor.isEqual( ranges[ 2 ].end ) ).to.be.true;
 			expect( selection.focus.isEqual( ranges[ 2 ].start ) ).to.be.true;
-		} );
-
-		it( 'should return DocumentFragment if range is around single element', () => {
-			const { view, selection } = parse( '[<b>foobar</b>]' );
-			expect( view ).to.be.instanceOf( DocumentFragment );
-			expect( selection.rangeCount ).to.equal( 1 );
-			expect( selection.getFirstRange().isEqual( Range.createFromParentsAndOffsets( view, 0, view, 1 ) ) ).to.be.true;
 		} );
 
 		it( 'should throw when ranges order does not include all ranges', () => {

--- a/tests/_utils/view.js
+++ b/tests/_utils/view.js
@@ -199,11 +199,6 @@ export function stringify( node, selectionOrPositionOrRange = null, options = {}
 
 /**
  * Parses HTML-like string and returns view tree nodes.
- *
- * Empty string will be converted to empty {@link engine.view.DocumentFragment DocumentFragment}.
- *
- *		parse( '' ); // Returns instance of DocumentFragment.
- *
  * Simple string will be converted to {@link engine.view.Text Text} node:
  *
  *		parse( 'foobar' ); // Returns instance of Text.
@@ -239,6 +234,17 @@ export function stringify( node, selectionOrPositionOrRange = null, options = {}
  * represented by `start` position) use `lastRangeBackward` flag:
  *
  *		const { root, selection } = parse( `{foo}bar{baz}`, { lastRangeBackward: true } );
+ *
+ * Other examples and edge cases:
+ *
+ *		// Returns empty DocumentFragment.
+ *		parse( '' );
+ *
+ *		// Returns empty DocumentFragment and collapsed selection.
+ *		const { root, selection } = parse( '[]' );
+ *
+ *		// Returns Element and selection that is placed inside of DocumentFragment containing that element.
+ *		const { root, selection } = parse( '[<a></a>]' );
  *
  * @param {String} data HTML-like string to be parsed.
  * @param {Object} options

--- a/tests/_utils/view.js
+++ b/tests/_utils/view.js
@@ -268,7 +268,7 @@ export function parse( data, options = {} ) {
 	let view = viewParser.parse( data, options.rootElement );
 
 	// If single Element or Text is returned - move it to the DocumentFragment.
-	if ( view instanceof ViewText || view instanceof ViewElement ) {
+	if ( !options.rootElement && ( view instanceof ViewText || view instanceof ViewElement ) ) {
 		view = new ViewDocumentFragment( view );
 	}
 
@@ -288,6 +288,11 @@ export function parse( data, options = {} ) {
 			view: view,
 			selection: selection
 		};
+	}
+
+	// If single element is returned without selection - remove it from parent and return detached element.
+	if ( view.parent ) {
+		view.remove();
 	}
 
 	return view;

--- a/tests/_utils/view.js
+++ b/tests/_utils/view.js
@@ -199,6 +199,11 @@ export function stringify( node, selectionOrPositionOrRange = null, options = {}
 
 /**
  * Parses HTML-like string and returns view tree nodes.
+ *
+ * Empty string will be converted to empty {@link engine.view.DocumentFragment DocumentFragment}.
+ *
+ *		parse( '' ); // Returns instance of DocumentFragment.
+ *
  * Simple string will be converted to {@link engine.view.Text Text} node:
  *
  *		parse( 'foobar' ); // Returns instance of Text.
@@ -254,8 +259,19 @@ export function parse( data, options = {} ) {
 	const viewParser = new ViewParser();
 	const rangeParser = new RangeParser();
 
-	const view = viewParser.parse( data, options.rootElement );
+	let view = viewParser.parse( data, options.rootElement );
+
+	// If single Element or Text is returned - move it to the DocumentFragment.
+	if ( view instanceof ViewText || view instanceof ViewElement ) {
+		view = new ViewDocumentFragment( view );
+	}
+
 	const ranges = rangeParser.parse( view, options.order );
+
+	// If only one element is returned inside DocumentFragment - return that element.
+	if ( view instanceof ViewDocumentFragment && view.getChildCount() === 1 ) {
+		view = view.getChild( 0 );
+	}
 
 	// When ranges are present - return object containing view, and selection.
 	if ( ranges.length ) {

--- a/tests/view/node.js
+++ b/tests/view/node.js
@@ -100,6 +100,17 @@ describe( 'Node', () => {
 			expect( result2[ 1 ] ).to.equal( two );
 			expect( result2[ 0 ] ).to.equal( charR );
 		} );
+
+		it( 'should return ancestors including DocumentFragment', () => {
+			const fragment = new DocumentFragment( root );
+			const result = img.getAncestors();
+			root.remove();
+
+			expect( result.length ).to.equal( 3 );
+			expect( result[ 0 ] ).to.equal( fragment );
+			expect( result[ 1 ] ).to.equal( root );
+			expect( result[ 2 ] ).to.equal( two );
+		} );
 	} );
 
 	describe( 'getIndex', () => {

--- a/tests/view/writer/breakAt.js
+++ b/tests/view/writer/breakAt.js
@@ -8,9 +8,6 @@
 'use strict';
 
 import { breakAt } from '/ckeditor5/engine/view/writer.js';
-import DocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
-import AttributeElement from '/ckeditor5/engine/view/attributeelement.js';
-import Text from '/ckeditor5/engine/view/text.js';
 import { stringify, parse } from '/tests/engine/_utils/view.js';
 
 describe( 'writer', () => {
@@ -24,13 +21,8 @@ describe( 'writer', () => {
 	function test( input, expected ) {
 		let { view, selection } = parse( input );
 
-		// Wrap attributes and text into DocumentFragment.
-		if ( view instanceof AttributeElement || view instanceof Text ) {
-			view = new DocumentFragment( view );
-		}
-
 		const newPosition = breakAt( selection.getFirstPosition() );
-		expect( stringify( view, newPosition, { showType: true, showPriority: true } ) ).to.equal( expected );
+		expect( stringify( view.getRoot(), newPosition, { showType: true, showPriority: true } ) ).to.equal( expected );
 	}
 
 	describe( 'breakAt', () => {

--- a/tests/view/writer/breakrange.js
+++ b/tests/view/writer/breakrange.js
@@ -8,10 +8,8 @@
 'use strict';
 
 import { breakRange } from '/ckeditor5/engine/view/writer.js';
-import DocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
 import ContainerElement from '/ckeditor5/engine/view/containerelement.js';
 import AttributeElement from '/ckeditor5/engine/view/attributeelement.js';
-import Text from '/ckeditor5/engine/view/text.js';
 import Range from '/ckeditor5/engine/view/range.js';
 import { stringify, parse } from '/tests/engine/_utils/view.js';
 import CKEditorError from '/ckeditor5/utils/ckeditorerror.js';
@@ -26,12 +24,8 @@ describe( 'writer', () => {
 	function test( input, expected ) {
 		let { view, selection } = parse( input );
 
-		if ( view instanceof AttributeElement || view instanceof Text ) {
-			view = new DocumentFragment( view );
-		}
-
 		const newRange = breakRange( selection.getFirstRange() );
-		expect( stringify( view, newRange, { showType: true } ) ).to.equal( expected );
+		expect( stringify( view.getRoot(), newRange, { showType: true } ) ).to.equal( expected );
 	}
 
 	describe( 'breakRange', () => {

--- a/tests/view/writer/insert.js
+++ b/tests/view/writer/insert.js
@@ -28,7 +28,7 @@ describe( 'writer', () => {
 		let { view, selection } = parse( input );
 
 		const newRange = insert( selection.getFirstPosition(), nodesToInsert );
-		expect( stringify( view.parent, newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
+		expect( stringify( view.getRoot(), newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
 	}
 
 	describe( 'insert', () => {

--- a/tests/view/writer/insert.js
+++ b/tests/view/writer/insert.js
@@ -8,14 +8,12 @@
 'use strict';
 
 import { insert } from '/ckeditor5/engine/view/writer.js';
-import DocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
 import ContainerElement from '/ckeditor5/engine/view/containerelement.js';
 import Element from '/ckeditor5/engine/view/element.js';
 import Position from '/ckeditor5/engine/view/position.js';
 import CKEditorError from '/ckeditor5/utils/ckeditorerror.js';
 import { stringify, parse } from '/tests/engine/_utils/view.js';
 import AttributeElement from '/ckeditor5/engine/view/attributeelement.js';
-import Text from '/ckeditor5/engine/view/text.js';
 
 describe( 'writer', () => {
 	/**
@@ -29,12 +27,8 @@ describe( 'writer', () => {
 		nodesToInsert = nodesToInsert.map( node => parse( node ) );
 		let { view, selection } = parse( input );
 
-		if ( view instanceof AttributeElement || view instanceof Text ) {
-			view = new DocumentFragment( view );
-		}
-
 		const newRange = insert( selection.getFirstPosition(), nodesToInsert );
-		expect( stringify( view, newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
+		expect( stringify( view.parent, newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
 	}
 
 	describe( 'insert', () => {

--- a/tests/view/writer/move.js
+++ b/tests/view/writer/move.js
@@ -8,10 +8,7 @@
 'use strict';
 
 import { move } from '/ckeditor5/engine/view/writer.js';
-import DocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
 import { stringify, parse } from '/tests/engine/_utils/view.js';
-import AttributeElement from '/ckeditor5/engine/view/attributeelement.js';
-import Text from '/ckeditor5/engine/view/text.js';
 
 describe( 'writer', () => {
 	/**
@@ -25,14 +22,6 @@ describe( 'writer', () => {
 	function test( source, destination, sourceAfterMove, destinationAfterMove ) {
 		let { view: srcView, selection: srcSelection } = parse( source );
 		let { view: dstView, selection: dstSelection } = parse( destination );
-
-		if ( srcView instanceof AttributeElement || srcView instanceof Text ) {
-			srcView = new DocumentFragment( srcView );
-		}
-
-		if ( dstView instanceof AttributeElement || dstView instanceof Text ) {
-			dstView = new DocumentFragment( dstView );
-		}
 
 		const newRange = move( srcSelection.getFirstRange(), dstSelection.getFirstPosition() );
 

--- a/tests/view/writer/remove.js
+++ b/tests/view/writer/remove.js
@@ -13,7 +13,6 @@ import Range from '/ckeditor5/engine/view/range.js';
 import DocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
 import { stringify, parse } from '/tests/engine/_utils/view.js';
 import AttributeElement from '/ckeditor5/engine/view/attributeelement.js';
-import Text from '/ckeditor5/engine/view/text.js';
 import CKEditorError from '/ckeditor5/utils/ckeditorerror.js';
 
 describe( 'writer', () => {
@@ -27,10 +26,6 @@ describe( 'writer', () => {
 	 */
 	function test( input, expectedResult, expectedRemoved ) {
 		let { view, selection } = parse( input );
-
-		if ( view instanceof AttributeElement || view instanceof Text ) {
-			view = new DocumentFragment( view );
-		}
 
 		const range = selection.getFirstRange();
 		const removed = remove( range );

--- a/tests/view/writer/unwrap.js
+++ b/tests/view/writer/unwrap.js
@@ -11,7 +11,6 @@ import { unwrap } from '/ckeditor5/engine/view/writer.js';
 import Element from '/ckeditor5/engine/view/element.js';
 import ContainerElement from '/ckeditor5/engine/view/containerelement.js';
 import AttributeElement from '/ckeditor5/engine/view/attributeelement.js';
-import DocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
 import Position from '/ckeditor5/engine/view/position.js';
 import Range from '/ckeditor5/engine/view/range.js';
 import Text from '/ckeditor5/engine/view/text.js';
@@ -29,12 +28,8 @@ describe( 'writer', () => {
 	function test( input, unwrapAttribute, expected ) {
 		let { view, selection } = parse( input );
 
-		if ( view instanceof AttributeElement || view instanceof Text ) {
-			view = new DocumentFragment( view );
-		}
-
 		const newRange = unwrap( selection.getFirstRange(), parse( unwrapAttribute ) );
-		expect( stringify( view, newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
+		expect( stringify( view.getRoot(), newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
 	}
 
 	describe( 'unwrap', () => {

--- a/tests/view/writer/wrap.js
+++ b/tests/view/writer/wrap.js
@@ -11,7 +11,6 @@ import { wrap } from '/ckeditor5/engine/view/writer.js';
 import Element from '/ckeditor5/engine/view/element.js';
 import ContainerElement from '/ckeditor5/engine/view/containerelement.js';
 import AttributeElement from '/ckeditor5/engine/view/attributeelement.js';
-import DocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
 import Position from '/ckeditor5/engine/view/position.js';
 import Range from '/ckeditor5/engine/view/range.js';
 import Text from '/ckeditor5/engine/view/text.js';
@@ -23,18 +22,14 @@ describe( 'writer', () => {
 	 * Executes test using `parse` and `stringify` utils functions.
 	 *
 	 * @param {String} input
-	 * @param {String} unwrapAttribute
+	 * @param {String} wrapAttribute
 	 * @param {String} expected
 	 */
-	function test( input, unwrapAttribute, expected ) {
+	function test( input, wrapAttribute, expected ) {
 		let { view, selection } = parse( input );
+		const newRange = wrap( selection.getFirstRange(), parse( wrapAttribute ) );
 
-		if ( view instanceof AttributeElement || view instanceof Text ) {
-			view = new DocumentFragment( view );
-		}
-
-		const newRange = wrap( selection.getFirstRange(), parse( unwrapAttribute ) );
-		expect( stringify( view, newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
+		expect( stringify( view.getRoot(), newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
 	}
 
 	describe( 'wrap', () => {

--- a/tests/view/writer/wrapposition.js
+++ b/tests/view/writer/wrapposition.js
@@ -11,11 +11,9 @@ import { wrapPosition } from '/ckeditor5/engine/view/writer.js';
 import Text from '/ckeditor5/engine/view/text.js';
 import Element from '/ckeditor5/engine/view/element.js';
 import ContainerElement from '/ckeditor5/engine/view/containerelement.js';
-import DocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
 import Position from '/ckeditor5/engine/view/position.js';
 import CKEditorError from '/ckeditor5/utils/ckeditorerror.js';
 import { stringify, parse } from '/tests/engine/_utils/view.js';
-import AttributeElement from '/ckeditor5/engine/view/attributeelement.js';
 
 describe( 'wrapPosition', () => {
 	/**
@@ -27,10 +25,6 @@ describe( 'wrapPosition', () => {
 	 */
 	function test( input, unwrapAttribute, expected ) {
 		let { view, selection } = parse( input );
-
-		if ( view instanceof AttributeElement || view instanceof Text ) {
-			view = new DocumentFragment( view );
-		}
 
 		const newPosition = wrapPosition( selection.getFirstPosition(), parse( unwrapAttribute ) );
 		expect( stringify( view, newPosition, { showType: true, showPriority: true } ) ).to.equal( expected );


### PR DESCRIPTION
Fixes #433.
Now `view` and `model` `parse()` methods work similar:
1. `parse( '' )` returns empty `DocumentFragment`,
2. `parse( '[]' )` returns empty `DocumentFragment` and collapsed selection inside that fragment,
3. `parse( '<a></a>' )` returns single `Element`,
4. `parse( '[<a></a>]' )` returns single `Element` and selection that is placed inside `DocumentFragment` that contains that element,
5. `parse( '<a></a><b></b>' )` returns `DocumentFragment` with all elements inside.
