### PR TITLE
Added event namespaces to change event in DocumentFragment

### DIFF
--- a/src/view/documentfragment.js
+++ b/src/view/documentfragment.js
@@ -144,7 +144,7 @@ export default class DocumentFragment {
 	 * @fires engine.view.Node#change
 	 */
 	_fireChange( type, node ) {
-		this.fire( 'change', type, node );
+		this.fire( 'change:' + type, node );
 	}
 }
 

--- a/tests/view/documentfragment.js
+++ b/tests/view/documentfragment.js
@@ -90,8 +90,8 @@ describe( 'DocumentFragment', () => {
 			} );
 
 			it( 'should fire change event when inserting', ( done ) => {
-				fragment.once( 'change', ( event, type ) => {
-					expect( type ).to.equal( 'children' );
+				fragment.once( 'change:children', ( event, node ) => {
+					expect( node ).to.equal( fragment );
 					done();
 				} );
 
@@ -99,8 +99,8 @@ describe( 'DocumentFragment', () => {
 			} );
 
 			it( 'should fire change event when appending', ( done ) => {
-				fragment.once( 'change', ( event, type ) => {
-					expect( type ).to.equal( 'children' );
+				fragment.once( 'change:children', ( event, node ) => {
+					expect( node ).to.equal( fragment );
 					done();
 				} );
 
@@ -176,8 +176,8 @@ describe( 'DocumentFragment', () => {
 			it( 'should fire change event', ( done ) => {
 				fragment.appendChildren( el1 );
 
-				fragment.once( 'change', ( event, type ) => {
-					expect( type ).to.equal( 'children' );
+				fragment.once( 'change:children', ( event, node ) => {
+					expect( node ).to.equal( fragment );
 					done();
 				} );
 


### PR DESCRIPTION
Fixes #383. 
It looks like `engine.view.Node` is already using event namespaces (also descendant classes: `Element` and `Text` ). One place where event namespaces were missing is `engine.view.DocumentFragment`.