### PR TITLE
T/518 Getters vs methods

### DIFF
--- a/src/conversion/mapper.js
+++ b/src/conversion/mapper.js
@@ -154,7 +154,7 @@ export default class Mapper {
 	_toModelOffset( viewParent, viewOffset, viewBlock ) {
 		if ( viewBlock != viewParent ) {
 			// See example.
-			const offsetToParentStart = this._toModelOffset( viewParent.parent, viewParent.getIndex(), viewBlock );
+			const offsetToParentStart = this._toModelOffset( viewParent.parent, viewParent.index, viewBlock );
 			const offsetInParent = this._toModelOffset( viewParent, viewOffset, viewParent );
 
 			return offsetToParentStart + offsetInParent;

--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -201,7 +201,7 @@ export function clearAttributes() {
 			// Not collapsed selection should not have artifacts.
 			if ( range.isCollapsed ) {
 				// Position might be in the node removed by the view writer.
-				if ( range.end.parent.getDocument() ) {
+				if ( range.end.parent.document ) {
 					viewWriter.mergeAt( range.start );
 				}
 			}

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -104,7 +104,7 @@ export function insertText() {
  *			let value = data.attributeNewValue;
  *
  *			// Force attribute value to 'empty' if the model element is empty.
- *			if ( data.item.getChildCount() === 0 ) {
+ *			if ( data.item.childCount === 0 ) {
  *				value = 'empty';
  *			}
  *
@@ -151,7 +151,7 @@ export function setAttribute( attributeCreator ) {
  *			let value = data.attributeNewValue;
  *
  *			// Force attribute value to 'empty' if the model element is empty.
- *			if ( data.item.getChildCount() === 0 ) {
+ *			if ( data.item.childCount === 0 ) {
  *				value = 'empty';
  *			}
  *

--- a/src/conversion/modelconsumable.js
+++ b/src/conversion/modelconsumable.js
@@ -57,7 +57,7 @@ import TextProxy from '../model/textproxy.js';
  *			const insertPosition = conversionApi.mapper.toViewPosition( data.range.start );
  *
  *			// Check if the `image` element has children.
- *			if ( data.item.getChildCount() > 0 ) {
+ *			if ( data.item.childCount > 0 ) {
  *				const modelCaption = data.item.getChild( 0 );
  *
  *				// `modelCaption` insertion change is consumed from consumable values.

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -93,7 +93,7 @@ import extend from '../../utils/lib/lodash/extend.js';
  *			// after `data.item` insert conversion was done. If the event is fired due to attribute insertion coming from
  *			// different source, `data.item` already existed. This means we are safe to get `viewQuote` from mapper.
  *			const viewQuote = conversionApi.mapper.toViewElement( data.item );
- *			const position = new ViewPosition( viewQuote, viewQuote.getChildCount() );
+ *			const position = new ViewPosition( viewQuote, viewQuote.childCount );
  *			viewWriter.insert( position, viewSourceBtn );
  *
  *			evt.stop();

--- a/src/model/delta/mergedelta.js
+++ b/src/model/delta/mergedelta.js
@@ -109,9 +109,9 @@ register( 'merge', function( position ) {
 	}
 
 	const positionAfter = Position.createFromParentAndOffset( nodeAfter, 0 );
-	const positionBefore = Position.createFromParentAndOffset( nodeBefore, nodeBefore.getMaxOffset() );
+	const positionBefore = Position.createFromParentAndOffset( nodeBefore, nodeBefore.maxOffset );
 
-	const move = new MoveOperation( positionAfter, nodeAfter.getMaxOffset(), positionBefore, this.document.version );
+	const move = new MoveOperation( positionAfter, nodeAfter.maxOffset, positionBefore, this.document.version );
 	move.isSticky = true;
 	delta.addOperation( move );
 	this.document.applyOperation( move );

--- a/src/model/delta/renamedelta.js
+++ b/src/model/delta/renamedelta.js
@@ -70,7 +70,7 @@ register( 'rename', function( newName, element ) {
 
 	apply(
 		this, delta,
-		new MoveOperation( Position.createAt( element ), element.getMaxOffset(), Position.createAt( newElement ), this.document.version )
+		new MoveOperation( Position.createAt( element ), element.maxOffset, Position.createAt( newElement ), this.document.version )
 	);
 
 	apply(

--- a/src/model/delta/splitdelta.js
+++ b/src/model/delta/splitdelta.js
@@ -126,7 +126,7 @@ register( 'split', function( position ) {
 
 	const move = new MoveOperation(
 		position,
-		splitElement.getMaxOffset() - position.offset,
+		splitElement.maxOffset - position.offset,
 		Position.createFromParentAndOffset( copy, 0 ),
 		this.document.version
 	);

--- a/src/model/delta/unwrapdelta.js
+++ b/src/model/delta/unwrapdelta.js
@@ -84,7 +84,7 @@ register( 'unwrap', function( element ) {
 
 	let sourcePosition = Position.createFromParentAndOffset( element, 0 );
 
-	const move = new MoveOperation( sourcePosition, element.getMaxOffset(), Position.createBefore( element ), this.document.version );
+	const move = new MoveOperation( sourcePosition, element.maxOffset, Position.createBefore( element ), this.document.version );
 	move.isSticky = true;
 	delta.addOperation( move );
 	this.document.applyOperation( move );

--- a/src/model/delta/wrapdelta.js
+++ b/src/model/delta/wrapdelta.js
@@ -107,7 +107,7 @@ register( 'wrap', function( range, elementOrString ) {
 
 	let element = elementOrString instanceof Element ? elementOrString : new Element( elementOrString );
 
-	if ( element.getChildCount() > 0 ) {
+	if ( element.childCount > 0 ) {
 		/**
 		 * Element to wrap with is not empty.
 		 *

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -66,6 +66,16 @@ export default class Document {
 		this.schema = new Schema();
 
 		/**
+		 * Document's history.
+		 *
+		 * **Note:** Be aware that deltas applied to the stored deltas might be removed or changed.
+		 *
+		 * @readonly
+		 * @member {engine.model.History} engine.model.Document#history
+		 */
+		this.history = new History( this );
+
+		/**
 		 * Composer for this document. Set of tools to work with the document.
 		 *
 		 * The features can tune up these tools to better work on their specific cases.
@@ -103,16 +113,6 @@ export default class Document {
 
 		// Graveyard tree root. Document always have a graveyard root, which stores removed nodes.
 		this.createRoot( '$root', graveyardName );
-
-		/**
-		 * Document's history.
-		 *
-		 * **Note:** Be aware that deltas applied to the stored deltas might be removed or changed.
-		 *
-		 * @readonly
-		 * @member {engine.model.History} engine.model.Document#history
-		 */
-		this.history = new History( this );
 	}
 
 	/**
@@ -123,16 +123,6 @@ export default class Document {
 	 */
 	get graveyard() {
 		return this.getRoot( graveyardName );
-	}
-
-	/**
-	 * Gets names of all roots (without the {@link engine.model.Document#graveyard}).
-	 *
-	 * @readonly
-	 * @type {Iterable.<String>}
-	 */
-	get rootNames() {
-		return Array.from( this._roots.keys() ).filter( ( name ) => name != graveyardName );
 	}
 
 	/**
@@ -263,6 +253,16 @@ export default class Document {
 		}
 
 		return this._roots.get( name );
+	}
+
+	/**
+	 * Gets names of all roots (without the {@link engine.model.Document#graveyard}).
+	 *
+	 * @readonly
+	 * @type {Iterable.<String>}
+	 */
+	getRootNames() {
+		return Array.from( this._roots.keys() ).filter( ( name ) => name != graveyardName );
 	}
 
 	/**

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -256,16 +256,6 @@ export default class Document {
 	}
 
 	/**
-	 * Gets names of all roots (without the {@link engine.model.Document#graveyard}).
-	 *
-	 * @readonly
-	 * @type {Iterable.<String>}
-	 */
-	getRootNames() {
-		return Array.from( this._roots.keys() ).filter( ( name ) => name != graveyardName );
-	}
-
-	/**
 	 * Checks if root with given name is defined.
 	 *
 	 * @param {String} name Name of root to check.
@@ -273,6 +263,15 @@ export default class Document {
 	 */
 	hasRoot( name ) {
 		return this._roots.has( name );
+	}
+
+	/**
+	 * Returns array with names of all roots (without the {@link engine.model.Document#graveyard}) added to the document.
+	 *
+	 * @returns {Array.<String>} Roots names.
+	 */
+	getRootNames() {
+		return Array.from( this._roots.keys() ).filter( ( name ) => name != graveyardName );
 	}
 
 	/**

--- a/src/model/documentfragment.js
+++ b/src/model/documentfragment.js
@@ -44,22 +44,21 @@ export default class DocumentFragment {
 	}
 
 	/**
-	 * Artificial root of `DocumentFragment`. Returns itself. Added for compatibility reasons.
+	 * Returns the number of this document fragment's children.
 	 *
-	 * @readonly
-	 * @type {engine.model.DocumentFragment}
+	 * @returns {Number}
 	 */
-	get root() {
-		return this;
+	get childCount() {
+		return this._children.length;
 	}
 
 	/**
-	 * Returns path to a `DocumentFragment`, which is an empty array. Added for compatibility reasons.
+	 * Returns the sum of {engine.model.Node#offsetSize offset sizes} of all of this document fragment's children.
 	 *
-	 * @returns {Array}
+	 * @returns {Number}
 	 */
-	getPath() {
-		return [];
+	get maxOffset() {
+		return this._children.maxOffset;
 	}
 
 	/**
@@ -67,8 +66,18 @@ export default class DocumentFragment {
 	 *
 	 * @returns {Boolean}
 	 */
-	isEmpty() {
-		return this.getChildCount() === 0;
+	get isEmpty() {
+		return this.childCount === 0;
+	}
+
+	/**
+	 * Artificial root of `DocumentFragment`. Returns itself. Added for compatibility reasons.
+	 *
+	 * @readonly
+	 * @type {engine.model.DocumentFragment}
+	 */
+	get root() {
+		return this;
 	}
 
 	/**
@@ -82,16 +91,6 @@ export default class DocumentFragment {
 	}
 
 	/**
-	 * Returns an index of the given child node. Returns `null` if given node is not a child of this document fragment.
-	 *
-	 * @param {engine.model.Node} node Child node to look for.
-	 * @returns {Number|null} Child node's index.
-	 */
-	getChildIndex( node ) {
-		return this._children.getNodeIndex( node );
-	}
-
-	/**
 	 * Returns an iterator that iterates over all of this document fragment's children.
 	 *
 	 * @returns {Iterable.<engine.model.Node>}
@@ -101,12 +100,13 @@ export default class DocumentFragment {
 	}
 
 	/**
-	 * Returns the number of this document fragment's children.
+	 * Returns an index of the given child node. Returns `null` if given node is not a child of this document fragment.
 	 *
-	 * @returns {Number}
+	 * @param {engine.model.Node} node Child node to look for.
+	 * @returns {Number|null} Child node's index.
 	 */
-	getChildCount() {
-		return this._children.length;
+	getChildIndex( node ) {
+		return this._children.getNodeIndex( node );
 	}
 
 	/**
@@ -122,12 +122,12 @@ export default class DocumentFragment {
 	}
 
 	/**
-	 * Returns the sum of {engine.model.Node#offsetSize offset sizes} of all of this document fragment's children.
+	 * Returns path to a `DocumentFragment`, which is an empty array. Added for compatibility reasons.
 	 *
-	 * @returns {Number}
+	 * @returns {Array}
 	 */
-	getMaxOffset() {
-		return this._children.getMaxOffset();
+	getPath() {
+		return [];
 	}
 
 	/**
@@ -159,7 +159,7 @@ export default class DocumentFragment {
 	 * @param {engine.model.Node|Iterable.<engine.model.Node>} nodes Nodes to be inserted.
 	 */
 	appendChildren( nodes ) {
-		this.insertChildren( this.getChildCount(), nodes );
+		this.insertChildren( this.childCount, nodes );
 	}
 
 	/**

--- a/src/model/documentfragment.js
+++ b/src/model/documentfragment.js
@@ -44,27 +44,30 @@ export default class DocumentFragment {
 	}
 
 	/**
-	 * Returns the number of this document fragment's children.
+	 * Number of this document fragment's children.
 	 *
-	 * @returns {Number}
+	 * @readonly
+	 * @type {Number}
 	 */
 	get childCount() {
 		return this._children.length;
 	}
 
 	/**
-	 * Returns the sum of {engine.model.Node#offsetSize offset sizes} of all of this document fragment's children.
+	 * Sum of {engine.model.Node#offsetSize offset sizes} of all of this document fragment's children.
 	 *
-	 * @returns {Number}
+	 * @readonly
+	 * @type {Number}
 	 */
 	get maxOffset() {
 		return this._children.maxOffset;
 	}
 
 	/**
-	 * Returns `true` if there are no nodes inside this document fragment, `false` otherwise.
+	 * Is `true` if there are no nodes inside this document fragment, `false` otherwise.
 	 *
-	 * @returns {Boolean}
+	 * @readonly
+	 * @type {Boolean}
 	 */
 	get isEmpty() {
 		return this.childCount === 0;

--- a/src/model/element.js
+++ b/src/model/element.js
@@ -50,27 +50,30 @@ export default class Element extends Node {
 	}
 
 	/**
-	 * Returns the number of this element's children.
+	 * Number of this element's children.
 	 *
-	 * @returns {Number}
+	 * @readonly
+	 * @type {Number}
 	 */
 	get childCount() {
 		return this._children.length;
 	}
 
 	/**
-	 * Returns the sum of {engine.model.Node#offsetSize offset sizes} of all of this element's children.
+	 * Sum of {engine.model.Node#offsetSize offset sizes} of all of this element's children.
 	 *
-	 * @returns {Number}
+	 * @readonly
+	 * @type {Number}
 	 */
 	get maxOffset() {
 		return this._children.maxOffset;
 	}
 
 	/**
-	 * Returns `true` if there are no nodes inside this element, `false` otherwise.
+	 * Is `true` if there are no nodes inside this element, `false` otherwise.
 	 *
-	 * @returns {Boolean}
+	 * @readonly
+	 * @type {Boolean}
 	 */
 	get isEmpty() {
 		return this.childCount === 0;

--- a/src/model/element.js
+++ b/src/model/element.js
@@ -50,18 +50,21 @@ export default class Element extends Node {
 	}
 
 	/**
-	 * Creates a copy of this element and returns it. Created element has same name and attributes as original element.
-	 * If clone is not deep, children of copied element are references to the same nodes as in original element.
-	 * If clone is deep, original element's children are also cloned.
+	 * Returns the number of this element's children.
 	 *
-	 * @param {Boolean} [deep=false] Decides whether children of this element should also be cloned (`true`) or not (`false`).
+	 * @returns {Number}
 	 */
-	clone( deep = false ) {
-		const children = deep ?
-			Array.from( this._children ).map( ( node ) => node.clone() ) :
-			Array.from( this._children );
+	get childCount() {
+		return this._children.length;
+	}
 
-		return new Element( this.name, this.getAttributes(), children );
+	/**
+	 * Returns the sum of {engine.model.Node#offsetSize offset sizes} of all of this element's children.
+	 *
+	 * @returns {Number}
+	 */
+	get maxOffset() {
+		return this._children.maxOffset;
 	}
 
 	/**
@@ -69,8 +72,8 @@ export default class Element extends Node {
 	 *
 	 * @returns {Boolean}
 	 */
-	isEmpty() {
-		return this.getChildCount() === 0;
+	get isEmpty() {
+		return this.childCount === 0;
 	}
 
 	/**
@@ -84,16 +87,6 @@ export default class Element extends Node {
 	}
 
 	/**
-	 * Returns an index of the given child node. Returns `null` if given node is not a child of this element.
-	 *
-	 * @param {engine.model.Node} node Child node to look for.
-	 * @returns {Number} Child node's index in this element.
-	 */
-	getChildIndex( node ) {
-		return this._children.getNodeIndex( node );
-	}
-
-	/**
 	 * Returns an iterator that iterates over all of this element's children.
 	 *
 	 * @returns {Iterable.<engine.model.Node>}
@@ -103,12 +96,13 @@ export default class Element extends Node {
 	}
 
 	/**
-	 * Returns the number of this element's children.
+	 * Returns an index of the given child node. Returns `null` if given node is not a child of this element.
 	 *
-	 * @returns {Number}
+	 * @param {engine.model.Node} node Child node to look for.
+	 * @returns {Number} Child node's index in this element.
 	 */
-	getChildCount() {
-		return this._children.length;
+	getChildIndex( node ) {
+		return this._children.getNodeIndex( node );
 	}
 
 	/**
@@ -124,12 +118,18 @@ export default class Element extends Node {
 	}
 
 	/**
-	 * Returns the sum of {engine.model.Node#offsetSize offset sizes} of all of this element's children.
+	 * Creates a copy of this element and returns it. Created element has same name and attributes as original element.
+	 * If clone is not deep, children of copied element are references to the same nodes as in original element.
+	 * If clone is deep, original element's children are also cloned.
 	 *
-	 * @returns {Number}
+	 * @param {Boolean} [deep=false] Decides whether children of this element should also be cloned (`true`) or not (`false`).
 	 */
-	getMaxOffset() {
-		return this._children.getMaxOffset();
+	clone( deep = false ) {
+		const children = deep ?
+			Array.from( this._children ).map( ( node ) => node.clone() ) :
+			Array.from( this._children );
+
+		return new Element( this.name, this.getAttributes(), children );
 	}
 
 	/**
@@ -159,7 +159,7 @@ export default class Element extends Node {
 	 * @param {engine.model.Node|Iterable.<engine.model.Node>} nodes Nodes to be inserted.
 	 */
 	appendChildren( nodes ) {
-		this.insertChildren( this.getChildCount(), nodes );
+		this.insertChildren( this.childCount, nodes );
 	}
 
 	/**

--- a/src/model/liveselection.js
+++ b/src/model/liveselection.js
@@ -200,7 +200,7 @@ export default class LiveSelection extends Selection {
 	*_getStoredAttributes() {
 		const selectionParent = this.getFirstPosition().parent;
 
-		if ( this.isCollapsed && selectionParent.getChildCount() === 0 ) {
+		if ( this.isCollapsed && selectionParent.childCount === 0 ) {
 			for ( let key of selectionParent.getAttributeKeys() ) {
 				if ( key.indexOf( storePrefix ) === 0 ) {
 					const realKey = key.substr( storePrefix.length );
@@ -220,7 +220,7 @@ export default class LiveSelection extends Selection {
 	_removeStoredAttribute( key ) {
 		const selectionParent = this.getFirstPosition().parent;
 
-		if ( this.isCollapsed && selectionParent.getChildCount() === 0 ) {
+		if ( this.isCollapsed && selectionParent.childCount === 0 ) {
 			const storeKey = LiveSelection._getStoreAttributeKey( key );
 
 			this._document.enqueueChanges( () => {
@@ -240,7 +240,7 @@ export default class LiveSelection extends Selection {
 	_storeAttribute( key, value ) {
 		const selectionParent = this.getFirstPosition().parent;
 
-		if ( this.isCollapsed && selectionParent.getChildCount() === 0 ) {
+		if ( this.isCollapsed && selectionParent.childCount === 0 ) {
 			const storeKey = LiveSelection._getStoreAttributeKey( key );
 
 			this._document.enqueueChanges( () => {
@@ -258,7 +258,7 @@ export default class LiveSelection extends Selection {
 	_setStoredAttributesTo( attrs ) {
 		const selectionParent = this.getFirstPosition().parent;
 
-		if ( this.isCollapsed && selectionParent.getChildCount() === 0 ) {
+		if ( this.isCollapsed && selectionParent.childCount === 0 ) {
 			this._document.enqueueChanges( () => {
 				const batch = this._document.batch();
 

--- a/src/model/node.js
+++ b/src/model/node.js
@@ -66,9 +66,11 @@ export default class Node {
 	/**
 	 * Index of this node in it's parent or `null` if the node has no parent.
 	 *
-	 * Throws error if the parent element does not contain this node. This means that model tree got broken.
+	 * Accessing this property throws an error if this node's parent element does not contain it.
+	 * This means that model tree got broken.
 	 *
-	 * @returns {Number|null}
+	 * @readonly
+	 * @type {Number|null}
 	 */
 	get index() {
 		let pos;
@@ -93,7 +95,8 @@ export default class Node {
 	 * Offset at which this node starts in it's parent. It is equal to the sum of {@link engine.model.Node#offsetSize offsetSize}
 	 * of all it's previous siblings. Equals to `null` if node has no parent.
 	 *
-	 * Throws error if the parent element does not contain this node. This means that model tree got broken.
+	 * Accessing this property throws an error if this node's parent element does not contain it.
+	 * This means that model tree got broken.
 	 *
 	 * @readonly
 	 * @type {Number|Null}

--- a/src/model/node.js
+++ b/src/model/node.js
@@ -64,61 +64,29 @@ export default class Node {
 	}
 
 	/**
-	 * Node's next sibling or `null` if the node is a last child of it's parent or if the node has no parent.
+	 * Index of this node in it's parent or `null` if the node has no parent.
 	 *
-	 * @readonly
-	 * @type {engine.model.Node|null}
-	 */
-	get nextSibling() {
-		const index = this.getIndex();
-
-		return ( index !== null && this.parent.getChild( index + 1 ) ) || null;
-	}
-
-	/**
-	 * Node's previous sibling or `null` if the node is a first child of it's parent or if the node has no parent.
+	 * Throws error if the parent element does not contain this node. This means that model tree got broken.
 	 *
-	 * @readonly
-	 * @type {engine.model.Node|null}
+	 * @returns {Number|null}
 	 */
-	get previousSibling() {
-		const index = this.getIndex();
+	get index() {
+		let pos;
 
-		return ( index !== null && this.parent.getChild( index - 1 ) ) || null;
-	}
-
-	/**
-	 * The top-most ancestor of the node. If node has no parent it is the root itself. If the node is a part
-	 * of {@link engine.model.DocumentFragment}, it's `root` is equal to that `DocumentFragment`.
-	 *
-	 * @readonly
-	 * @type {engine.model.Node|engine.model.DocumentFragment}
-	 */
-	get root() {
-		let root = this;
-
-		while ( root.parent ) {
-			root = root.parent;
-		}
-
-		return root;
-	}
-
-	/**
-	 * {@link engine.model.Document Document} that owns this node or `null` if the node has no parent or is inside
-	 * a {@link engine.model.DocumentFragment DocumentFragment}.
-	 *
-	 * @readonly
-	 * @type {engine.model.Document|null}
-	 */
-	get document() {
-		// This is a top element of a sub-tree.
-		if ( this.root == this ) {
+		if ( !this.parent ) {
 			return null;
 		}
 
-		// Root may be `DocumentFragment` which does not have document property.
-		return this.root.document || null;
+		if ( ( pos = this.parent.getChildIndex( this ) ) === null ) {
+			/**
+			 * The node's parent does not contain this node.
+			 *
+			 * @error node-not-found-in-parent
+			 */
+			throw new CKEditorError( 'node-not-found-in-parent: The node\'s parent does not contain this node.' );
+		}
+
+		return pos;
 	}
 
 	/**
@@ -179,38 +147,70 @@ export default class Node {
 	}
 
 	/**
+	 * Node's next sibling or `null` if the node is a last child of it's parent or if the node has no parent.
+	 *
+	 * @readonly
+	 * @type {engine.model.Node|null}
+	 */
+	get nextSibling() {
+		const index = this.index;
+
+		return ( index !== null && this.parent.getChild( index + 1 ) ) || null;
+	}
+
+	/**
+	 * Node's previous sibling or `null` if the node is a first child of it's parent or if the node has no parent.
+	 *
+	 * @readonly
+	 * @type {engine.model.Node|null}
+	 */
+	get previousSibling() {
+		const index = this.index;
+
+		return ( index !== null && this.parent.getChild( index - 1 ) ) || null;
+	}
+
+	/**
+	 * The top-most ancestor of the node. If node has no parent it is the root itself. If the node is a part
+	 * of {@link engine.model.DocumentFragment}, it's `root` is equal to that `DocumentFragment`.
+	 *
+	 * @readonly
+	 * @type {engine.model.Node|engine.model.DocumentFragment}
+	 */
+	get root() {
+		let root = this;
+
+		while ( root.parent ) {
+			root = root.parent;
+		}
+
+		return root;
+	}
+
+	/**
+	 * {@link engine.model.Document Document} that owns this node or `null` if the node has no parent or is inside
+	 * a {@link engine.model.DocumentFragment DocumentFragment}.
+	 *
+	 * @readonly
+	 * @type {engine.model.Document|null}
+	 */
+	get document() {
+		// This is a top element of a sub-tree.
+		if ( this.root == this ) {
+			return null;
+		}
+
+		// Root may be `DocumentFragment` which does not have document property.
+		return this.root.document || null;
+	}
+
+	/**
 	 * Creates a copy of this node, that is a node with exactly same attributes, and returns it.
 	 *
 	 * @returns {engine.model.Node} Node with same attributes as this node.
 	 */
 	clone() {
 		return new Node( this._attrs );
-	}
-
-	/**
-	 * Index of this node in it's parent or `null` if the node has no parent.
-	 *
-	 * Throws error if the parent element does not contain this node. This means that model tree got broken.
-	 *
-	 * @returns {Number|null}
-	 */
-	getIndex() {
-		let pos;
-
-		if ( !this.parent ) {
-			return null;
-		}
-
-		if ( ( pos = this.parent.getChildIndex( this ) ) === null ) {
-			/**
-			 * The node's parent does not contain this node.
-			 *
-			 * @error node-not-found-in-parent
-			 */
-			throw new CKEditorError( 'node-not-found-in-parent: The node\'s parent does not contain this node.' );
-		}
-
-		return pos;
 	}
 
 	/**
@@ -266,7 +266,7 @@ export default class Node {
 	 * Removes this node from it's parent.
 	 */
 	remove() {
-		this.parent.removeChildren( this.getIndex() );
+		this.parent.removeChildren( this.index );
 	}
 
 	/**

--- a/src/model/nodelist.js
+++ b/src/model/nodelist.js
@@ -40,18 +40,20 @@ export default class NodeList {
 	}
 
 	/**
-	 * Returns the number of nodes contained inside this node list.
+	 * Number of nodes contained inside this node list.
 	 *
-	 * @returns {Number}
+	 * @readonly
+	 * @type {Number}
 	 */
 	get length() {
 		return this._nodes.length;
 	}
 
 	/**
-	 * Returns the sum of {engine.model.Node#offsetSize offset sizes} of all nodes contained inside this node list.
+	 * Sum of {@link engine.model.Node#offsetSize offset sizes} of all nodes contained inside this node list.
 	 *
-	 * @returns {Number}
+	 * @readonly
+	 * @type {Number}
 	 */
 	get maxOffset() {
 		return this._nodes.reduce( ( sum, node ) => sum + node.offsetSize, 0 );

--- a/src/model/nodelist.js
+++ b/src/model/nodelist.js
@@ -53,7 +53,7 @@ export default class NodeList {
 	 *
 	 * @returns {Number}
 	 */
-	getMaxOffset() {
+	get maxOffset() {
 		return this._nodes.reduce( ( sum, node ) => sum + node.offsetSize, 0 );
 	}
 
@@ -103,7 +103,7 @@ export default class NodeList {
 	 */
 	indexToOffset( index ) {
 		if ( index == this._nodes.length ) {
-			return this.getMaxOffset();
+			return this.maxOffset;
 		}
 
 		const node = this._nodes[ index ];

--- a/src/model/operation/insertoperation.js
+++ b/src/model/operation/insertoperation.js
@@ -66,7 +66,7 @@ export default class InsertOperation extends Operation {
 	 * @returns {engine.model.operation.RemoveOperation}
 	 */
 	getReversed() {
-		return new RemoveOperation( this.position, this.nodes.getMaxOffset(), this.baseVersion + 1 );
+		return new RemoveOperation( this.position, this.nodes.maxOffset, this.baseVersion + 1 );
 	}
 
 	/**

--- a/src/model/operation/moveoperation.js
+++ b/src/model/operation/moveoperation.js
@@ -128,7 +128,7 @@ export default class MoveOperation extends Operation {
 			throw new CKEditorError(
 				'move-operation-position-invalid: Source position or target position is invalid.'
 			);
-		} else if ( sourceOffset + this.howMany > sourceElement.getMaxOffset() ) {
+		} else if ( sourceOffset + this.howMany > sourceElement.maxOffset ) {
 			/**
 			 * The nodes which should be moved do not exist.
 			 *

--- a/src/model/operation/removeoperation.js
+++ b/src/model/operation/removeoperation.js
@@ -24,7 +24,7 @@ export default class RemoveOperation extends MoveOperation {
 	 */
 	constructor( position, howMany, baseVersion ) {
 		const graveyard = position.root.document.graveyard;
-		const graveyardPosition = new Position( graveyard, [ graveyard.getMaxOffset(), 0 ] );
+		const graveyardPosition = new Position( graveyard, [ graveyard.maxOffset, 0 ] );
 
 		super( position, howMany, graveyardPosition, baseVersion );
 	}

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -63,7 +63,7 @@ const ot = {
 			const transformed = a.clone();
 
 			// Transform insert position by the other operation position.
-			transformed.position = transformed.position._getTransformedByInsertion( b.position, b.nodes.getMaxOffset(), !isStrong );
+			transformed.position = transformed.position._getTransformedByInsertion( b.position, b.nodes.maxOffset, !isStrong );
 
 			return [ transformed ];
 		},
@@ -88,7 +88,7 @@ const ot = {
 		// Transforms AttributeOperation `a` by InsertOperation `b`. Returns results as an array of operations.
 		InsertOperation( a, b ) {
 			// Transform this operation's range.
-			const ranges = a.range._getTransformedByInsertion( b.position, b.nodes.getMaxOffset(), true, false );
+			const ranges = a.range._getTransformedByInsertion( b.position, b.nodes.maxOffset, true, false );
 
 			// Map transformed range(s) to operations and return them.
 			return ranges.reverse().map( ( range ) => {
@@ -221,14 +221,14 @@ const ot = {
 		InsertOperation( a, b, isStrong ) {
 			// Create range from MoveOperation properties and transform it by insertion.
 			let range = Range.createFromPositionAndShift( a.sourcePosition, a.howMany );
-			range = range._getTransformedByInsertion( b.position, b.nodes.getMaxOffset(), false, a.isSticky )[ 0 ];
+			range = range._getTransformedByInsertion( b.position, b.nodes.maxOffset, false, a.isSticky )[ 0 ];
 
 			let result = new a.constructor(
 				range.start,
 				range.end.offset - range.start.offset,
 				a instanceof RemoveOperation ?
 					a.baseVersion :
-					a.targetPosition._getTransformedByInsertion( b.position, b.nodes.getMaxOffset(), !isStrong ),
+					a.targetPosition._getTransformedByInsertion( b.position, b.nodes.maxOffset, !isStrong ),
 				a instanceof RemoveOperation ? undefined : a.baseVersion
 			);
 

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -187,18 +187,20 @@ export default class Position {
 	}
 
 	/**
-	 * Returns `true` if position is at the beginning of its {@link engine.model.Position#parent parent}, `false` otherwise.
+	 * Is `true` if position is at the beginning of its {@link engine.model.Position#parent parent}, `false` otherwise.
 	 *
-	 * @returns {Boolean}
+	 * @readonly
+	 * @type {Boolean}
 	 */
 	get isAtStart() {
 		return this.offset === 0;
 	}
 
 	/**
-	 * Returns `true` if position is at the end of its {@link engine.model.Position#parent parent}, `false` otherwise.
+	 * Is `true` if position is at the end of its {@link engine.model.Position#parent parent}, `false` otherwise.
 	 *
-	 * @returns {Boolean}
+	 * @readonly
+	 * @type {Boolean}
 	 */
 	get isAtEnd() {
 		return this.offset == this.parent.maxOffset;

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -104,6 +104,44 @@ export default class Position {
 	}
 
 	/**
+	 * Offset at which this position is located in it's {@link engine.model.Position#parent parent}. It is equal
+	 * to the last item in position {@link engine.model.Position#path path}.
+	 *
+	 * @type {Number}
+	 */
+	get offset() {
+		return last( this.path );
+	}
+
+	/**
+	 * @param {Number} newOffset
+	 */
+	set offset( newOffset ) {
+		this.path[ this.path.length - 1 ] = newOffset;
+	}
+
+	/**
+	 * Parent element of this position.
+	 *
+	 * Keep in mind that `parent` value is calculated when the property is accessed. If {@link engine.model.Position#path position path}
+	 * leads to a non-existing element, `parent` property will throw error.
+	 *
+	 * Also it is a good idea to cache `parent` property if it is used frequently in an algorithm (i.e. in a long loop).
+	 *
+	 * @readonly
+	 * @type {engine.model.Element}
+	 */
+	get parent() {
+		let parent = this.root;
+
+		for ( let i = 0; i < this.path.length - 1; i++ ) {
+			parent = parent.getChild( parent.offsetToIndex( this.path[ i ] ) );
+		}
+
+		return parent;
+	}
+
+	/**
 	 * Position {@link engine.model.Position#offset offset} converted to an index in position's parent node. It is
 	 * equal to the {@link engine.model.Node#getIndex index} of a node after this position. If position is placed
 	 * in text node, position index is equal to the index of that text node.
@@ -149,41 +187,21 @@ export default class Position {
 	}
 
 	/**
-	 * Offset at which this position is located in it's {@link engine.model.Position#parent parent}. It is equal
-	 * to the last item in position {@link engine.model.Position#path path}.
+	 * Returns `true` if position is at the beginning of its {@link engine.model.Position#parent parent}, `false` otherwise.
 	 *
-	 * @type {Number}
+	 * @returns {Boolean}
 	 */
-	get offset() {
-		return last( this.path );
+	get isAtStart() {
+		return this.offset === 0;
 	}
 
 	/**
-	 * @param {Number} newOffset
+	 * Returns `true` if position is at the end of its {@link engine.model.Position#parent parent}, `false` otherwise.
+	 *
+	 * @returns {Boolean}
 	 */
-	set offset( newOffset ) {
-		this.path[ this.path.length - 1 ] = newOffset;
-	}
-
-	/**
-	 * Parent element of this position.
-	 *
-	 * Keep in mind that `parent` value is calculated when the property is accessed. If {@link engine.model.Position#path position path}
-	 * leads to a non-existing element, `parent` property will throw error.
-	 *
-	 * Also it is a good idea to cache `parent` property if it is used frequently in an algorithm (i.e. in a long loop).
-	 *
-	 * @readonly
-	 * @type {engine.model.Element}
-	 */
-	get parent() {
-		let parent = this.root;
-
-		for ( let i = 0; i < this.path.length - 1; i++ ) {
-			parent = parent.getChild( parent.offsetToIndex( this.path[ i ] ) );
-		}
-
-		return parent;
+	get isAtEnd() {
+		return this.offset == this.parent.maxOffset;
 	}
 
 	/**
@@ -343,7 +361,7 @@ export default class Position {
 			}
 
 			if ( left.path.length > right.path.length ) {
-				if ( left.offset !== leftParent.getMaxOffset() ) {
+				if ( left.offset !== leftParent.maxOffset ) {
 					return false;
 				}
 
@@ -358,24 +376,6 @@ export default class Position {
 				right.path = right.path.slice( 0, -1 );
 			}
 		}
-	}
-
-	/**
-	 * Returns `true` if position is at the beginning of its {@link engine.model.Position#parent parent}, `false` otherwise.
-	 *
-	 * @returns {Boolean}
-	 */
-	isAtStart() {
-		return this.offset === 0;
-	}
-
-	/**
-	 * Returns `true` if position is at the end of its {@link engine.model.Position#parent parent}, `false` otherwise.
-	 *
-	 * @returns {Boolean}
-	 */
-	isAtEnd() {
-		return this.offset == this.parent.getMaxOffset();
 	}
 
 	/**
@@ -572,7 +572,7 @@ export default class Position {
 			const node = itemOrPosition;
 
 			if ( offset == 'end' ) {
-				offset = node.getMaxOffset();
+				offset = node.maxOffset;
 			} else if ( offset == 'before' ) {
 				return this.createBefore( node );
 			} else if ( offset == 'after' ) {

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -277,7 +277,7 @@ export default class Range {
 
 		// Go up.
 		while ( pos.path.length > diffAt + 1 ) {
-			let howMany = posParent.getMaxOffset() - pos.offset;
+			let howMany = posParent.maxOffset - pos.offset;
 
 			if ( howMany !== 0 ) {
 				ranges.push( new Range( pos, pos.getShiftedBy( howMany ) ) );
@@ -496,7 +496,7 @@ export default class Range {
 	 * @returns {engine.model.Range}
 	 */
 	static createFromElement( element ) {
-		return this.createFromParentsAndOffsets( element, 0, element, element.getMaxOffset() );
+		return this.createFromParentsAndOffsets( element, 0, element, element.maxOffset );
 	}
 
 	/**

--- a/src/model/textproxy.js
+++ b/src/model/textproxy.js
@@ -68,36 +68,6 @@ export default class TextProxy {
 	}
 
 	/**
-	 * Parent of this text proxy, which is same as parent of text node represented by this text proxy.
-	 *
-	 * @readonly
-	 * @type {engine.model.Element|engine.model.DocumentFragment|null}
-	 */
-	get parent() {
-		return this.textNode.parent;
-	}
-
-	/**
-	 * Root of this text proxy, which is same as root of text node represented by this text proxy.
-	 *
-	 * @readonly
-	 * @type {engine.model.Element|engine.model.DocumentFragment}
-	 */
-	get root() {
-		return this.textNode.root;
-	}
-
-	/**
-	 * {@link engine.model.Document Document} that owns text node represented by this text proxy or `null` if the text node
-	 * has no parent or is inside a {@link engine.model.DocumentFragment DocumentFragment}.
-	 *
-	 * @returns {engine.model.Document|null}
-	 */
-	get document() {
-		return this.textNode.document;
-	}
-
-	/**
 	 * Offset at which this text proxy starts in it's parent.
 	 *
 	 * @see engine.model.Node#startOffset
@@ -143,6 +113,36 @@ export default class TextProxy {
 	 */
 	get isPartial() {
 		return this.offsetInText !== 0 || this.offsetSize !== this.textNode.offsetSize;
+	}
+
+	/**
+	 * Parent of this text proxy, which is same as parent of text node represented by this text proxy.
+	 *
+	 * @readonly
+	 * @type {engine.model.Element|engine.model.DocumentFragment|null}
+	 */
+	get parent() {
+		return this.textNode.parent;
+	}
+
+	/**
+	 * Root of this text proxy, which is same as root of text node represented by this text proxy.
+	 *
+	 * @readonly
+	 * @type {engine.model.Element|engine.model.DocumentFragment}
+	 */
+	get root() {
+		return this.textNode.root;
+	}
+
+	/**
+	 * {@link engine.model.Document Document} that owns text node represented by this text proxy or `null` if the text node
+	 * has no parent or is inside a {@link engine.model.DocumentFragment DocumentFragment}.
+	 *
+	 * @returns {engine.model.Document|null}
+	 */
+	get document() {
+		return this.textNode.document;
 	}
 
 	/**

--- a/src/model/textproxy.js
+++ b/src/model/textproxy.js
@@ -129,7 +129,7 @@ export default class TextProxy {
 	 * Root of this text proxy, which is same as root of text node represented by this text proxy.
 	 *
 	 * @readonly
-	 * @type {engine.model.Element|engine.model.DocumentFragment}
+	 * @type {engine.model.Node|engine.model.DocumentFragment}
 	 */
 	get root() {
 		return this.textNode.root;
@@ -139,7 +139,8 @@ export default class TextProxy {
 	 * {@link engine.model.Document Document} that owns text node represented by this text proxy or `null` if the text node
 	 * has no parent or is inside a {@link engine.model.DocumentFragment DocumentFragment}.
 	 *
-	 * @returns {engine.model.Document|null}
+	 * @readonly
+	 * @type {engine.model.Document|null}
 	 */
 	get document() {
 		return this.textNode.document;

--- a/src/model/treewalker.js
+++ b/src/model/treewalker.js
@@ -177,7 +177,7 @@ export default class TreeWalker {
 		const parent = this._visitedParent;
 
 		// We are at the end of the root.
-		if ( parent.parent === null && position.offset === parent.getMaxOffset() ) {
+		if ( parent.parent === null && position.offset === parent.maxOffset ) {
 			return { done: true };
 		}
 
@@ -268,7 +268,7 @@ export default class TreeWalker {
 			position.offset--;
 
 			if ( !this.shallow ) {
-				position.path.push( node.getMaxOffset() );
+				position.path.push( node.maxOffset );
 				this.position = position;
 				this._visitedParent = node;
 

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -153,7 +153,7 @@ export function setAttribute( range, key, value ) {
 		}
 
 		// After attributes changing it may happen that some text nodes can be merged. Try to merge with previous node.
-		_mergeNodesAtIndex( node.parent, node.getIndex() );
+		_mergeNodesAtIndex( node.parent, node.index );
 	}
 
 	// Try to merge last changed node with it's previous sibling (not covered by the loop above).
@@ -259,7 +259,7 @@ function _splitNodeAtPosition( position ) {
 
 	if ( textNode ) {
 		const offsetDiff = position.offset - textNode.startOffset;
-		const index = textNode.getIndex();
+		const index = textNode.index;
 
 		element.removeChildren( index, 1 );
 

--- a/src/view/attributeelement.js
+++ b/src/view/attributeelement.js
@@ -73,7 +73,7 @@ export default class AttributeElement extends Element {
 	 */
 	getFillerOffset() {
 		// <b>foo</b> does not need filler.
-		if ( this.getChildCount() ) {
+		if ( this.childCount ) {
 			return null;
 		}
 
@@ -81,14 +81,14 @@ export default class AttributeElement extends Element {
 
 		// <p><b></b></p> needs filler -> <p><b><br></b></p>
 		while ( element instanceof AttributeElement ) {
-			if ( element.getChildCount() > 1 ) {
+			if ( element.childCount > 1 ) {
 				return null;
 			}
 
 			element = element.parent;
 		}
 
-		if ( !element || element.getChildCount() > 1 ) {
+		if ( !element || element.childCount > 1 ) {
 			return null;
 		}
 

--- a/src/view/containerelement.js
+++ b/src/view/containerelement.js
@@ -56,6 +56,6 @@ export default class ContainerElement extends Element {
 	 * @returns {Number|null} Block filler offset or `null` if block filler is not needed.
 	 */
 	getFillerOffset() {
-		return this.getChildCount() === 0 ? 0 : null;
+		return this.childCount === 0 ? 0 : null;
 	}
 }

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -265,7 +265,7 @@ export default class Document {
 	 */
 	focus() {
 		if ( !this.isFocused ) {
-			const editable = this.selection.getEditableElement();
+			const editable = this.selection.editableElement;
 
 			if ( editable ) {
 				this.domConverter.focus( editable );

--- a/src/view/documentfragment.js
+++ b/src/view/documentfragment.js
@@ -42,6 +42,24 @@ export default class DocumentFragment {
 	}
 
 	/**
+	 * Gets the number of elements in fragment.
+	 *
+	 * @returns {Number} The number of elements.
+	 */
+	get childCount() {
+		return this._children.length;
+	}
+
+	/**
+	 * Returns `true` if there are no nodes inside this document fragment, `false` otherwise.
+	 *
+	 * @returns {Boolean}
+	 */
+	get isEmpty() {
+		return this.childCount === 0;
+	}
+
+	/**
 	 * Artificial root of `DocumentFragment`. Returns itself. Added for compatibility reasons.
 	 *
 	 * @readonly
@@ -68,7 +86,7 @@ export default class DocumentFragment {
 	 * @returns {Number} Number of appended nodes.
 	 */
 	appendChildren( nodes ) {
-		return this.insertChildren( this.getChildCount(), nodes );
+		return this.insertChildren( this.childCount, nodes );
 	}
 
 	/**
@@ -79,15 +97,6 @@ export default class DocumentFragment {
 	 */
 	getChild( index ) {
 		return this._children[ index ];
-	}
-
-	/**
-	 * Gets the number of elements in fragment.
-	 *
-	 * @returns {Number} The number of elements.
-	 */
-	getChildCount() {
-		return this._children.length;
 	}
 
 	/**
@@ -132,15 +141,6 @@ export default class DocumentFragment {
 		}
 
 		return count;
-	}
-
-	/**
-	 * Returns `true` if there are no nodes inside this document fragment, `false` otherwise.
-	 *
-	 * @returns {Boolean}
-	 */
-	isEmpty() {
-		return this.getChildCount() === 0;
 	}
 
 	/**

--- a/src/view/documentfragment.js
+++ b/src/view/documentfragment.js
@@ -42,18 +42,20 @@ export default class DocumentFragment {
 	}
 
 	/**
-	 * Gets the number of elements in fragment.
+	 * Number of child nodes in this document fragment.
 	 *
-	 * @returns {Number} The number of elements.
+	 * @readonly
+	 * @type {Number} The number of elements.
 	 */
 	get childCount() {
 		return this._children.length;
 	}
 
 	/**
-	 * Returns `true` if there are no nodes inside this document fragment, `false` otherwise.
+	 * Is `true` if there are no nodes inside this document fragment, `false` otherwise.
 	 *
-	 * @returns {Boolean}
+	 * @readonly
+	 * @type {Boolean}
 	 */
 	get isEmpty() {
 		return this.childCount === 0;

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -412,7 +412,7 @@ export default class DomConverter {
 				const viewBefore = this.getCorrespondingView( domParent.childNodes[ domOffset - 1 ] );
 
 				if ( viewBefore ) {
-					return new ViewPosition( viewBefore.parent, viewBefore.getIndex() + 1 );
+					return new ViewPosition( viewBefore.parent, viewBefore.index + 1 );
 				}
 			}
 
@@ -501,11 +501,11 @@ export default class DomConverter {
 			const viewElement = this.getCorrespondingViewElement( previousSibling );
 
 			if ( viewElement ) {
-				const nextSibling = viewElement.getNextSibling();
+				const nextSibling = viewElement.nextSibling;
 
 				// It might be filler which has no corresponding view node.
 				if ( nextSibling instanceof ViewText ) {
-					return viewElement.getNextSibling();
+					return viewElement.nextSibling;
 				} else {
 					return null;
 				}
@@ -590,7 +590,7 @@ export default class DomConverter {
 	 * @returns {Text|null} Corresponding DOM text node or `null`, if it was not possible to find a corresponding node.
 	 */
 	getCorrespondingDomText( viewText ) {
-		const previousSibling = viewText.getPreviousSibling();
+		const previousSibling = viewText.previousSibling;
 
 		// Try to use previous sibling to find the corresponding text node.
 		if ( previousSibling && this.getCorrespondingDom( previousSibling ) ) {

--- a/src/view/editableelement.js
+++ b/src/view/editableelement.js
@@ -51,13 +51,13 @@ export default class EditableElement extends ContainerElement {
 		this.bind( 'isFocused' ).to(
 			document,
 			'isFocused',
-			( isFocused ) => isFocused && document.selection.getEditableElement() == this
+			( isFocused ) => isFocused && document.selection.editableElement == this
 		);
 
 		// Update focus state after each rendering. Selection might be moved to different editable before rendering,
 		// but this does not mean that editable has focus - it will be placed there after rendering.
 		this.listenTo( document, 'render', () => {
-			this.isFocused = document.isFocused && document.selection.getEditableElement() == this;
+			this.isFocused = document.isFocused && document.selection.editableElement == this;
 		}, null, 11 );
 	}
 
@@ -66,7 +66,7 @@ export default class EditableElement extends ContainerElement {
 	 *
 	 * @returns {engine.view.Document|null} View Document of the node or `null`.
 	 */
-	getDocument() {
+	get document() {
 		return this._document;
 	}
 }

--- a/src/view/editableelement.js
+++ b/src/view/editableelement.js
@@ -62,9 +62,9 @@ export default class EditableElement extends ContainerElement {
 	}
 
 	/**
-	 * Gets the {@link engine.view.Document} reference.
+	 * {@link engine.view.Document View document} reference that owns this editable element.
 	 *
-	 * @returns {engine.view.Document|null} View Document of the node or `null`.
+	 * @type {engine.view.Document|null}
 	 */
 	get document() {
 		return this._document;

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -103,18 +103,20 @@ export default class Element extends Node {
 	}
 
 	/**
-	 * Gets the number of element's children.
+	 * Number of element's children.
 	 *
-	 * @returns {Number} The number of element's children.
+	 * @readonly
+	 * @type {Number}
 	 */
 	get childCount() {
 		return this._children.length;
 	}
 
 	/**
-	 * Returns `true` if there are no nodes inside this element, `false` otherwise.
+	 * Is `true` if there are no nodes inside this element, `false` otherwise.
 	 *
-	 * @returns {Boolean}
+	 * @readonly
+	 * @type {Boolean}
 	 */
 	get isEmpty() {
 		return this._children.length === 0;

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -103,6 +103,24 @@ export default class Element extends Node {
 	}
 
 	/**
+	 * Gets the number of element's children.
+	 *
+	 * @returns {Number} The number of element's children.
+	 */
+	get childCount() {
+		return this._children.length;
+	}
+
+	/**
+	 * Returns `true` if there are no nodes inside this element, `false` otherwise.
+	 *
+	 * @returns {Boolean}
+	 */
+	get isEmpty() {
+		return this._children.length === 0;
+	}
+
+	/**
 	 * Clones provided element.
 	 *
 	 * @param {Boolean} deep If set to `true` clones element and all its children recursively. When set to `false`,
@@ -138,7 +156,7 @@ export default class Element extends Node {
 	 * @returns {Number} Number of appended nodes.
 	 */
 	appendChildren( nodes ) {
-		return this.insertChildren( this.getChildCount(), nodes );
+		return this.insertChildren( this.childCount, nodes );
 	}
 
 	/**
@@ -149,15 +167,6 @@ export default class Element extends Node {
 	 */
 	getChild( index ) {
 		return this._children[ index ];
-	}
-
-	/**
-	 * Gets the number of element's children.
-	 *
-	 * @returns {Number} The number of element's children.
-	 */
-	getChildCount() {
-		return this._children.length;
 	}
 
 	/**
@@ -367,15 +376,6 @@ export default class Element extends Node {
 		}
 
 		return this._children.splice( index, howMany );
-	}
-
-	/**
-	 * Returns `true` if there are no nodes inside this element, `false` otherwise.
-	 *
-	 * @returns {Boolean}
-	 */
-	isEmpty() {
-		return this._children.length === 0;
 	}
 
 	/**

--- a/src/view/matcher.js
+++ b/src/view/matcher.js
@@ -75,7 +75,7 @@ export default class Matcher {
 	 *		matcher.add( ( element ) => {
 	 *			// Result of this function will be included in `match`
 	 *			// property of the object returned from matcher.match() call.
-	 *			if ( element.name === 'div' && element.getChildCount() > 0 ) {
+	 *			if ( element.name === 'div' && element.childCount > 0 ) {
 	 *				return { name: true };
 	 *			}
 	 *

--- a/src/view/node.js
+++ b/src/view/node.js
@@ -30,11 +30,13 @@ export default class Node {
 	}
 
 	/**
-	 * Returns index of the node in the parent element or null if the node has no parent.
+	 * Index of the node in the parent element or null if the node has no parent.
 	 *
-	 * Throws error if the parent element does not contain this node.
+	 * Accessing this property throws an error if this node's parent element does not contain it.
+	 * This means that view tree got broken.
 	 *
-	 * @returns {Number|null} Index of the node in the parent element or null if the node has not parent.
+	 * @readonly
+	 * @type {Number|null}
 	 */
 	get index() {
 		let pos;
@@ -57,9 +59,10 @@ export default class Node {
 	}
 
 	/**
-	 * Returns nodes next sibling or `null` if it is the last child.
+	 * Node's next sibling, or `null` if it is the last child.
 	 *
-	 * @returns {engine.view.Node|null} Nodes next sibling or `null` if it is the last child.
+	 * @readonly
+	 * @type {engine.view.Node|null}
 	 */
 	get nextSibling() {
 		const index = this.index;
@@ -68,9 +71,10 @@ export default class Node {
 	}
 
 	/**
-	 * Returns nodes previous sibling or `null` if it is the first child.
+	 * Node's previous sibling, or `null` if it is the first child.
 	 *
-	 * @returns {engine.view.Node|null} Nodes previous sibling or `null` if it is the first child.
+	 * @readonly
+	 * @type {engine.view.Node|null}
 	 */
 	get previousSibling() {
 		const index = this.index;
@@ -79,9 +83,10 @@ export default class Node {
 	}
 
 	/**
-	 * Gets the top parent for the node. If node has no parent it is the root itself.
+	 * Top-most ancestor of the node. If the node has no parent it is the root itself.
 	 *
-	 * @returns {engine.view.Node|engine.view.DocumentFragment}
+	 * @readonly
+	 * @type {engine.view.Node|engine.view.DocumentFragment}
 	 */
 	get root() {
 		let root = this;
@@ -94,10 +99,11 @@ export default class Node {
 	}
 
 	/**
-	 * Gets {@link engine.view.Document} reference, from the {@link engine.view.Node#getRoot root} or
-	 * returns null if the root has no reference to the {@link engine.view.Document}.
+	 * {@link engine.view.Document View document} that owns this node, or `null` if the node is inside
+	 * {@link engine.view.DocumentFragment document fragment}.
 	 *
-	 * @returns {engine.view.Document|null} View document of the node or null.
+	 * @readonly
+	 * @type {engine.view.Document|null}
 	 */
 	get document() {
 		// Parent might be Node, null or DocumentFragment.

--- a/src/view/node.js
+++ b/src/view/node.js
@@ -36,7 +36,7 @@ export default class Node {
 	 *
 	 * @returns {Number|null} Index of the node in the parent element or null if the node has not parent.
 	 */
-	getIndex() {
+	get index() {
 		let pos;
 
 		if ( !this.parent ) {
@@ -61,8 +61,8 @@ export default class Node {
 	 *
 	 * @returns {engine.view.Node|null} Nodes next sibling or `null` if it is the last child.
 	 */
-	getNextSibling() {
-		const index = this.getIndex();
+	get nextSibling() {
+		const index = this.index;
 
 		return ( index !== null && this.parent.getChild( index + 1 ) ) || null;
 	}
@@ -72,10 +72,25 @@ export default class Node {
 	 *
 	 * @returns {engine.view.Node|null} Nodes previous sibling or `null` if it is the first child.
 	 */
-	getPreviousSibling() {
-		const index = this.getIndex();
+	get previousSibling() {
+		const index = this.index;
 
 		return ( index !== null && this.parent.getChild( index - 1 ) ) || null;
+	}
+
+	/**
+	 * Gets the top parent for the node. If node has no parent it is the root itself.
+	 *
+	 * @returns {engine.view.Node|engine.view.DocumentFragment}
+	 */
+	get root() {
+		let root = this;
+
+		while ( root.parent ) {
+			root = root.parent;
+		}
+
+		return root;
 	}
 
 	/**
@@ -84,28 +99,13 @@ export default class Node {
 	 *
 	 * @returns {engine.view.Document|null} View document of the node or null.
 	 */
-	getDocument() {
+	get document() {
 		// Parent might be Node, null or DocumentFragment.
 		if ( this.parent instanceof Node ) {
-			return this.parent.getDocument();
+			return this.parent.document;
 		} else {
 			return null;
 		}
-	}
-
-	/**
-	 * Gets the top parent for the node. If node has no parent it is the root itself.
-	 *
-	 * @returns {engine.view.Node|engine.view.DocumentFragment}
-	 */
-	getRoot() {
-		let root = this;
-
-		while ( root.parent ) {
-			root = root.parent;
-		}
-
-		return root;
 	}
 
 	/**
@@ -133,7 +133,7 @@ export default class Node {
 	 * Removes node from parent.
 	 */
 	remove() {
-		this.parent.removeChildren( this.getIndex() );
+		this.parent.removeChildren( this.index );
 	}
 
 	/**

--- a/src/view/observer/focusobserver.js
+++ b/src/view/observer/focusobserver.js
@@ -26,7 +26,7 @@ export default class FocusObserver extends DomEventObserver {
 		} );
 
 		document.on( 'blur', ( evt, data ) => {
-			const selectedEditable = document.selection.getEditableElement();
+			const selectedEditable = document.selection.editableElement;
 
 			if ( selectedEditable === null || selectedEditable === data.target ) {
 				document.isFocused = false;

--- a/src/view/position.js
+++ b/src/view/position.js
@@ -69,18 +69,20 @@ export default class Position {
 	}
 
 	/**
-	 * Returns `true` if position is at the beginning of its {@link engine.view.Position#parent parent}, `false` otherwise.
+	 * Is `true` if position is at the beginning of its {@link engine.view.Position#parent parent}, `false` otherwise.
 	 *
-	 * @returns {Boolean}
+	 * @readonly
+	 * @type {Boolean}
 	 */
 	get isAtStart() {
 		return this.offset === 0;
 	}
 
 	/**
-	 * Returns `true` if position is at the end of its {@link engine.view.Position#parent parent}, `false` otherwise.
+	 * Is `true` if position is at the end of its {@link engine.view.Position#parent parent}, `false` otherwise.
 	 *
-	 * @returns {Boolean}
+	 * @readonly
+	 * @type {Boolean}
 	 */
 	get isAtEnd() {
 		const endOffset = this.parent instanceof Text ? this.parent.data.length : this.parent.childCount;
@@ -89,18 +91,20 @@ export default class Position {
 	}
 
 	/**
-	 * Returns position root, that is the root of the position's parent element.
+	 * Position's root, that is the root of the position's parent element.
 	 *
-	 * @returns {engine.view.Node|engine.view.DocumentFragment} Position's root.
+	 * @readonly
+	 * @type {engine.view.Node|engine.view.DocumentFragment}
 	 */
 	get root() {
 		return this.parent.root;
 	}
 
 	/**
-	 * Returns {@link engine.view.EditableElement EditableElement} instance that contains this position.
+	 * {@link engine.view.EditableElement EditableElement} instance that contains this position, or `null` if
+	 * position is not inside an editable element.
 	 *
-	 * @returns {engine.view.EditableElement|null} Returns closest EditableElement or null if none is found.
+	 * @type {engine.view.EditableElement|null}
 	 */
 	get editableElement() {
 		let editable = this.parent;

--- a/src/view/position.js
+++ b/src/view/position.js
@@ -69,6 +69,54 @@ export default class Position {
 	}
 
 	/**
+	 * Returns `true` if position is at the beginning of its {@link engine.view.Position#parent parent}, `false` otherwise.
+	 *
+	 * @returns {Boolean}
+	 */
+	get isAtStart() {
+		return this.offset === 0;
+	}
+
+	/**
+	 * Returns `true` if position is at the end of its {@link engine.view.Position#parent parent}, `false` otherwise.
+	 *
+	 * @returns {Boolean}
+	 */
+	get isAtEnd() {
+		const endOffset = this.parent instanceof Text ? this.parent.data.length : this.parent.childCount;
+
+		return this.offset === endOffset;
+	}
+
+	/**
+	 * Returns position root, that is the root of the position's parent element.
+	 *
+	 * @returns {engine.view.Node|engine.view.DocumentFragment} Position's root.
+	 */
+	get root() {
+		return this.parent.root;
+	}
+
+	/**
+	 * Returns {@link engine.view.EditableElement EditableElement} instance that contains this position.
+	 *
+	 * @returns {engine.view.EditableElement|null} Returns closest EditableElement or null if none is found.
+	 */
+	get editableElement() {
+		let editable = this.parent;
+
+		while ( !( editable instanceof EditableElement ) ) {
+			if ( editable.parent ) {
+				editable = editable.parent;
+			} else {
+				return null;
+			}
+		}
+
+		return editable;
+	}
+
+	/**
 	 * Returns a new instance of Position with offset incremented by `shift` value.
 	 *
 	 * @param {Number} shift How position offset should get changed. Accepts negative values.
@@ -81,15 +129,6 @@ export default class Position {
 		shifted.offset = offset < 0 ? 0 : offset;
 
 		return shifted;
-	}
-
-	/**
-	 * Returns position root, that is the root of the position's parent element.
-	 *
-	 * @returns {engine.view.Node|engine.view.DocumentFragment} Position's root.
-	 */
-	getRoot() {
-		return this.parent.getRoot();
 	}
 
 	/**
@@ -137,26 +176,6 @@ export default class Position {
 	 */
 	isAfter( otherPosition ) {
 		return this.compareWith( otherPosition ) == 'after';
-	}
-
-	/**
-	 * Returns `true` if position is at the beginning of its {@link engine.view.Position#parent parent}, `false` otherwise.
-	 *
-	 * @returns {Boolean}
-	 */
-	isAtStart() {
-		return this.offset === 0;
-	}
-
-	/**
-	 * Returns `true` if position is at the end of its {@link engine.view.Position#parent parent}, `false` otherwise.
-	 *
-	 * @returns {Boolean}
-	 */
-	isAtEnd() {
-		const endOffset = this.parent instanceof Text ? this.parent.data.length : this.parent.getChildCount();
-
-		return this.offset === endOffset;
 	}
 
 	/**
@@ -209,38 +228,19 @@ export default class Position {
 
 		// Check if common ancestor is not one of the parents.
 		if ( commonAncestor === this.parent ) {
-			const index = this.offset - nextAncestor2.getIndex();
+			const index = this.offset - nextAncestor2.index;
 
 			return index <= 0 ? 'before' : 'after';
 		} else if ( commonAncestor === otherPosition.parent ) {
-			const index = nextAncestor1.getIndex() - otherPosition.offset;
+			const index = nextAncestor1.index - otherPosition.offset;
 
 			return index < 0 ? 'before' : 'after';
 		}
 
-		const index = nextAncestor1.getIndex() - nextAncestor2.getIndex();
+		const index = nextAncestor1.index - nextAncestor2.index;
 
 		// Compare indexes of next ancestors inside common one.
 		return index < 0 ? 'before' : 'after';
-	}
-
-	/**
-	 * Returns {@link engine.view.EditableElement EditableElement} instance that contains this position.
-	 *
-	 * @returns {engine.view.EditableElement|null} Returns closest EditableElement or null if none is found.
-	 */
-	getEditableElement() {
-		let editable = this.parent;
-
-		while ( !( editable instanceof EditableElement ) ) {
-			if ( editable.parent ) {
-				editable = editable.parent;
-			} else {
-				return null;
-			}
-		}
-
-		return editable;
 	}
 
 	/**
@@ -268,7 +268,7 @@ export default class Position {
 			let node = itemOrPosition;
 
 			if ( offset == 'end' ) {
-				offset = node instanceof Text ? node.data.length : node.getChildCount();
+				offset = node instanceof Text ? node.data.length : node.childCount;
 			} else if ( offset == 'before' ) {
 				return this.createBefore( node );
 			} else if ( offset == 'after' ) {
@@ -303,7 +303,7 @@ export default class Position {
 			throw new CKEditorError( 'position-after-root: You can not make position after root.', { root: item } );
 		}
 
-		return new Position( item.parent, item.getIndex() + 1 );
+		return new Position( item.parent, item.index + 1 );
 	}
 
 	/**
@@ -328,7 +328,7 @@ export default class Position {
 			throw new CKEditorError( 'position-before-root: You can not make position before root.', { root: item } );
 		}
 
-		return new Position( item.parent, item.getIndex() );
+		return new Position( item.parent, item.index );
 	}
 
 	/**

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -75,8 +75,8 @@ export default class Range {
 	 *
 	 * @type {engine.view.Element|engine.view.DocumentFragment}
 	 */
-	getRoot() {
-		return this.start.getRoot();
+	get root() {
+		return this.start.root;
 	}
 
 	/**
@@ -331,6 +331,6 @@ export default class Range {
 	 * @returns {engine.view.Range}
 	 */
 	static createFromElement( element ) {
-		return this.createFromParentsAndOffsets( element, 0, element, element.getChildCount() );
+		return this.createFromParentsAndOffsets( element, 0, element, element.childCount );
 	}
 }

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -280,7 +280,7 @@ export default class Renderer {
 		const selectionOffset = selectionPosition.offset;
 
 		// If there is no DOM root we do not care about fillers.
-		if ( !this.domConverter.getCorrespondingDomElement( selectionParent.getRoot() ) ) {
+		if ( !this.domConverter.getCorrespondingDomElement( selectionParent.root ) ) {
 			return false;
 		}
 
@@ -317,7 +317,7 @@ export default class Renderer {
 
 		const filler = this._inlineFillerPosition;
 
-		if ( filler && filler.parent == viewText.parent && filler.offset == viewText.getIndex() ) {
+		if ( filler && filler.parent == viewText.parent && filler.offset == viewText.index ) {
 			expectedText = INLINE_FILLER + expectedText;
 		}
 
@@ -428,7 +428,7 @@ export default class Renderer {
 			return;
 		}
 
-		const selectedEditable = this.selection.getEditableElement();
+		const selectedEditable = this.selection.editableElement;
 		const domRoot = this.domConverter.getCorrespondingDomElement( selectedEditable );
 
 		if ( !domRoot ) {
@@ -446,7 +446,7 @@ export default class Renderer {
 
 		for ( let range of this.selection.getRanges() ) {
 			// Update ranges only in currently selected editable.
-			if ( range.start.parent.getRoot() == selectedEditable ) {
+			if ( range.start.parent.root == selectedEditable ) {
 				const domRangeStart = this.domConverter.viewPositionToDom( range.start );
 				const domRangeEnd = this.domConverter.viewPositionToDom( range.end );
 				const domRange = new Range();
@@ -479,7 +479,7 @@ export default class Renderer {
 	 */
 	_updateFocus() {
 		if ( this.isFocused ) {
-			const editable = this.selection.getEditableElement();
+			const editable = this.selection.editableElement;
 
 			if ( editable ) {
 				this.domConverter.focus( editable );

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -111,6 +111,19 @@ export default class Selection {
 	}
 
 	/**
+	 * Returns {@link engine.view.EditableElement EditableElement} instance that contains this selection.
+	 *
+	 * @returns {engine.view.EditableElement|null} Returns closest EditableElement or null if none is found.
+	 */
+	get editableElement() {
+		if ( this.rangeCount ) {
+			return this.getFirstPosition().editableElement;
+		}
+
+		return null;
+	}
+
+	/**
 	 * Adds a range to the selection. Added range is copied. This means that passed range is not saved in the
 	 * selection instance and you can safely operate on it.
 	 *
@@ -326,19 +339,6 @@ export default class Selection {
 		if ( endPosition !== null ) {
 			this.setRanges( [ new Range( endPosition, endPosition ) ] );
 		}
-	}
-
-	/**
-	 * Returns {@link engine.view.EditableElement EditableElement} instance that contains this selection.
-	 *
-	 * @returns {engine.view.EditableElement|null} Returns closest EditableElement or null if none is found.
-	 */
-	getEditableElement() {
-		if ( this.rangeCount ) {
-			return this.getFirstPosition().getEditableElement();
-		}
-
-		return null;
 	}
 
 	/**

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -111,9 +111,10 @@ export default class Selection {
 	}
 
 	/**
-	 * Returns {@link engine.view.EditableElement EditableElement} instance that contains this selection.
+	 * {@link engine.view.EditableElement EditableElement} instance that contains this selection, or `null`
+	 * if the selection is not inside an editable element.
 	 *
-	 * @returns {engine.view.EditableElement|null} Returns closest EditableElement or null if none is found.
+	 * @type {engine.view.EditableElement|null}
 	 */
 	get editableElement() {
 		if ( this.rangeCount ) {

--- a/src/view/textproxy.js
+++ b/src/view/textproxy.js
@@ -53,16 +53,6 @@ export default class TextProxy {
 	}
 
 	/**
-	 * Element that is a parent of this text proxy.
-	 *
-	 * @readonly
-	 * @type {engine.view.Element|engine.view.DocumentFragment|null}
-	 */
-	get parent() {
-		return this.textNode.parent;
-	}
-
-	/**
 	 * Flag indicating whether `TextProxy` instance covers only part of the original {@link engine.view.Text text node}
 	 * (`true`) or the whole text node (`false`).
 	 *
@@ -78,13 +68,13 @@ export default class TextProxy {
 	}
 
 	/**
-	 * Gets {@link engine.view.Document} reference, from the {@link engine.view.Node#getRoot root} of
-	 * {#textNode} or returns null if the root has no reference to the {@link engine.view.Document}.
+	 * Element that is a parent of this text proxy.
 	 *
-	 * @returns {engine.view.Document|null} View Document of the text proxy or null.
+	 * @readonly
+	 * @type {engine.view.Element|engine.view.DocumentFragment|null}
 	 */
-	getDocument() {
-		return this.textNode.getDocument();
+	get parent() {
+		return this.textNode.parent;
 	}
 
 	/**
@@ -92,8 +82,18 @@ export default class TextProxy {
 	 *
 	 * @returns {engine.view.Node}
 	 */
-	getRoot() {
-		return this.textNode.getRoot();
+	get root() {
+		return this.textNode.root;
+	}
+
+	/**
+	 * Gets {@link engine.view.Document} reference, from the {@link engine.view.Node#getRoot root} of
+	 * {#textNode} or returns null if the root has no reference to the {@link engine.view.Document}.
+	 *
+	 * @returns {engine.view.Document|null} View Document of the text proxy or null.
+	 */
+	get document() {
+		return this.textNode.document;
 	}
 
 	/**

--- a/src/view/textproxy.js
+++ b/src/view/textproxy.js
@@ -68,7 +68,7 @@ export default class TextProxy {
 	}
 
 	/**
-	 * Element that is a parent of this text proxy.
+	 * Parent of this text proxy, which is same as parent of text node represented by this text proxy.
 	 *
 	 * @readonly
 	 * @type {engine.view.Element|engine.view.DocumentFragment|null}
@@ -78,19 +78,21 @@ export default class TextProxy {
 	}
 
 	/**
-	 * Gets the top parent for the {#textNode}. If there is no parent {#textNode} is the root.
+	 * Root of this text proxy, which is same as root of text node represented by this text proxy.
 	 *
-	 * @returns {engine.view.Node}
+	 * @readonly
+	 * @type {engine.view.Node|engine.view.DocumentFragment}
 	 */
 	get root() {
 		return this.textNode.root;
 	}
 
 	/**
-	 * Gets {@link engine.view.Document} reference, from the {@link engine.view.Node#getRoot root} of
-	 * {#textNode} or returns null if the root has no reference to the {@link engine.view.Document}.
+	 * {@link engine.view.Document View document} that owns this text proxy, or `null` if the text proxy is inside
+	 * {@link engine.view.DocumentFragment document fragment}.
 	 *
-	 * @returns {engine.view.Document|null} View Document of the text proxy or null.
+	 * @readonly
+	 * @type {engine.view.Document|null}
 	 */
 	get document() {
 		return this.textNode.document;

--- a/src/view/treewalker.js
+++ b/src/view/treewalker.js
@@ -164,7 +164,7 @@ export default class TreeWalker {
 		const parent = position.parent;
 
 		// We are at the end of the root.
-		if ( parent.parent === null && position.offset === parent.getChildCount() ) {
+		if ( parent.parent === null && position.offset === parent.childCount ) {
 			return { done: true };
 		}
 
@@ -283,7 +283,7 @@ export default class TreeWalker {
 
 		if ( node instanceof Element ) {
 			if ( !this.shallow ) {
-				position = new Position( node, node.getChildCount() );
+				position = new Position( node, node.childCount );
 				this.position = position;
 
 				if ( this.ignoreElementEnd ) {

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -102,9 +102,9 @@ export function mergeAt( position ) {
 	}
 
 	// When inside empty attribute - remove it.
-	if ( positionParent instanceof AttributeElement && positionParent.getChildCount() === 0 ) {
+	if ( positionParent instanceof AttributeElement && positionParent.childCount === 0 ) {
 		const parent = positionParent.parent;
-		const offset = positionParent.getIndex();
+		const offset = positionParent.index;
 		positionParent.remove();
 
 		return mergeAt( new Position( parent, offset ) );
@@ -131,7 +131,7 @@ export function mergeAt( position ) {
 	// When selection is between same nodes.
 	else if ( nodeBefore.isSimilar( nodeAfter ) ) {
 		// Move all children nodes from node placed after selection and remove that node.
-		const count = nodeBefore.getChildCount();
+		const count = nodeBefore.childCount;
 		nodeBefore.appendChildren( nodeAfter.getChildren() );
 		nodeAfter.remove();
 
@@ -295,7 +295,7 @@ export function wrap( range, attribute ) {
 	// Range is inside single attribute and spans on all children.
 	if ( rangeSpansOnAllChildren( range ) && wrapAttributeElement( attribute, range.start.parent ) ) {
 		const parent = range.start.parent.parent;
-		const index = range.start.parent.getIndex();
+		const index = range.start.parent.index;
 
 		return Range.createFromParentsAndOffsets( parent, index, parent, index + 1 ) ;
 	}
@@ -369,7 +369,7 @@ export function wrapPosition( position, attribute ) {
 	wrap( wrapRange, attribute );
 
 	// Remove fake element and place new position there.
-	const newPosition = new Position( fakePosition.parent, fakePosition.getIndex() );
+	const newPosition = new Position( fakePosition.parent, fakePosition.index );
 	fakePosition.remove();
 
 	// If position is placed between text nodes - merge them and return position inside.
@@ -485,11 +485,11 @@ function _breakRange( range, forceSplitText = false ) {
 	}
 
 	const breakEnd = _breakAt( rangeEnd, forceSplitText );
-	const count = breakEnd.parent.getChildCount();
+	const count = breakEnd.parent.childCount;
 	const breakStart = _breakAt( rangeStart, forceSplitText );
 
 	// Calculate new break end offset.
-	breakEnd.offset += breakEnd.parent.getChildCount() - count;
+	breakEnd.offset += breakEnd.parent.childCount - count;
 
 	return new Range( breakStart, breakEnd );
 }
@@ -521,13 +521,13 @@ function _breakAt( position, forceSplitText = false ) {
 		return _breakAt( breakTextNode( position ), forceSplitText );
 	}
 
-	const length = positionParent.getChildCount();
+	const length = positionParent.childCount;
 
 	// <p>foo<b><u>bar{}</u></b></p>
 	// <p>foo<b><u>bar</u>[]</b></p>
 	// <p>foo<b><u>bar</u></b>[]</p>
 	if ( positionOffset == length ) {
-		const newPosition = new Position( positionParent.parent, positionParent.getIndex() + 1 );
+		const newPosition = new Position( positionParent.parent, positionParent.index + 1 );
 
 		return _breakAt( newPosition, forceSplitText );
 	} else
@@ -535,7 +535,7 @@ function _breakAt( position, forceSplitText = false ) {
 	// <p>foo<b>[]<u>bar</u></b></p>
 	// <p>foo{}<b><u>bar</u></b></p>
 	if ( positionOffset === 0 ) {
-		const newPosition = new Position( positionParent.parent, positionParent.getIndex() );
+		const newPosition = new Position( positionParent.parent, positionParent.index );
 
 		return _breakAt( newPosition, forceSplitText );
 	}
@@ -544,7 +544,7 @@ function _breakAt( position, forceSplitText = false ) {
 	// <p>foo<b><u>b</u>[]<u>ar</u></b></p>
 	// <p>foo<b><u>b</u></b>[]<b><u>ar</u></b></p>
 	else {
-		const offsetAfter = positionParent.getIndex() + 1;
+		const offsetAfter = positionParent.index + 1;
 
 		// Break element.
 		const clonedNode = positionParent.clone();
@@ -553,7 +553,7 @@ function _breakAt( position, forceSplitText = false ) {
 		positionParent.parent.insertChildren( offsetAfter, clonedNode );
 
 		// Get nodes to move.
-		const count = positionParent.getChildCount() - positionOffset;
+		const count = positionParent.childCount - positionOffset;
 		const nodesToMove = positionParent.removeChildren( positionOffset, count );
 
 		// Move nodes to cloned node.
@@ -584,7 +584,7 @@ function unwrapChildren( parent, startOffset, endOffset, attribute ) {
 		// If attributes are the similar, then unwrap.
 		if (  child.isSimilar( attribute ) ) {
 			const unwrapped = child.getChildren();
-			const count = child.getChildCount();
+			const count = child.childCount;
 
 			// Replace wrapper element with its children
 			child.remove();
@@ -603,7 +603,7 @@ function unwrapChildren( parent, startOffset, endOffset, attribute ) {
 		} else {
 			// If other nested attribute is found start unwrapping there.
 			if ( child instanceof AttributeElement ) {
-				unwrapChildren( child, 0, child.getChildCount(), attribute );
+				unwrapChildren( child, 0, child.childCount, attribute );
 			}
 
 			i++;
@@ -663,7 +663,7 @@ function wrapChildren( parent, startOffset, endOffset, attribute ) {
 		} else {
 			// If other nested attribute is found start wrapping there.
 			if ( child instanceof AttributeElement ) {
-				wrapChildren( child, 0, child.getChildCount(), attribute );
+				wrapChildren( child, 0, child.childCount, attribute );
 			}
 		}
 
@@ -726,11 +726,11 @@ function movePositionToTextNode( position ) {
 // @returns {engine.view.Position} New position after breaking text node.
 function breakTextNode( position ) {
 	if ( position.offset == position.parent.data.length ) {
-		return new Position( position.parent.parent, position.parent.getIndex() + 1 );
+		return new Position( position.parent.parent, position.parent.index + 1 );
 	}
 
 	if ( position.offset === 0 ) {
-		return new Position( position.parent.parent, position.parent.getIndex() );
+		return new Position( position.parent.parent, position.parent.index );
 	}
 
 	// Get part of the text that need to be moved.
@@ -740,10 +740,10 @@ function breakTextNode( position ) {
 	position.parent.data = position.parent.data.slice( 0, position.offset );
 
 	// Insert new text node after position's parent text node.
-	position.parent.parent.insertChildren( position.parent.getIndex() + 1, new Text( textToMove ) );
+	position.parent.parent.insertChildren( position.parent.index + 1, new Text( textToMove ) );
 
 	// Return new position between two newly created text nodes.
-	return new Position( position.parent.parent, position.parent.getIndex() + 1 );
+	return new Position( position.parent.parent, position.parent.index + 1 );
 }
 
 // Merges two text nodes into first node. Removes second node and returns merge position.
@@ -888,7 +888,7 @@ function unwrapAttributeElement( wrapper, toUnwrap ) {
 // @returns {Boolean}
 function rangeSpansOnAllChildren( range ) {
 	return range.start.parent == range.end.parent && range.start.parent instanceof AttributeElement &&
-		range.start.offset === 0 && range.end.offset === range.start.parent.getChildCount();
+		range.start.offset === 0 && range.end.offset === range.start.parent.childCount;
 }
 
 // Checks if provided nodes are valid to insert. Checks if each node is an instance of

--- a/tests/_utils-tests/model.js
+++ b/tests/_utils-tests/model.js
@@ -372,7 +372,7 @@ describe( 'model test utils', () => {
 			data: '<selection />',
 			check( fragment, selection ) {
 				expect( fragment ).to.be.instanceOf( DocumentFragment );
-				expect( fragment.getChildCount() ).to.equal( 0 );
+				expect( fragment.childCount ).to.equal( 0 );
 				expect( selection.rangeCount ).to.equal( 1 );
 				expect( selection.getFirstRange().isEqual( Range.createFromParentsAndOffsets( fragment, 0, fragment, 0 ) ) ).to.be.true;
 			}
@@ -393,7 +393,7 @@ describe( 'model test utils', () => {
 			data: '<a></a><b></b>',
 			check( fragment ) {
 				expect( fragment ).to.be.instanceOf( DocumentFragment );
-				expect( fragment.getChildCount() ).to.equal( 2 );
+				expect( fragment.childCount ).to.equal( 2 );
 			}
 		} );
 
@@ -423,8 +423,8 @@ describe( 'model test utils', () => {
 		test( 'sets text attributes', {
 			data: '<$text bold=true italic=true>foo</$text><$text bold=true>bar</$text>bom',
 			check( root ) {
-				expect( root.getChildCount() ).to.equal( 3 );
-				expect( root.getMaxOffset() ).to.equal( 9 );
+				expect( root.childCount ).to.equal( 3 );
+				expect( root.maxOffset ).to.equal( 9 );
 				expect( root.getChild( 0 ) ).to.have.property( 'data', 'foo' );
 				expect( root.getChild( 0 ).getAttribute( 'italic' ) ).to.equal( true );
 				expect( root.getChild( 1 ) ).to.have.property( 'data', 'bar' );
@@ -522,7 +522,7 @@ describe( 'model test utils', () => {
 			test( 'sets collapsed selection between text and text with attributes', {
 				data: 'foo<selection /><$text bold=true>bar</$text>',
 				check( root, selection ) {
-					expect( root.getMaxOffset() ).to.equal( 6 );
+					expect( root.maxOffset ).to.equal( 6 );
 					expect( selection.getAttribute( 'bold' ) ).to.be.undefined;
 				}
 			} );

--- a/tests/_utils-tests/view.js
+++ b/tests/_utils-tests/view.js
@@ -313,7 +313,7 @@ describe( 'view test utils', () => {
 			const fragment = parse( '' );
 
 			expect( fragment ).to.be.instanceOf( DocumentFragment );
-			expect( fragment.getChildCount() ).to.equal( 0 );
+			expect( fragment.childCount ).to.equal( 0 );
 		} );
 
 		it( 'should return empty DocumentFragment and Selection for string containing range only', () => {
@@ -337,7 +337,7 @@ describe( 'view test utils', () => {
 		it( 'should create DocumentFragment when multiple elements on root', () => {
 			const view = parse( '<b></b><i></i>' );
 			expect( view ).to.be.instanceOf( DocumentFragment );
-			expect( view.getChildCount() ).to.equal( 2 );
+			expect( view.childCount ).to.equal( 2 );
 			expect( view.getChild( 0 ).isSimilar( new Element( 'b' ) ) ).to.be.true;
 			expect( view.getChild( 1 ).isSimilar( new Element( 'i' ) ) ).to.be.true;
 		} );
@@ -360,7 +360,7 @@ describe( 'view test utils', () => {
 
 			expect( view ).to.be.instanceof( Element );
 			expect( view.isSimilar( element ) ).to.be.true;
-			expect( view.getChildCount() ).to.equal( 1 );
+			expect( view.childCount ).to.equal( 1 );
 			const text = view.getChild( 0 );
 			expect( text ).to.be.instanceof( Text );
 			expect( text.data ).to.equal( 'foobar' );
@@ -372,7 +372,7 @@ describe( 'view test utils', () => {
 
 			expect( view ).to.be.instanceof( Element );
 			expect( view.isSimilar( element ) ).to.be.true;
-			expect( view.getChildCount() ).to.equal( 0 );
+			expect( view.childCount ).to.equal( 0 );
 		} );
 
 		it( 'should parse element type', () => {
@@ -403,12 +403,12 @@ describe( 'view test utils', () => {
 		it( 'should paste nested elements and texts', () => {
 			const parsed = parse( '<container:p>foo<b:12>bar<i:25>qux</i:25></b:12></container:p>' );
 			expect( parsed.isSimilar( new ContainerElement( 'p' ) ) ).to.be.true;
-			expect( parsed.getChildCount() ).to.equal( 2 );
+			expect( parsed.childCount ).to.equal( 2 );
 			expect( parsed.getChild( 0 ) ).to.be.instanceof( Text ).and.have.property( 'data' ).that.equal( 'foo' );
 			const b = parsed.getChild( 1 );
 			expect( b ).to.be.instanceof( AttributeElement );
 			expect( b.priority ).to.equal( 12 );
-			expect( b.getChildCount() ).to.equal( 2 );
+			expect( b.childCount ).to.equal( 2 );
 			expect( b.getChild( 0 ) ).to.be.instanceof( Text ).and.have.property( 'data' ).that.equal( 'bar' );
 			const i = b.getChild( 1 );
 			expect( i ).to.be.instanceof( AttributeElement );
@@ -430,11 +430,11 @@ describe( 'view test utils', () => {
 		it( 'should parse selection range between elements', () => {
 			const { view, selection } = parse( '<p>[<b>foobar]</b>[]</p>' );
 			expect( view ).to.be.instanceof( Element );
-			expect( view.getChildCount() ).to.equal( 1 );
+			expect( view.childCount ).to.equal( 1 );
 			const b = view.getChild( 0 );
 			expect( b ).to.be.instanceof( Element );
 			expect( b.name ).to.equal( 'b' );
-			expect( b.getChildCount() ).to.equal( 1 );
+			expect( b.childCount ).to.equal( 1 );
 			const text = b.getChild( 0 );
 			expect( text ).to.be.instanceof( Text );
 			expect( text.data ).to.equal( 'foobar' );
@@ -447,7 +447,7 @@ describe( 'view test utils', () => {
 		it( 'should parse ranges #1', () => {
 			const { view, selection } = parse( '<container:p>foo{bar]</container:p>' );
 			expect( view.isSimilar( new ContainerElement( 'p' ) ) ).to.be.true;
-			expect( view.getChildCount() ).to.equal( 1 );
+			expect( view.childCount ).to.equal( 1 );
 			const text = view.getChild( 0 );
 			expect( text ).to.be.instanceof( Text );
 			expect( text.data ).to.equal( 'foobar' );
@@ -458,13 +458,13 @@ describe( 'view test utils', () => {
 		it( 'should parse ranges #2', () => {
 			const { view, selection } = parse( '<attribute:b>[foob}ar<i>{baz</i>]</attribute:b>' );
 			expect( view.isSimilar( new AttributeElement( 'b' ) ) ).to.be.true;
-			expect( view.getChildCount() ).to.equal( 2 );
+			expect( view.childCount ).to.equal( 2 );
 			const text1 = view.getChild( 0 );
 			expect( text1 ).to.be.instanceof( Text );
 			expect( text1.data ).to.equal( 'foobar' );
 			const i = view.getChild( 1 );
 			expect( i.isSimilar( new Element( 'i' ) ) ).to.be.true;
-			expect( i.getChildCount() ).to.equal( 1 );
+			expect( i.childCount ).to.equal( 1 );
 			const text2 = i.getChild( 0 );
 			expect( text2 ).to.be.instanceof( Text );
 			expect( text2.data ).to.equal( 'baz' );

--- a/tests/_utils/model.js
+++ b/tests/_utils/model.js
@@ -193,7 +193,7 @@ export function parse( data ) {
 
 	const handlers = {
 		text( token ) {
-			writer.insert( Position.createFromParentAndOffset( root, root.getMaxOffset() ), new Text( token.data, textAttributes ) );
+			writer.insert( Position.createFromParentAndOffset( root, root.maxOffset ), new Text( token.data, textAttributes ) );
 		},
 
 		textStart( token ) {
@@ -211,7 +211,7 @@ export function parse( data ) {
 
 		openingTag( token ) {
 			let el = new Element( token.name, token.attributes );
-			writer.insert( Position.createFromParentAndOffset( root, root.getMaxOffset() ), el );
+			writer.insert( Position.createFromParentAndOffset( root, root.maxOffset ), el );
 
 			root = el;
 
@@ -233,7 +233,7 @@ export function parse( data ) {
 		},
 
 		selectionStart( token ) {
-			selectionStart = Position.createFromParentAndOffset( root, root.getMaxOffset() );
+			selectionStart = Position.createFromParentAndOffset( root, root.maxOffset );
 			selectionAttributes = token.attributes;
 		},
 
@@ -243,7 +243,7 @@ export function parse( data ) {
 			}
 
 			withSelection = true;
-			selectionEnd = Position.createFromParentAndOffset( root, root.getMaxOffset() );
+			selectionEnd = Position.createFromParentAndOffset( root, root.maxOffset );
 
 			selection.setRanges(
 				[ new Range( selectionStart, selectionEnd ) ],
@@ -269,7 +269,7 @@ export function parse( data ) {
 	}
 
 	// If root DocumentFragment contains only one element - return that element.
-	if ( root instanceof DocumentFragment && root.getChildCount() == 1 ) {
+	if ( root instanceof DocumentFragment && root.childCount == 1 ) {
 		root = root.getChild( 0 );
 	}
 

--- a/tests/_utils/view.js
+++ b/tests/_utils/view.js
@@ -273,9 +273,9 @@ export function parse( data, options = {} ) {
 	// If custom root is provided - move all nodes there.
 	if ( options.rootElement ) {
 		const root = options.rootElement;
-		const nodes = view.removeChildren( 0, view.getChildCount() );
+		const nodes = view.removeChildren( 0, view.childCount );
 
-		root.removeChildren( 0, root.getChildCount() );
+		root.removeChildren( 0, root.childCount );
 		root.appendChildren( nodes );
 
 		view = root;
@@ -285,7 +285,7 @@ export function parse( data, options = {} ) {
 	const ranges = rangeParser.parse( view, options.order );
 
 	// If only one element is returned inside DocumentFragment - return that element.
-	if ( view instanceof ViewDocumentFragment && view.getChildCount() === 1 ) {
+	if ( view instanceof ViewDocumentFragment && view.childCount === 1 ) {
 		view = view.getChild( 0 );
 	}
 
@@ -390,7 +390,7 @@ class RangeParser {
 			}
 			text = text.replace( regexp, '' );
 			node.data = text;
-			const index = node.getIndex();
+			const index = node.index;
 			const parent = node.parent;
 
 			// Remove empty text nodes.

--- a/tests/conversion/advanced-converters.js
+++ b/tests/conversion/advanced-converters.js
@@ -161,7 +161,7 @@ describe( 'image with caption converters', () => {
 			const insertPosition = conversionApi.mapper.toViewPosition( data.range.start );
 
 			// Check if the `image` element has children.
-			if ( data.item.getChildCount() > 0 ) {
+			if ( data.item.childCount > 0 ) {
 				const modelCaption = data.item.getChild( 0 );
 
 				// `modelCaption` insertion change is consumed from consumable values.
@@ -420,7 +420,7 @@ describe( 'custom attribute handling for given element', () => {
 					viewA.setAttribute( 'title', data.item.getAttribute( 'linkTitle' ) );
 				}
 
-				viewWriter.insert( new ViewPosition( viewElement, viewElement.getChildCount() ), viewA );
+				viewWriter.insert( new ViewPosition( viewElement, viewElement.childCount ), viewA );
 			}
 
 			evt.stop();
@@ -432,7 +432,7 @@ describe( 'custom attribute handling for given element', () => {
 			consumable.consume( data.item, eventNameToConsumableType( evt.name ) );
 
 			const viewElement = conversionApi.mapper.toViewElement( data.item );
-			const viewA = viewElement.getChild( viewElement.getChildCount() - 1 );
+			const viewA = viewElement.getChild( viewElement.childCount - 1 );
 
 			if ( data.attributeNewValue !== null ) {
 				viewA.setAttribute( viewKey, data.attributeNewValue );
@@ -450,8 +450,8 @@ describe( 'custom attribute handling for given element', () => {
 			consumable.consume( data.item, eventNameToConsumableType( evt.name ) );
 
 			const viewElement = conversionApi.mapper.toViewElement( data.item );
-			const viewA = viewElement.getChild( viewElement.getChildCount() - 1 );
-			const aIndex = viewA.getIndex();
+			const viewA = viewElement.getChild( viewElement.childCount - 1 );
+			const aIndex = viewA.index;
 
 			viewWriter.remove( ViewRange.createFromParentsAndOffsets( viewElement, aIndex, viewElement, aIndex + 1 ) );
 
@@ -464,7 +464,7 @@ describe( 'custom attribute handling for given element', () => {
 			if ( consumable.consume( data.input, { name: true } ) ) {
 				data.output = new ModelElement( 'quote' );
 
-				const viewA = data.input.getChild( data.input.getChildCount() - 1 );
+				const viewA = data.input.getChild( data.input.childCount - 1 );
 
 				// Convert the special "a" first, before converting all children.
 				if ( viewA instanceof ViewElement && viewA.name == 'a' && consumable.consume( viewA, { name: true } ) ) {

--- a/tests/conversion/model-selection-to-view-converters.js
+++ b/tests/conversion/model-selection-to-view-converters.js
@@ -487,7 +487,7 @@ function test( selectionPaths, modelInput, expectedView, selectionAttributes = {
 	}
 
 	// Remove view children since we do not want to convert deletion.
-	viewRoot.removeChildren( 0, viewRoot.getChildCount() );
+	viewRoot.removeChildren( 0, viewRoot.childCount );
 
 	// Convert model to view.
 	dispatcher.convertInsert( ModelRange.createFromElement( modelRoot ) );

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -155,7 +155,7 @@ describe( 'setAttribute/removeAttribute', () => {
 		const modelDiv = new ModelElement( 'div', { theme: 'nice' } );
 
 		const themeConverter = ( value, key, data ) => {
-			if ( data.item instanceof ModelElement && data.item.getChildCount() > 0 ) {
+			if ( data.item instanceof ModelElement && data.item.childCount > 0 ) {
 				value += ' ' + 'fix-content';
 			}
 

--- a/tests/conversion/view-to-model-converters.js
+++ b/tests/conversion/view-to-model-converters.js
@@ -89,7 +89,7 @@ describe( 'convertToModelFragment', () => {
 		const result = dispatcher.convert( viewFragment, objWithContext );
 
 		expect( result ).to.be.instanceof( ModelDocumentFragment );
-		expect( result.getMaxOffset() ).to.equal( 6 );
+		expect( result.maxOffset ).to.equal( 6 );
 		expect( result.getChild( 0 ).data ).to.equal( 'foobar' );
 	} );
 
@@ -115,7 +115,7 @@ describe( 'convertToModelFragment', () => {
 
 		expect( result ).to.be.instanceof( ModelElement );
 		expect( result.name ).to.equal( 'paragraph' );
-		expect( result.getMaxOffset() ).to.equal( 3 );
+		expect( result.maxOffset ).to.equal( 3 );
 		expect( result.getChild( 0 ).data ).to.equal( 'foo' );
 	} );
 } );

--- a/tests/dataprocessor/htmldataprocessor.js
+++ b/tests/dataprocessor/htmldataprocessor.js
@@ -17,7 +17,7 @@ describe( 'HtmlDataProcessor', () => {
 		it( 'should return empty DocumentFragment when empty string is passed', () => {
 			const fragment = dataProcessor.toView( '' );
 			expect( fragment ).to.be.an.instanceOf( ViewDocumentFragment );
-			expect( fragment.getChildCount() ).to.equal( 0 );
+			expect( fragment.childCount ).to.equal( 0 );
 		} );
 
 		it( 'should convert HTML to DocumentFragment with single text node', () => {

--- a/tests/editingcontroller.js
+++ b/tests/editingcontroller.js
@@ -121,9 +121,9 @@ describe( 'EditingController', () => {
 			// Note: The below code is highly overcomplicated due to #455.
 
 			model.selection.removeAllRanges();
-			modelRoot.removeChildren( 0, modelRoot.getChildCount() );
+			modelRoot.removeChildren( 0, modelRoot.childCount );
 
-			viewRoot.removeChildren( 0, viewRoot.getChildCount() );
+			viewRoot.removeChildren( 0, viewRoot.childCount );
 
 			const modelData = new ModelDocumentFragment( parse(
 				'<paragraph>foo</paragraph>' +

--- a/tests/model/delta/insertdelta.js
+++ b/tests/model/delta/insertdelta.js
@@ -34,8 +34,8 @@ describe( 'Batch', () => {
 
 	describe( 'insert', () => {
 		it( 'should insert given nodes at given position', () => {
-			expect( root.getChildCount() ).to.equal( 4 );
-			expect( root.getMaxOffset() ).to.equal( 5 );
+			expect( root.childCount ).to.equal( 4 );
+			expect( root.maxOffset ).to.equal( 5 );
 			expect( root.getChild( 1 ) ).to.equal( p );
 			expect( root.getChild( 2 ) ).to.equal( ul );
 		} );

--- a/tests/model/delta/mergedelta.js
+++ b/tests/model/delta/mergedelta.js
@@ -37,9 +37,9 @@ describe( 'Batch', () => {
 		it( 'should merge foo and bar into foobar', () => {
 			doc.batch().merge( new Position( root, [ 1 ] ) );
 
-			expect( root.getMaxOffset() ).to.equal( 1 );
+			expect( root.maxOffset ).to.equal( 1 );
 			expect( root.getChild( 0 ).name ).to.equal( 'p' );
-			expect( root.getChild( 0 ).getMaxOffset() ).to.equal( 6 );
+			expect( root.getChild( 0 ).maxOffset ).to.equal( 6 );
 			expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 1 );
 			expect( root.getChild( 0 ).getAttribute( 'key1' ) ).to.equal( 'value1' );
 			expect( root.getChild( 0 ).getChild( 0 ).data ).to.equal( 'foobar' );

--- a/tests/model/delta/movedelta.js
+++ b/tests/model/delta/movedelta.js
@@ -38,7 +38,7 @@ describe( 'Batch', () => {
 		it( 'should move specified node', () => {
 			batch.move( div, new Position( root, [ 2 ] ) );
 
-			expect( root.getMaxOffset() ).to.equal( 2 );
+			expect( root.maxOffset ).to.equal( 2 );
 			expect( getNodesAndText( Range.createFromElement( root.getChild( 0 ) ) ) ).to.equal( 'abcxyz' );
 			expect( getNodesAndText( Range.createFromElement( root.getChild( 1 ) ) ) ).to.equal( 'PggggPfoobarPhhhhP' );
 		} );

--- a/tests/model/delta/removedelta.js
+++ b/tests/model/delta/removedelta.js
@@ -39,8 +39,8 @@ describe( 'Batch', () => {
 		it( 'should remove specified node', () => {
 			batch.remove( div );
 
-			expect( root.getMaxOffset() ).to.equal( 1 );
-			expect( root.getChildCount() ).to.equal( 1 );
+			expect( root.maxOffset ).to.equal( 1 );
+			expect( root.childCount ).to.equal( 1 );
 			expect( getNodesAndText( Range.createFromElement( root.getChild( 0 ) ) ) ).to.equal( 'abcxyz' );
 		} );
 

--- a/tests/model/delta/renamedelta.js
+++ b/tests/model/delta/renamedelta.js
@@ -29,7 +29,7 @@ describe( 'Batch', () => {
 
 	describe( 'rename', () => {
 		it( 'should rename given element', () => {
-			expect( root.getMaxOffset() ).to.equal( 1 );
+			expect( root.maxOffset ).to.equal( 1 );
 			expect( root.getChild( 0 ) ).to.have.property( 'name', 'h' );
 			expect( root.getChild( 0 ) ).to.have.property( 'name', 'h' );
 		} );
@@ -92,7 +92,7 @@ describe( 'RenameDelta', () => {
 				doc.applyOperation( operation );
 			} );
 
-			expect( root.getMaxOffset() ).to.equal( 1 );
+			expect( root.maxOffset ).to.equal( 1 );
 			expect( root.getChild( 0 ) ).to.have.property( 'name', 'p' );
 		} );
 	} );

--- a/tests/model/delta/splitdelta.js
+++ b/tests/model/delta/splitdelta.js
@@ -36,16 +36,16 @@ describe( 'Batch', () => {
 		it( 'should split foobar to foo and bar', () => {
 			doc.batch().split( new Position( root, [ 0, 3 ] ) );
 
-			expect( root.getMaxOffset() ).to.equal( 2 );
+			expect( root.maxOffset ).to.equal( 2 );
 
 			expect( root.getChild( 0 ).name ).to.equal( 'p' );
-			expect( root.getChild( 0 ).getMaxOffset() ).to.equal( 3 );
+			expect( root.getChild( 0 ).maxOffset ).to.equal( 3 );
 			expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 1 );
 			expect( root.getChild( 0 ).getAttribute( 'key' ) ).to.equal( 'value' );
 			expect( root.getChild( 0 ).getChild( 0 ).data ).to.equal( 'foo' );
 
 			expect( root.getChild( 1 ).name ).to.equal( 'p' );
-			expect( root.getChild( 1 ).getMaxOffset() ).to.equal( 3 );
+			expect( root.getChild( 1 ).maxOffset ).to.equal( 3 );
 			expect( count( root.getChild( 1 ).getAttributes() ) ).to.equal( 1 );
 			expect( root.getChild( 1 ).getAttribute( 'key' ) ).to.equal( 'value' );
 			expect( root.getChild( 1 ).getChild( 0 ).data ).to.equal( 'bar' );
@@ -54,16 +54,16 @@ describe( 'Batch', () => {
 		it( 'should create an empty paragraph if we split at the end', () => {
 			doc.batch().split( new Position( root, [ 0, 6 ] ) );
 
-			expect( root.getMaxOffset() ).to.equal( 2 );
+			expect( root.maxOffset ).to.equal( 2 );
 
 			expect( root.getChild( 0 ).name ).to.equal( 'p' );
-			expect( root.getChild( 0 ).getMaxOffset() ).to.equal( 6 );
+			expect( root.getChild( 0 ).maxOffset ).to.equal( 6 );
 			expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 1 );
 			expect( root.getChild( 0 ).getAttribute( 'key' ) ).to.equal( 'value' );
 			expect( root.getChild( 0 ).getChild( 0 ).data ).to.equal( 'foobar' );
 
 			expect( root.getChild( 1 ).name ).to.equal( 'p' );
-			expect( root.getChild( 1 ).getMaxOffset() ).to.equal( 0 );
+			expect( root.getChild( 1 ).maxOffset ).to.equal( 0 );
 			expect( count( root.getChild( 1 ).getAttributes() ) ).to.equal( 1 );
 			expect( root.getChild( 1 ).getAttribute( 'key' ) ).to.equal( 'value' );
 		} );

--- a/tests/model/delta/unwrapdelta.js
+++ b/tests/model/delta/unwrapdelta.js
@@ -33,7 +33,7 @@ describe( 'Batch', () => {
 		it( 'should unwrap given element', () => {
 			doc.batch().unwrap( p );
 
-			expect( root.getMaxOffset() ).to.equal( 5 );
+			expect( root.maxOffset ).to.equal( 5 );
 			expect( root.getChild( 0 ).data ).to.equal( 'axyzb' );
 		} );
 

--- a/tests/model/delta/weakinsertdelta.js
+++ b/tests/model/delta/weakinsertdelta.js
@@ -30,7 +30,7 @@ describe( 'Batch', () => {
 
 	describe( 'weakInsert', () => {
 		it( 'should insert given nodes at given position', () => {
-			expect( root.getMaxOffset() ).to.equal( 6 );
+			expect( root.maxOffset ).to.equal( 6 );
 			expect( root.getChild( 0 ).data ).to.equal( 'ab' );
 			expect( root.getChild( 1 ).data ).to.equal( 'xyz' );
 			expect( root.getChild( 2 ).data ).to.equal( 'c' );

--- a/tests/model/delta/wrapdelta.js
+++ b/tests/model/delta/wrapdelta.js
@@ -36,7 +36,7 @@ describe( 'Batch', () => {
 			let p = new Element( 'p' );
 			doc.batch().wrap( range, p );
 
-			expect( root.getMaxOffset() ).to.equal( 5 );
+			expect( root.maxOffset ).to.equal( 5 );
 			expect( root.getChild( 0 ).data ).to.equal( 'fo' );
 			expect( root.getChild( 1 ) ).to.equal( p );
 			expect( p.getChild( 0 ).data ).to.equal( 'ob' );
@@ -46,7 +46,7 @@ describe( 'Batch', () => {
 		it( 'should wrap flat range with an element of given name', () => {
 			doc.batch().wrap( range, 'p' );
 
-			expect( root.getMaxOffset() ).to.equal( 5 );
+			expect( root.maxOffset ).to.equal( 5 );
 			expect( root.getChild( 0 ).data ).to.equal( 'fo' );
 			expect( root.getChild( 1 ).name ).to.equal( 'p' );
 			expect( root.getChild( 1 ).getChild( 0 ).data ).to.equal( 'ob' );

--- a/tests/model/document/document.js
+++ b/tests/model/document/document.js
@@ -27,7 +27,7 @@ describe( 'Document', () => {
 			expect( doc ).to.have.property( '_roots' ).that.is.instanceof( Map );
 			expect( doc._roots.size ).to.equal( 1 );
 			expect( doc.graveyard ).to.be.instanceof( RootElement );
-			expect( doc.graveyard.getMaxOffset() ).to.equal( 0 );
+			expect( doc.graveyard.maxOffset ).to.equal( 0 );
 			expect( count( doc.selection.getRanges() ) ).to.equal( 1 );
 
 			expect( doc.composer ).to.be.instanceof( Composer );
@@ -35,16 +35,16 @@ describe( 'Document', () => {
 		} );
 	} );
 
-	describe( 'rootNames', () => {
+	describe( 'getRootNames()', () => {
 		it( 'should return empty iterator if no roots exist', () => {
-			expect( count( doc.rootNames ) ).to.equal( 0 );
+			expect( count( doc.getRootNames() ) ).to.equal( 0 );
 		} );
 
 		it( 'should return an iterator of all roots without the graveyard', () => {
 			doc.createRoot( '$root', 'a' );
 			doc.createRoot( '$root', 'b' );
 
-			expect( Array.from( doc.rootNames ) ).to.deep.equal( [ 'a', 'b' ] );
+			expect( Array.from( doc.getRootNames() ) ).to.deep.equal( [ 'a', 'b' ] );
 		} );
 	} );
 
@@ -54,7 +54,7 @@ describe( 'Document', () => {
 
 			expect( doc._roots.size ).to.equal( 2 );
 			expect( root ).to.be.instanceof( RootElement );
-			expect( root.getMaxOffset() ).to.equal( 0 );
+			expect( root.maxOffset ).to.equal( 0 );
 			expect( root ).to.have.property( 'name', '$root' );
 			expect( root ).to.have.property( 'rootName', 'main' );
 		} );
@@ -64,7 +64,7 @@ describe( 'Document', () => {
 
 			expect( doc._roots.size ).to.equal( 2 );
 			expect( root ).to.be.instanceof( RootElement );
-			expect( root.getMaxOffset() ).to.equal( 0 );
+			expect( root.maxOffset ).to.equal( 0 );
 			expect( root ).to.have.property( 'name', 'customElementName' );
 			expect( root ).to.have.property( 'rootName', 'customRootName' );
 		} );

--- a/tests/model/documentfragment.js
+++ b/tests/model/documentfragment.js
@@ -16,15 +16,15 @@ describe( 'DocumentFragment', () => {
 		it( 'should create empty document fragment', () => {
 			let frag = new DocumentFragment();
 
-			expect( frag.getChildCount() ).to.equal( 0 );
-			expect( frag.getMaxOffset() ).to.equal( 0 );
+			expect( frag.childCount ).to.equal( 0 );
+			expect( frag.maxOffset ).to.equal( 0 );
 		} );
 
 		it( 'should create document fragment with children', () => {
 			let frag = new DocumentFragment( [ new Text( 'xx' ), new Element( 'p' ), new Text( 'yy' ) ] );
 
-			expect( frag.getChildCount() ).to.equal( 3 );
-			expect( frag.getMaxOffset() ).to.equal( 5 );
+			expect( frag.childCount ).to.equal( 3 );
+			expect( frag.maxOffset ).to.equal( 5 );
 
 			expect( frag.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'xx' );
 			expect( frag.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'p' );
@@ -61,13 +61,13 @@ describe( 'DocumentFragment', () => {
 		it( 'should return true if document fragment has no children', () => {
 			let frag = new DocumentFragment();
 
-			expect( frag.isEmpty() ).to.be.true;
+			expect( frag.isEmpty ).to.be.true;
 		} );
 
 		it( 'should return false if document fragment has children', () => {
 			let frag = new DocumentFragment( new Text( 'a' ) );
 
-			expect( frag.isEmpty() ).to.be.false;
+			expect( frag.isEmpty ).to.be.false;
 		} );
 	} );
 
@@ -96,7 +96,7 @@ describe( 'DocumentFragment', () => {
 			} ).to.throw( CKEditorError, /nodelist-offset-out-of-bounds/ );
 		} );
 
-		it( 'should return length if given offset is equal to getMaxOffset()', () => {
+		it( 'should return length if given offset is equal to maxOffset', () => {
 			expect( frag.offsetToIndex( 5 ) ).to.equal( 3 );
 		} );
 	} );
@@ -106,18 +106,25 @@ describe( 'DocumentFragment', () => {
 			let frag = new DocumentFragment( new Text( 'xy' ) );
 			frag.insertChildren( 1, new Text( 'foo' ) );
 
-			expect( frag.getChildCount() ).to.equal( 2 );
-			expect( frag.getMaxOffset() ).to.equal( 5 );
+			expect( frag.childCount ).to.equal( 2 );
+			expect( frag.maxOffset ).to.equal( 5 );
 			expect( frag.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'xy' );
 			expect( frag.getChild( 1 ) ).to.have.property( 'data' ).that.equals( 'foo' );
 		} );
 
 		it( 'should accept strings and arrays', () => {
 			let frag = new DocumentFragment();
+
+			frag.insertChildren( 0, 'abc' );
+			expect( frag.childCount ).to.equal( 1 );
+			expect( frag.maxOffset ).to.equal( 3 );
+			expect( frag.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'abc' );
+
+			frag.removeChildren( 0, 1 );
 			frag.insertChildren( 0, [ new Element( 'p' ), 'abc' ] );
 
-			expect( frag.getChildCount() ).to.equal( 2 );
-			expect( frag.getMaxOffset() ).to.equal( 4 );
+			expect( frag.childCount ).to.equal( 2 );
+			expect( frag.maxOffset ).to.equal( 4 );
 			expect( frag.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'p' );
 			expect( frag.getChild( 1 ) ).to.have.property( 'data' ).that.equals( 'abc' );
 		} );
@@ -128,8 +135,8 @@ describe( 'DocumentFragment', () => {
 			let frag = new DocumentFragment( new Text( 'xy' ) );
 			frag.appendChildren( new Text( 'foo' ) );
 
-			expect( frag.getChildCount() ).to.equal( 2 );
-			expect( frag.getMaxOffset() ).to.equal( 5 );
+			expect( frag.childCount ).to.equal( 2 );
+			expect( frag.maxOffset ).to.equal( 5 );
 			expect( frag.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'xy' );
 			expect( frag.getChild( 1 ) ).to.have.property( 'data' ).that.equals( 'foo' );
 		} );
@@ -140,8 +147,8 @@ describe( 'DocumentFragment', () => {
 			let frag = new DocumentFragment( [ new Text( 'foobar' ), new Element( 'image' ) ] );
 			let removed = frag.removeChildren( 1, 1 );
 
-			expect( frag.getChildCount() ).to.equal( 1 );
-			expect( frag.getMaxOffset() ).to.equal( 6 );
+			expect( frag.childCount ).to.equal( 1 );
+			expect( frag.maxOffset ).to.equal( 6 );
 
 			expect( frag.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'foobar' );
 
@@ -153,8 +160,8 @@ describe( 'DocumentFragment', () => {
 			let frag = new DocumentFragment( [ new Text( 'foo' ), new Element( 'image' ) ] );
 			let removed = frag.removeChildren( 0 );
 
-			expect( frag.getChildCount() ).to.equal( 1 );
-			expect( frag.getMaxOffset() ).to.equal( 1 );
+			expect( frag.childCount ).to.equal( 1 );
+			expect( frag.maxOffset ).to.equal( 1 );
 			expect( frag.getChild( 0 ).name ).to.equal( 'image' );
 
 			expect( removed.length ).to.equal( 1 );
@@ -201,7 +208,7 @@ describe( 'DocumentFragment', () => {
 		it( 'should return number of children nodes', () => {
 			let frag = new DocumentFragment( new Text( 'bar' ) );
 
-			expect( frag.getChildCount() ).to.equal( 1 );
+			expect( frag.childCount ).to.equal( 1 );
 		} );
 	} );
 
@@ -209,7 +216,7 @@ describe( 'DocumentFragment', () => {
 		it( 'should return offset after the last children', () => {
 			let frag = new DocumentFragment( new Text( 'bar' ) );
 
-			expect( frag.getMaxOffset() ).to.equal( 3 );
+			expect( frag.maxOffset ).to.equal( 3 );
 		} );
 	} );
 
@@ -250,7 +257,7 @@ describe( 'DocumentFragment', () => {
 			let serialized = jsonParseStringify( frag );
 			let deserialized = DocumentFragment.fromJSON( serialized );
 
-			expect( deserialized.isEmpty() ).to.be.true;
+			expect( deserialized.isEmpty ).to.be.true;
 		} );
 
 		it( 'should create element with children', () => {
@@ -261,7 +268,7 @@ describe( 'DocumentFragment', () => {
 			let serialized = jsonParseStringify( frag );
 			let deserialized = DocumentFragment.fromJSON( serialized );
 
-			expect( deserialized.getChildCount() ).to.equal( 2 );
+			expect( deserialized.childCount ).to.equal( 2 );
 
 			expect( deserialized.getChild( 0 ).name ).to.equal( 'p' );
 			expect( deserialized.getChild( 0 ).parent ).to.equal( deserialized );

--- a/tests/model/element.js
+++ b/tests/model/element.js
@@ -34,8 +34,8 @@ describe( 'Element', () => {
 		it( 'should create element with children', () => {
 			let element = new Element( 'elem', [], new Text( 'foo' ) );
 
-			expect( element.getChildCount() ).to.equal( 1 );
-			expect( element.getMaxOffset() ).to.equal( 3 );
+			expect( element.childCount ).to.equal( 1 );
+			expect( element.maxOffset ).to.equal( 3 );
 			expect( element.getChild( 0 ).data ).to.equal( 'foo' );
 		} );
 	} );
@@ -62,7 +62,7 @@ describe( 'Element', () => {
 
 			expect( copy.name ).to.equal( 'elem' );
 			expect( Array.from( copy.getAttributes() ) ).to.deep.equal( [ [ 'bold', true ], [ 'italic', true ] ] );
-			expect( copy.getChildCount() ).to.equal( 2 );
+			expect( copy.childCount ).to.equal( 2 );
 
 			expect( copy.getChild( 0 ) ).not.to.equal( p );
 			expect( copy.getChild( 1 ) ).not.to.equal( foo );
@@ -77,18 +77,18 @@ describe( 'Element', () => {
 			let element = new Element( 'elem', [], new Text( 'xy' ) );
 			element.insertChildren( 1, new Text( 'foo' ) );
 
-			expect( element.getChildCount() ).to.equal( 2 );
-			expect( element.getMaxOffset() ).to.equal( 5 );
+			expect( element.childCount ).to.equal( 2 );
+			expect( element.maxOffset ).to.equal( 5 );
 			expect( element.getChild( 0 ).data ).to.equal( 'xy' );
 			expect( element.getChild( 1 ).data ).to.equal( 'foo' );
 		} );
 
-		it( 'should add children to the element', () => {
+		it( 'should accept arrays and strings', () => {
 			let element = new Element( 'elem' );
-			element.insertChildren( 0, [ new Element( 'image' ), new Text( 'xy' ), new Element( 'list' ) ] );
+			element.insertChildren( 0, [ new Element( 'image' ), 'xy', new Element( 'list' ) ] );
 
-			expect( element.getChildCount() ).to.equal( 3 );
-			expect( element.getMaxOffset() ).to.equal( 4 );
+			expect( element.childCount ).to.equal( 3 );
+			expect( element.maxOffset ).to.equal( 4 );
 			expect( element.getChild( 0 ).name ).to.equal( 'image' );
 			expect( element.getChild( 1 ).data ).to.equal( 'xy' );
 			expect( element.getChild( 2 ).name ).to.equal( 'list' );
@@ -96,12 +96,11 @@ describe( 'Element', () => {
 
 		it( 'should accept strings', () => {
 			let element = new Element( 'div' );
-			element.insertChildren( 0, [ new Element( 'p' ), 'abc' ] );
+			element.insertChildren( 0, 'abc' );
 
-			expect( element.getChildCount() ).to.equal( 2 );
-			expect( element.getMaxOffset() ).to.equal( 4 );
-			expect( element.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'p' );
-			expect( element.getChild( 1 ) ).to.have.property( 'data' ).that.equals( 'abc' );
+			expect( element.childCount ).to.equal( 1 );
+			expect( element.maxOffset ).to.equal( 3 );
+			expect( element.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'abc' );
 		} );
 	} );
 
@@ -123,8 +122,8 @@ describe( 'Element', () => {
 			let element = new Element( 'elem', [], [ new Text( 'foobar' ), new Element( 'image' ) ] );
 			let removed = element.removeChildren( 1, 1 );
 
-			expect( element.getChildCount() ).to.equal( 1 );
-			expect( element.getMaxOffset() ).to.equal( 6 );
+			expect( element.childCount ).to.equal( 1 );
+			expect( element.maxOffset ).to.equal( 6 );
 
 			expect( element.getChild( 0 ).data ).to.equal( 'foobar' );
 
@@ -136,8 +135,8 @@ describe( 'Element', () => {
 			let element = new Element( 'element', [], [ new Text( 'foo' ), new Element( 'image' ) ] );
 			let removed = element.removeChildren( 0 );
 
-			expect( element.getChildCount() ).to.equal( 1 );
-			expect( element.getMaxOffset() ).to.equal( 1 );
+			expect( element.childCount ).to.equal( 1 );
+			expect( element.maxOffset ).to.equal( 1 );
 			expect( element.getChild( 0 ).name ).to.equal( 'image' );
 
 			expect( removed.length ).to.equal( 1 );
@@ -175,7 +174,7 @@ describe( 'Element', () => {
 		it( 'should return number of children', () => {
 			let element = new Element( 'elem', [], new Text( 'bar' ) );
 
-			expect( element.getChildCount() ).to.equal( 1 );
+			expect( element.childCount ).to.equal( 1 );
 		} );
 	} );
 
@@ -183,14 +182,14 @@ describe( 'Element', () => {
 		it( 'should return offset number after the last child', () => {
 			let element = new Element( 'elem', [], [ new Element( 'p' ), new Text( 'bar' ), new Element( 'h' ) ] );
 
-			expect( element.getMaxOffset() ).to.equal( 5 );
+			expect( element.maxOffset ).to.equal( 5 );
 		} );
 	} );
 
 	describe( 'isEmpty', () => {
 		it( 'checks whether element has no children', () => {
-			expect( new Element( 'a' ).isEmpty() ).to.be.true;
-			expect( new Element( 'a', null, new Text( 'x' ) ).isEmpty() ).to.be.false;
+			expect( new Element( 'a' ).isEmpty ).to.be.true;
+			expect( new Element( 'a', null, new Text( 'x' ) ).isEmpty ).to.be.false;
 		} );
 	} );
 
@@ -219,7 +218,7 @@ describe( 'Element', () => {
 			} ).to.throw( CKEditorError, /nodelist-offset-out-of-bounds/ );
 		} );
 
-		it( 'should return length if given offset is equal to getMaxOffset()', () => {
+		it( 'should return length if given offset is equal to maxOffset', () => {
 			expect( element.offsetToIndex( 5 ) ).to.equal( 3 );
 		} );
 	} );
@@ -276,7 +275,7 @@ describe( 'Element', () => {
 
 			expect( deserialized.parent ).to.be.null;
 			expect( deserialized.name ).to.equal( 'el' );
-			expect( deserialized.getChildCount() ).to.equal( 0 );
+			expect( deserialized.childCount ).to.equal( 0 );
 		} );
 
 		it( 'should create element with attributes', () => {
@@ -288,7 +287,7 @@ describe( 'Element', () => {
 
 			expect( deserialized.parent ).to.be.null;
 			expect( deserialized.name ).to.equal( 'el' );
-			expect( deserialized.getChildCount() ).to.equal( 0 );
+			expect( deserialized.childCount ).to.equal( 0 );
 			expect( deserialized.hasAttribute( 'foo' ) ).to.be.true;
 			expect( deserialized.getAttribute( 'foo' ) ).to.be.true;
 		} );
@@ -304,7 +303,7 @@ describe( 'Element', () => {
 
 			expect( deserialized.parent ).to.be.null;
 			expect( deserialized.name ).to.equal( 'el' );
-			expect( deserialized.getChildCount() ).to.equal( 2 );
+			expect( deserialized.childCount ).to.equal( 2 );
 
 			expect( deserialized.getChild( 0 ).name ).to.equal( 'p' );
 			expect( deserialized.getChild( 0 ).parent ).to.equal( deserialized );

--- a/tests/model/node.js
+++ b/tests/model/node.js
@@ -112,17 +112,17 @@ describe( 'Node', () => {
 
 	describe( 'getIndex', () => {
 		it( 'should return null if the parent is null', () => {
-			expect( root.getIndex() ).to.be.null;
+			expect( root.index ).to.be.null;
 		} );
 
 		it( 'should return index in the parent', () => {
-			expect( one.getIndex() ).to.equal( 0 );
-			expect( two.getIndex() ).to.equal( 1 );
-			expect( three.getIndex() ).to.equal( 2 );
+			expect( one.index ).to.equal( 0 );
+			expect( two.index ).to.equal( 1 );
+			expect( three.index ).to.equal( 2 );
 
-			expect( textBA.getIndex() ).to.equal( 0 );
-			expect( img.getIndex() ).to.equal( 1 );
-			expect( textR.getIndex() ).to.equal( 2 );
+			expect( textBA.index ).to.equal( 0 );
+			expect( img.index ).to.equal( 1 );
+			expect( textR.index ).to.equal( 2 );
 		} );
 
 		it( 'should throw an error if parent does not contain element', () => {
@@ -130,7 +130,7 @@ describe( 'Node', () => {
 
 			expect(
 				() => {
-					node.getIndex();
+					node.index;
 				}
 			).to.throw( CKEditorError, /node-not-found-in-parent/ );
 		} );
@@ -153,7 +153,7 @@ describe( 'Node', () => {
 
 			node.remove();
 
-			expect( element.getChildCount() ).to.equal( 0 );
+			expect( element.childCount ).to.equal( 0 );
 			expect( node.parent ).to.be.null;
 		} );
 

--- a/tests/model/nodelist.js
+++ b/tests/model/nodelist.js
@@ -42,7 +42,7 @@ describe( 'NodeList', () => {
 
 	describe( 'getMaxOffset', () => {
 		it( 'should be equal to the sum of offsetSize of all nodes in node list', () => {
-			expect( nodes.getMaxOffset() ).to.equal( 5 );
+			expect( nodes.maxOffset ).to.equal( 5 );
 		} );
 	} );
 
@@ -94,7 +94,7 @@ describe( 'NodeList', () => {
 			} ).to.throw( CKEditorError, /nodelist-index-out-of-bounds/ );
 		} );
 
-		it( 'should return length if given offset is equal to getMaxOffset()', () => {
+		it( 'should return length if given offset is equal to maxOffset', () => {
 			expect( nodes.indexToOffset( 3 ) ).to.equal( 5 );
 		} );
 	} );
@@ -118,7 +118,7 @@ describe( 'NodeList', () => {
 			} ).to.throw( CKEditorError, /nodelist-offset-out-of-bounds/ );
 		} );
 
-		it( 'should return length if given offset is equal to getMaxOffset()', () => {
+		it( 'should return length if given offset is equal to maxOffset', () => {
 			expect( nodes.offsetToIndex( 5 ) ).to.equal( 3 );
 		} );
 	} );
@@ -133,7 +133,7 @@ describe( 'NodeList', () => {
 			nodes.insertNodes( 4, [ bar, xyz ] );
 
 			expect( nodes.length ).to.equal( 6 );
-			expect( nodes.getMaxOffset() ).to.equal( 12 );
+			expect( nodes.maxOffset ).to.equal( 12 );
 
 			expect( Array.from( nodes ) ).to.deep.equal( [ p, newImg, foo, img, bar, xyz ] );
 
@@ -171,7 +171,7 @@ describe( 'NodeList', () => {
 			nodes.removeNodes( 0, 2 );
 
 			expect( nodes.length ).to.equal( 1 );
-			expect( nodes.getMaxOffset() ).to.equal( 1 );
+			expect( nodes.maxOffset ).to.equal( 1 );
 
 			expect( nodes.getNode( 0 ) ).to.equal( img );
 			expect( nodes.getNodeIndex( img ) ).to.equal( 0 );
@@ -182,7 +182,7 @@ describe( 'NodeList', () => {
 			nodes.removeNodes( 1 );
 
 			expect( nodes.length ).to.equal( 2 );
-			expect( nodes.getMaxOffset() ).to.equal( 2 );
+			expect( nodes.maxOffset ).to.equal( 2 );
 
 			expect( nodes.getNode( 0 ) ).to.equal( p );
 			expect( nodes.getNode( 1 ) ).to.equal( img );

--- a/tests/model/operation/attributeoperation.js
+++ b/tests/model/operation/attributeoperation.js
@@ -75,7 +75,7 @@ describe( 'AttributeOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 3 );
+		expect( root.maxOffset ).to.equal( 3 );
 		expect( root.getChild( 0 ).hasAttribute( 'isNew' ) ).to.be.true;
 		expect( root.getChild( 0 ).data ).to.equal( 'ba' );
 		expect( root.getChild( 1 ).hasAttribute( 'isNew' ) ).to.be.false;
@@ -96,7 +96,7 @@ describe( 'AttributeOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 1 );
+		expect( root.maxOffset ).to.equal( 1 );
 		expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 3 );
 		expect( root.getChild( 0 ).hasAttribute( 'isNew' ) ).to.be.true;
 		expect( root.getChild( 0 ).hasAttribute( 'foo' ) ).to.be.true;
@@ -117,7 +117,7 @@ describe( 'AttributeOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 3 );
+		expect( root.maxOffset ).to.equal( 3 );
 		expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 1 );
 		expect( root.getChild( 0 ).getAttribute( 'isNew' ) ).to.be.true;
 		expect( count( root.getChild( 1 ).getAttributes() ) ).to.equal( 1 );
@@ -138,7 +138,7 @@ describe( 'AttributeOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 1 );
+		expect( root.maxOffset ).to.equal( 1 );
 		expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 3 );
 		expect( root.getChild( 0 ).getAttribute( 'foo' ) ).to.be.true;
 		expect( root.getChild( 0 ).getAttribute( 'x' ) ).to.equal( 2 );
@@ -159,7 +159,7 @@ describe( 'AttributeOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 1 );
+		expect( root.maxOffset ).to.equal( 1 );
 		expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 2 );
 		expect( root.getChild( 0 ).hasAttribute( 'foo' ) ).to.be.true;
 		expect( root.getChild( 0 ).hasAttribute( 'bar' ) ).to.be.true;
@@ -195,7 +195,7 @@ describe( 'AttributeOperation', () => {
 		doc.applyOperation( wrapInDelta( reverse ) );
 
 		expect( doc.version ).to.equal( 2 );
-		expect( root.getMaxOffset() ).to.equal( 3 );
+		expect( root.maxOffset ).to.equal( 3 );
 		expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 0 );
 	} );
 
@@ -256,7 +256,7 @@ describe( 'AttributeOperation', () => {
 		doc.applyOperation( wrapInDelta( reverse ) );
 
 		expect( doc.version ).to.equal( 2 );
-		expect( root.getMaxOffset() ).to.equal( 3 );
+		expect( root.maxOffset ).to.equal( 3 );
 		expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 1 );
 		expect( root.getChild( 0 ).getAttribute( 'isNew' ) ).to.be.false;
 	} );
@@ -278,7 +278,7 @@ describe( 'AttributeOperation', () => {
 		doc.applyOperation( wrapInDelta( reverse ) );
 
 		expect( doc.version ).to.equal( 2 );
-		expect( root.getMaxOffset() ).to.equal( 3 );
+		expect( root.maxOffset ).to.equal( 3 );
 		expect( count( root.getChild( 0 ).getAttributes() ) ).to.equal( 1 );
 		expect( root.getChild( 0 ).getAttribute( 'foo' ) ).to.be.true;
 	} );

--- a/tests/model/operation/insertoperation.js
+++ b/tests/model/operation/insertoperation.js
@@ -42,7 +42,7 @@ describe( 'InsertOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 1 );
+		expect( root.maxOffset ).to.equal( 1 );
 		expect( root.getChild( 0 ).data ).to.equal( 'x' );
 	} );
 
@@ -56,7 +56,7 @@ describe( 'InsertOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 1 );
+		expect( root.maxOffset ).to.equal( 1 );
 		expect( root.getChild( 0 ).name ).to.equal( 'p' );
 	} );
 
@@ -70,8 +70,8 @@ describe( 'InsertOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 7 );
-		expect( root.getChildCount() ).to.equal( 3 );
+		expect( root.maxOffset ).to.equal( 7 );
+		expect( root.childCount ).to.equal( 3 );
 		expect( root.getChild( 0 ).data ).to.equal( 'bar' );
 		expect( root.getChild( 1 ).name ).to.equal( 'p' );
 		expect( root.getChild( 2 ).data ).to.equal( 'foo' );
@@ -89,7 +89,7 @@ describe( 'InsertOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 5 );
+		expect( root.maxOffset ).to.equal( 5 );
 		expect( root.getChild( 0 ).data ).to.equal( 'xbary' );
 	} );
 
@@ -103,7 +103,7 @@ describe( 'InsertOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 7 );
+		expect( root.maxOffset ).to.equal( 7 );
 		expect( root.getChild( 0 ).data ).to.equal( 'fooxbar' );
 	} );
 
@@ -139,7 +139,7 @@ describe( 'InsertOperation', () => {
 		doc.applyOperation( wrapInDelta( reverse ) );
 
 		expect( doc.version ).to.equal( 2 );
-		expect( root.getMaxOffset() ).to.equal( 0 );
+		expect( root.maxOffset ).to.equal( 0 );
 	} );
 
 	it( 'should undo insert set of nodes by applying reverse operation', () => {
@@ -158,7 +158,7 @@ describe( 'InsertOperation', () => {
 		doc.applyOperation( wrapInDelta( reverse ) );
 
 		expect( doc.version ).to.equal( 2 );
-		expect( root.getMaxOffset() ).to.equal( 0 );
+		expect( root.maxOffset ).to.equal( 0 );
 	} );
 
 	it( 'should create operation with the same parameters when cloned', () => {
@@ -197,8 +197,8 @@ describe( 'InsertOperation', () => {
 		expect( op.nodes.getNode( 0 ).name ).to.equal( 'p' );
 		expect( Array.from( op.nodes.getNode( 0 ).getAttributes() ) ).to.deep.equal( [ [ 'key', 'value' ] ] );
 
-		expect( op.nodes.getNode( 0 ).getChildCount() ).to.equal( 0 );
-		expect( element.getChildCount() ).to.equal( 1 );
+		expect( op.nodes.getNode( 0 ).childCount ).to.equal( 0 );
+		expect( element.childCount ).to.equal( 1 );
 
 		expect( op2.nodes.getNode( 0 ) ).not.to.equal( text );
 	} );

--- a/tests/model/operation/moveoperation.js
+++ b/tests/model/operation/moveoperation.js
@@ -59,11 +59,11 @@ describe( 'MoveOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 2 );
+		expect( root.maxOffset ).to.equal( 2 );
 		expect( root.getChild( 0 ).name ).to.equal( 'p1' );
 		expect( root.getChild( 1 ).name ).to.equal( 'p2' );
-		expect( p1.getMaxOffset() ).to.equal( 0 );
-		expect( p2.getMaxOffset() ).to.equal( 1 );
+		expect( p1.maxOffset ).to.equal( 0 );
+		expect( p2.maxOffset ).to.equal( 1 );
 		expect( p2.getChild( 0 ).name ).to.equal( 'x' );
 	} );
 
@@ -80,7 +80,7 @@ describe( 'MoveOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 5 );
+		expect( root.maxOffset ).to.equal( 5 );
 		expect( root.getChild( 0 ).data ).to.equal( 'xarbx' );
 	} );
 
@@ -97,7 +97,7 @@ describe( 'MoveOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 5 );
+		expect( root.maxOffset ).to.equal( 5 );
 		expect( root.getChild( 0 ).data ).to.equal( 'xrbax' );
 	} );
 
@@ -137,18 +137,18 @@ describe( 'MoveOperation', () => {
 		doc.applyOperation( wrapInDelta( operation ) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 2 );
-		expect( p1.getMaxOffset() ).to.equal( 0 );
-		expect( p2.getMaxOffset() ).to.equal( 1 );
+		expect( root.maxOffset ).to.equal( 2 );
+		expect( p1.maxOffset ).to.equal( 0 );
+		expect( p2.maxOffset ).to.equal( 1 );
 		expect( p2.getChild( 0 ).name ).to.equal( 'x' );
 
 		doc.applyOperation( wrapInDelta( operation.getReversed() ) );
 
 		expect( doc.version ).to.equal( 2 );
-		expect( root.getMaxOffset() ).to.equal( 2 );
-		expect( p1.getMaxOffset() ).to.equal( 1 );
+		expect( root.maxOffset ).to.equal( 2 );
+		expect( p1.maxOffset ).to.equal( 1 );
 		expect( p1.getChild( 0 ).name ).to.equal( 'x' );
-		expect( p2.getMaxOffset() ).to.equal( 0 );
+		expect( p2.maxOffset ).to.equal( 0 );
 	} );
 
 	it( 'should throw an error if number of nodes to move exceeds the number of existing nodes in given element', () => {
@@ -225,8 +225,8 @@ describe( 'MoveOperation', () => {
 			}
 		).not.to.throw();
 
-		expect( root.getMaxOffset() ).to.equal( 4 );
-		expect( p.getMaxOffset() ).to.equal( 1 );
+		expect( root.maxOffset ).to.equal( 4 );
+		expect( p.maxOffset ).to.equal( 1 );
 		expect( p.getChild( 0 ).data ).to.equal( 'b' );
 	} );
 

--- a/tests/model/operation/reinsertoperation.js
+++ b/tests/model/operation/reinsertoperation.js
@@ -83,13 +83,13 @@ describe( 'ReinsertOperation', () => {
 		doc.applyOperation( wrapInDelta( operation ) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 2 );
-		expect( element.getMaxOffset() ).to.equal( 0 );
+		expect( root.maxOffset ).to.equal( 2 );
+		expect( element.maxOffset ).to.equal( 0 );
 
 		doc.applyOperation( wrapInDelta( reverse ) );
 
 		expect( doc.version ).to.equal( 2 );
-		expect( root.getMaxOffset() ).to.equal( 0 );
+		expect( root.maxOffset ).to.equal( 0 );
 		// Don't check `element` - nodes are moved to new holder element.
 	} );
 

--- a/tests/model/operation/removeoperation.js
+++ b/tests/model/operation/removeoperation.js
@@ -65,10 +65,10 @@ describe( 'RemoveOperation', () => {
 		) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 4 );
+		expect( root.maxOffset ).to.equal( 4 );
 		expect( root.getChild( 0 ).data ).to.equal( 'foar' );
 
-		expect( graveyard.getMaxOffset() ).to.equal( 1 );
+		expect( graveyard.maxOffset ).to.equal( 1 );
 		expect( graveyard.getChild( 0 ).getChild( 0 ).data ).to.equal( 'zb' );
 	} );
 
@@ -99,7 +99,7 @@ describe( 'RemoveOperation', () => {
 			)
 		) );
 
-		expect( graveyard.getMaxOffset() ).to.equal( 3 );
+		expect( graveyard.maxOffset ).to.equal( 3 );
 		expect( graveyard.getChild( 0 ).getChild( 0 ).data ).to.equal( 'f' );
 		expect( graveyard.getChild( 1 ).getChild( 0 ).data ).to.equal( 'o' );
 		expect( graveyard.getChild( 2 ).getChild( 0 ).data ).to.equal( 'z' );
@@ -128,7 +128,7 @@ describe( 'RemoveOperation', () => {
 		doc.applyOperation( removeOpA );
 		doc.applyOperation( removeOpB );
 
-		expect( graveyard.getChildCount() ).to.equal( 1 );
+		expect( graveyard.childCount ).to.equal( 1 );
 		expect( graveyard.getChild( 0 ).getChild( 0 ).data ).to.equal( 'fo' );
 	} );
 
@@ -166,12 +166,12 @@ describe( 'RemoveOperation', () => {
 		doc.applyOperation( wrapInDelta( operation ) );
 
 		expect( doc.version ).to.equal( 1 );
-		expect( root.getMaxOffset() ).to.equal( 0 );
+		expect( root.maxOffset ).to.equal( 0 );
 
 		doc.applyOperation( wrapInDelta( reverse ) );
 
 		expect( doc.version ).to.equal( 2 );
-		expect( root.getMaxOffset() ).to.equal( 3 );
+		expect( root.maxOffset ).to.equal( 3 );
 		expect( root.getChild( 0 ).data ).to.equal( 'bar' );
 	} );
 

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -491,15 +491,15 @@ describe( 'position', () => {
 
 	describe( 'isAtStart', () => {
 		it( 'should return true if position is at the beginning of its parent', () => {
-			expect( new Position( root, [ 0 ] ).isAtStart() ).to.be.true;
-			expect( new Position( root, [ 1 ] ).isAtStart() ).to.be.false;
+			expect( new Position( root, [ 0 ] ).isAtStart ).to.be.true;
+			expect( new Position( root, [ 1 ] ).isAtStart ).to.be.false;
 		} );
 	} );
 
 	describe( 'isAtEnd', () => {
 		it( 'should return true if position is at the end of its parent', () => {
-			expect( new Position( root, [ root.getMaxOffset() ] ).isAtEnd() ).to.be.true;
-			expect( new Position( root, [ 0 ] ).isAtEnd() ).to.be.false;
+			expect( new Position( root, [ root.maxOffset ] ).isAtEnd ).to.be.true;
+			expect( new Position( root, [ 0 ] ).isAtEnd ).to.be.false;
 		} );
 	} );
 

--- a/tests/model/rootelement.js
+++ b/tests/model/rootelement.js
@@ -19,7 +19,7 @@ describe( 'Element', () => {
 			expect( root ).to.be.an.instanceof( Element );
 			expect( root ).to.have.property( 'document' ).that.equals( doc );
 			expect( count( root.getAttributes() ) ).to.equal( 0 );
-			expect( root.getChildCount() ).to.equal( 0 );
+			expect( root.childCount ).to.equal( 0 );
 		} );
 	} );
 } );

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -221,7 +221,7 @@ describe( 'Selection', () => {
 
 			const focus = selection.focus;
 			expect( focus ).to.have.property( 'parent', root );
-			expect( focus ).to.have.property( 'offset', root.getMaxOffset() );
+			expect( focus ).to.have.property( 'offset', root.maxOffset );
 		} );
 
 		it( 'sets selection before the specified element', () => {

--- a/tests/model/treewalker.js
+++ b/tests/model/treewalker.js
@@ -601,9 +601,9 @@ function expectEnd( value, expected, options = {} ) {
 
 	if ( options.direction == 'backward' ) {
 		previousPosition = Position.createAfter( value.item );
-		nextPosition = Position.createFromParentAndOffset( value.item, value.item.getMaxOffset() );
+		nextPosition = Position.createFromParentAndOffset( value.item, value.item.maxOffset );
 	} else {
-		previousPosition = Position.createFromParentAndOffset( value.item, value.item.getMaxOffset() );
+		previousPosition = Position.createFromParentAndOffset( value.item, value.item.maxOffset );
 		nextPosition = Position.createAfter( value.item );
 	}
 

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -78,7 +78,7 @@ describe( 'writer', () => {
 			writer.remove( range );
 
 			expectData( 'fooxyz' );
-			expect( root.getChildCount() ).to.equal( 1 );
+			expect( root.childCount ).to.equal( 1 );
 		} );
 
 		it( 'should throw if given range is not flat', () => {

--- a/tests/view/document/jumpoverinlinefiller.js
+++ b/tests/view/document/jumpoverinlinefiller.js
@@ -16,10 +16,9 @@ import { parse, setData } from '/tests/engine/_utils/view.js';
 describe( 'Document', () => {
 	let viewDocument;
 
-	beforeEach( () => {
+	before( () => {
 		viewDocument = new ViewDocument();
-
-		viewDocument.createRoot( document.getElementById( 'editor' ) );
+		viewDocument.createRoot( document.getElementById( 'editor' ) ) ;
 
 		document.getSelection().removeAllRanges();
 

--- a/tests/view/documentfragment.js
+++ b/tests/view/documentfragment.js
@@ -15,14 +15,14 @@ describe( 'DocumentFragment', () => {
 			const fragment = new DocumentFragment();
 
 			expect( fragment ).to.be.an.instanceof( DocumentFragment );
-			expect( fragment.getChildCount() ).to.equal( 0 );
+			expect( fragment.childCount ).to.equal( 0 );
 		} );
 
 		it( 'should create DocumentFragment with child node', () => {
 			const child = new Element( 'p' );
 			const fragment = new DocumentFragment( child );
 
-			expect( fragment.getChildCount() ).to.equal( 1 );
+			expect( fragment.childCount ).to.equal( 1 );
 			expect( fragment.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'p' );
 		} );
 
@@ -30,7 +30,7 @@ describe( 'DocumentFragment', () => {
 			const children = [ new Element( 'p' ), new Element( 'div' ) ];
 			const fragment = new DocumentFragment( children );
 
-			expect( fragment.getChildCount() ).to.equal( 2 );
+			expect( fragment.childCount ).to.equal( 2 );
 			expect( fragment.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'p' );
 			expect( fragment.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'div' );
 		} );
@@ -69,13 +69,13 @@ describe( 'DocumentFragment', () => {
 		it( 'should return true if there are no children in document fragment', () => {
 			const fragment = new DocumentFragment();
 
-			expect( fragment.isEmpty() ).to.be.true;
+			expect( fragment.isEmpty ).to.be.true;
 		} );
 
 		it( 'should return false if there are children in document fragment', () => {
 			const fragment = new DocumentFragment( [ new Element( 'p' ) ] );
 
-			expect( fragment.isEmpty() ).to.be.false;
+			expect( fragment.isEmpty ).to.be.false;
 		} );
 	} );
 
@@ -95,7 +95,7 @@ describe( 'DocumentFragment', () => {
 				const count1 = fragment.insertChildren( 0, [ el1, el3 ] );
 				const count2 = fragment.insertChildren( 1, el2 );
 
-				expect( fragment.getChildCount() ).to.equal( 3 );
+				expect( fragment.childCount ).to.equal( 3 );
 				expect( fragment.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
 				expect( fragment.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'el2' );
 				expect( fragment.getChild( 2 ) ).to.have.property( 'name' ).that.equals( 'el3' );
@@ -106,8 +106,14 @@ describe( 'DocumentFragment', () => {
 			it( 'should accept strings', () => {
 				fragment.insertChildren( 0, 'abc' );
 
-				expect( fragment.getChildCount() ).to.equal( 1 );
+				expect( fragment.childCount ).to.equal( 1 );
 				expect( fragment.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'abc' );
+
+				fragment.removeChildren( 0, 1 );
+				fragment.insertChildren( 0, [ new Element( 'p' ), 'abc' ] );
+
+				expect( fragment.childCount ).to.equal( 2 );
+				expect( fragment.getChild( 1 ) ).to.have.property( 'data' ).that.equals( 'abc' );
 			} );
 
 			it( 'should append children', () => {
@@ -115,7 +121,7 @@ describe( 'DocumentFragment', () => {
 				const count2 = fragment.appendChildren( el2 );
 				const count3 = fragment.appendChildren( el3 );
 
-				expect( fragment.getChildCount() ).to.equal( 3 );
+				expect( fragment.childCount ).to.equal( 3 );
 				expect( fragment.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
 				expect( fragment.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'el2' );
 				expect( fragment.getChild( 2 ) ).to.have.property( 'name' ).that.equals( 'el3' );
@@ -149,7 +155,7 @@ describe( 'DocumentFragment', () => {
 				fragment.appendChildren( el2 );
 				fragment.appendChildren( el3 );
 
-				expect( fragment.getChildCount() ).to.equal( 3 );
+				expect( fragment.childCount ).to.equal( 3 );
 				expect( fragment.getChildIndex( el1 ) ).to.equal( 0 );
 				expect( fragment.getChildIndex( el2 ) ).to.equal( 1 );
 				expect( fragment.getChildIndex( el3 ) ).to.equal( 2 );
@@ -183,7 +189,7 @@ describe( 'DocumentFragment', () => {
 
 				fragment.removeChildren( 1, 2 );
 
-				expect( fragment.getChildCount() ).to.equal( 2 );
+				expect( fragment.childCount ).to.equal( 2 );
 				expect( fragment.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
 				expect( fragment.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'el4' );
 
@@ -200,7 +206,7 @@ describe( 'DocumentFragment', () => {
 
 				const removed = fragment.removeChildren( 1 );
 
-				expect( fragment.getChildCount() ).to.equal( 2 );
+				expect( fragment.childCount ).to.equal( 2 );
 				expect( fragment.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
 				expect( fragment.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'el3' );
 
@@ -222,40 +228,40 @@ describe( 'DocumentFragment', () => {
 	} );
 
 	describe( 'node methods when inserted to fragment', () => {
-		it( 'getIndex() should return proper value', () => {
+		it( 'index should return proper value', () => {
 			const node1 = new Node();
 			const node2 = new Node();
 			const node3 = new Node();
 			const fragment = new DocumentFragment( [ node1, node2, node3 ] );
 
-			expect( node1.getIndex() ).to.equal( 0 );
-			expect( node2.getIndex() ).to.equal( 1 );
-			expect( node3.getIndex() ).to.equal( 2 );
+			expect( node1.index ).to.equal( 0 );
+			expect( node2.index ).to.equal( 1 );
+			expect( node3.index ).to.equal( 2 );
 			expect( node1.parent ).to.equal( fragment );
 			expect( node2.parent ).to.equal( fragment );
 			expect( node3.parent ).to.equal( fragment );
 		} );
 
-		it( 'getNextSibling() should return proper node', () => {
+		it( 'nextSibling should return proper node', () => {
 			const node1 = new Node();
 			const node2 = new Node();
 			const node3 = new Node();
 			new DocumentFragment( [ node1, node2, node3 ] );
 
-			expect( node1.getNextSibling() ).to.equal( node2 );
-			expect( node2.getNextSibling() ).to.equal( node3 );
-			expect( node3.getNextSibling() ).to.be.null;
+			expect( node1.nextSibling ).to.equal( node2 );
+			expect( node2.nextSibling ).to.equal( node3 );
+			expect( node3.nextSibling ).to.be.null;
 		} );
 
-		it( 'getPreviousSibling() should return proper node', () => {
+		it( 'previousSibling should return proper node', () => {
 			const node1 = new Node();
 			const node2 = new Node();
 			const node3 = new Node();
 			new DocumentFragment( [ node1, node2, node3 ] );
 
-			expect( node1.getPreviousSibling() ).to.be.null;
-			expect( node2.getPreviousSibling() ).to.equal( node1 );
-			expect( node3.getPreviousSibling() ).to.equal( node2 );
+			expect( node1.previousSibling ).to.be.null;
+			expect( node2.previousSibling ).to.equal( node1 );
+			expect( node3.previousSibling ).to.equal( node2 );
 		} );
 
 		it( 'remove() should remove node from fragment', () => {
@@ -267,7 +273,7 @@ describe( 'DocumentFragment', () => {
 			node1.remove();
 			node3.remove();
 
-			expect( fragment.getChildCount() ).to.equal( 1 );
+			expect( fragment.childCount ).to.equal( 1 );
 			expect( node1.parent ).to.be.null;
 			expect( node3.parent ).to.be.null;
 			expect( fragment.getChild( 0 ) ).to.equal( node2 );

--- a/tests/view/domconverter/dom-to-view.js
+++ b/tests/view/domconverter/dom-to-view.js
@@ -40,7 +40,7 @@ describe( 'DomConverter', () => {
 			expect( viewP.getAttribute( 'class' ) ).to.equal( 'foo' );
 			expect( count( viewP.getAttributeKeys() ) ).to.equal( 1 );
 
-			expect( viewP.getChildCount() ).to.equal( 2 );
+			expect( viewP.childCount ).to.equal( 2 );
 			expect( viewP.getChild( 0 ).name ).to.equal( 'img' );
 			expect( viewP.getChild( 1 ).data ).to.equal( 'foo' );
 
@@ -61,7 +61,7 @@ describe( 'DomConverter', () => {
 			expect( viewP.getAttribute( 'class' ) ).to.equal( 'foo' );
 			expect( count( viewP.getAttributeKeys() ) ).to.equal( 1 );
 
-			expect( viewP.getChildCount() ).to.equal( 2 );
+			expect( viewP.childCount ).to.equal( 2 );
 			expect( viewP.getChild( 0 ).name ).to.equal( 'img' );
 			expect( viewP.getChild( 1 ).data ).to.equal( 'foo' );
 
@@ -86,7 +86,7 @@ describe( 'DomConverter', () => {
 			expect( viewP.getAttribute( 'class' ) ).to.equal( 'foo' );
 			expect( count( viewP.getAttributeKeys() ) ).to.equal( 1 );
 
-			expect( viewP.getChildCount() ).to.equal( 0 );
+			expect( viewP.childCount ).to.equal( 0 );
 			expect( converter.getCorrespondingDom( viewP ) ).to.not.equal( domP );
 		} );
 
@@ -101,7 +101,7 @@ describe( 'DomConverter', () => {
 			const viewFragment = converter.domToView( domFragment, { bind: true } );
 
 			expect( viewFragment ).to.be.an.instanceof( ViewDocumentFragment );
-			expect( viewFragment.getChildCount() ).to.equal( 2 );
+			expect( viewFragment.childCount ).to.equal( 2 );
 			expect( viewFragment.getChild( 0 ).name ).to.equal( 'img' );
 			expect( viewFragment.getChild( 1 ).data ).to.equal( 'foo' );
 
@@ -125,7 +125,7 @@ describe( 'DomConverter', () => {
 
 			expect( viewFragment ).to.be.an.instanceof( ViewDocumentFragment );
 
-			expect( viewFragment.getChildCount() ).to.equal( 0 );
+			expect( viewFragment.childCount ).to.equal( 0 );
 			expect( converter.getCorrespondingDom( viewFragment ) ).to.not.equal( domFragment );
 		} );
 

--- a/tests/view/editableelement.js
+++ b/tests/view/editableelement.js
@@ -96,7 +96,7 @@ describe( 'EditableElement', () => {
 			const docMock = createDocumentMock();
 			const root = new RootEditableElement( docMock, 'div' );
 
-			expect( root.getDocument() ).to.equal( docMock );
+			expect( root.document ).to.equal( docMock );
 		} );
 	} );
 } );

--- a/tests/view/element.js
+++ b/tests/view/element.js
@@ -44,7 +44,7 @@ describe( 'Element', () => {
 			const parent = new Element( 'div', [], [ child ] );
 
 			expect( parent ).to.have.property( 'name' ).that.equals( 'div' );
-			expect( parent.getChildCount() ).to.equal( 1 );
+			expect( parent.childCount ).to.equal( 1 );
 			expect( parent.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'p' );
 		} );
 
@@ -76,13 +76,13 @@ describe( 'Element', () => {
 		it( 'should return true if there are no children in element', () => {
 			const element = new Element( 'p' );
 
-			expect( element.isEmpty() ).to.be.true;
+			expect( element.isEmpty ).to.be.true;
 		} );
 
 		it( 'should return false if there are children in element', () => {
 			const fragment = new Element( 'p', null, new Element( 'img' ) );
 
-			expect( fragment.isEmpty() ).to.be.false;
+			expect( fragment.isEmpty ).to.be.false;
 		} );
 	} );
 
@@ -102,14 +102,14 @@ describe( 'Element', () => {
 				new Element( 'b', { attr: 'baz' } ),
 				new Element( 'span', { attr: 'qux' } )
 			] );
-			const count = el.getChildCount();
+			const count = el.childCount;
 			const clone = el.clone( true );
 
 			expect( clone ).to.not.equal( el );
 			expect( clone.name ).to.equal( el.name );
 			expect( clone.getAttribute( 'attr1' ) ).to.equal( 'foo' );
 			expect( clone.getAttribute( 'attr2' ) ).to.equal( 'bar' );
-			expect( clone.getChildCount() ).to.equal( count );
+			expect( clone.childCount ).to.equal( count );
 
 			for ( let i = 0; i < count; i++ ) {
 				const child = el.getChild( i );
@@ -132,7 +132,7 @@ describe( 'Element', () => {
 			expect( clone.name ).to.equal( el.name );
 			expect( clone.getAttribute( 'attr1' ) ).to.equal( 'foo' );
 			expect( clone.getAttribute( 'attr2' ) ).to.equal( 'bar' );
-			expect( clone.getChildCount() ).to.equal( 0 );
+			expect( clone.childCount ).to.equal( 0 );
 		} );
 
 		it( 'should clone class attribute', () => {
@@ -247,7 +247,7 @@ describe( 'Element', () => {
 				const count1 = parent.insertChildren( 0, [ el1, el3 ] );
 				const count2 = parent.insertChildren( 1, el2 );
 
-				expect( parent.getChildCount() ).to.equal( 3 );
+				expect( parent.childCount ).to.equal( 3 );
 				expect( parent.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
 				expect( parent.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'el2' );
 				expect( parent.getChild( 2 ) ).to.have.property( 'name' ).that.equals( 'el3' );
@@ -258,8 +258,14 @@ describe( 'Element', () => {
 			it( 'should accept strings', () => {
 				parent.insertChildren( 0, 'abc' );
 
-				expect( parent.getChildCount() ).to.equal( 1 );
+				expect( parent.childCount ).to.equal( 1 );
 				expect( parent.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'abc' );
+
+				parent.removeChildren( 0, 1 );
+				parent.insertChildren( 0, [ new Element( 'p' ), 'abc' ] );
+
+				expect( parent.childCount ).to.equal( 2 );
+				expect( parent.getChild( 1 ) ).to.have.property( 'data' ).that.equals( 'abc' );
 			} );
 
 			it( 'should append children', () => {
@@ -267,7 +273,7 @@ describe( 'Element', () => {
 				const count2 = parent.appendChildren( el2 );
 				const count3 = parent.appendChildren( el3 );
 
-				expect( parent.getChildCount() ).to.equal( 3 );
+				expect( parent.childCount ).to.equal( 3 );
 				expect( parent.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
 				expect( parent.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'el2' );
 				expect( parent.getChild( 2 ) ).to.have.property( 'name' ).that.equals( 'el3' );
@@ -283,7 +289,7 @@ describe( 'Element', () => {
 				parent.appendChildren( el2 );
 				parent.appendChildren( el3 );
 
-				expect( parent.getChildCount() ).to.equal( 3 );
+				expect( parent.childCount ).to.equal( 3 );
 				expect( parent.getChildIndex( el1 ) ).to.equal( 0 );
 				expect( parent.getChildIndex( el2 ) ).to.equal( 1 );
 				expect( parent.getChildIndex( el3 ) ).to.equal( 2 );
@@ -317,7 +323,7 @@ describe( 'Element', () => {
 
 				parent.removeChildren( 1, 2 );
 
-				expect( parent.getChildCount() ).to.equal( 2 );
+				expect( parent.childCount ).to.equal( 2 );
 				expect( parent.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
 				expect( parent.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'el4' );
 
@@ -334,7 +340,7 @@ describe( 'Element', () => {
 
 				const removed = parent.removeChildren( 1 );
 
-				expect( parent.getChildCount() ).to.equal( 2 );
+				expect( parent.childCount ).to.equal( 2 );
 				expect( parent.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
 				expect( parent.getChild( 1 ) ).to.have.property( 'name' ).that.equals( 'el3' );
 

--- a/tests/view/matcher.js
+++ b/tests/view/matcher.js
@@ -215,7 +215,7 @@ describe( 'Matcher', () => {
 		it( 'should allow to use function as a pattern', () => {
 			const match = { name: true };
 			const pattern = ( element ) => {
-				if ( element.name === 'div' && element.getChildCount() > 0 ) {
+				if ( element.name === 'div' && element.childCount > 0 ) {
 					return match;
 				}
 

--- a/tests/view/node.js
+++ b/tests/view/node.js
@@ -33,29 +33,29 @@ describe( 'Node', () => {
 
 	describe( 'getNextSibling/getPreviousSibling', () => {
 		it( 'should return next sibling', () => {
-			expect( root.getNextSibling() ).to.be.null;
+			expect( root.nextSibling ).to.be.null;
 
-			expect( one.getNextSibling() ).to.equal( two );
-			expect( two.getNextSibling() ).to.equal( three );
-			expect( three.getNextSibling() ).to.be.null;
+			expect( one.nextSibling ).to.equal( two );
+			expect( two.nextSibling ).to.equal( three );
+			expect( three.nextSibling ).to.be.null;
 
-			expect( charB.getNextSibling() ).to.equal( charA );
-			expect( charA.getNextSibling() ).to.equal( img );
-			expect( img.getNextSibling() ).to.equal( charR );
-			expect( charR.getNextSibling() ).to.be.null;
+			expect( charB.nextSibling ).to.equal( charA );
+			expect( charA.nextSibling ).to.equal( img );
+			expect( img.nextSibling ).to.equal( charR );
+			expect( charR.nextSibling ).to.be.null;
 		} );
 
 		it( 'should return previous sibling', () => {
-			expect( root.getPreviousSibling() ).to.be.null;
+			expect( root.previousSibling ).to.be.null;
 
-			expect( one.getPreviousSibling() ).to.be.null;
-			expect( two.getPreviousSibling() ).to.equal( one );
-			expect( three.getPreviousSibling() ).to.equal( two );
+			expect( one.previousSibling ).to.be.null;
+			expect( two.previousSibling ).to.equal( one );
+			expect( three.previousSibling ).to.equal( two );
 
-			expect( charB.getPreviousSibling() ).to.be.null;
-			expect( charA.getPreviousSibling() ).to.equal( charB );
-			expect( img.getPreviousSibling() ).to.equal( charA );
-			expect( charR.getPreviousSibling() ).to.equal( img );
+			expect( charB.previousSibling ).to.be.null;
+			expect( charA.previousSibling ).to.equal( charB );
+			expect( img.previousSibling ).to.equal( charA );
+			expect( charR.previousSibling ).to.equal( img );
 		} );
 	} );
 
@@ -113,18 +113,18 @@ describe( 'Node', () => {
 
 	describe( 'getIndex', () => {
 		it( 'should return null if the parent is null', () => {
-			expect( root.getIndex() ).to.be.null;
+			expect( root.index ).to.be.null;
 		} );
 
 		it( 'should return index in the parent', () => {
-			expect( one.getIndex() ).to.equal( 0 );
-			expect( two.getIndex() ).to.equal( 1 );
-			expect( three.getIndex() ).to.equal( 2 );
+			expect( one.index ).to.equal( 0 );
+			expect( two.index ).to.equal( 1 );
+			expect( three.index ).to.equal( 2 );
 
-			expect( charB.getIndex() ).to.equal( 0 );
-			expect( charA.getIndex() ).to.equal( 1 );
-			expect( img.getIndex() ).to.equal( 2 );
-			expect( charR.getIndex() ).to.equal( 3 );
+			expect( charB.index ).to.equal( 0 );
+			expect( charA.index ).to.equal( 1 );
+			expect( img.index ).to.equal( 2 );
+			expect( charR.index ).to.equal( 3 );
 		} );
 
 		it( 'should throw an error if parent does not contain element', () => {
@@ -135,7 +135,7 @@ describe( 'Node', () => {
 
 			expect(
 				() => {
-					f.getIndex();
+					f.index;
 				}
 			).to.throw( CKEditorError, /view-node-not-found-in-parent/ );
 		} );
@@ -143,7 +143,7 @@ describe( 'Node', () => {
 
 	describe( 'getDocument', () => {
 		it( 'should return null if any parent has not set Document', () => {
-			expect( charA.getDocument() ).to.be.null;
+			expect( charA.document ).to.be.null;
 		} );
 
 		it( 'should return Document attached to the parent element', () => {
@@ -153,15 +153,15 @@ describe( 'Node', () => {
 
 			child.parent = parent;
 
-			expect( parent.getDocument() ).to.equal( docMock );
-			expect( child.getDocument() ).to.equal( docMock );
+			expect( parent.document ).to.equal( docMock );
+			expect( child.document ).to.equal( docMock );
 		} );
 
 		it( 'should return null if element is inside DocumentFragment', () => {
 			const child = new Element( 'p' );
 			new DocumentFragment( [ child ] );
 
-			expect( child.getDocument() ).to.be.null;
+			expect( child.document ).to.be.null;
 		} );
 	} );
 
@@ -169,7 +169,7 @@ describe( 'Node', () => {
 		it( 'should return this element if it has no parent', () => {
 			const child = new Element( 'p' );
 
-			expect( child.getRoot() ).to.equal( child );
+			expect( child.root ).to.equal( child );
 		} );
 
 		it( 'should return root element', () => {
@@ -178,8 +178,8 @@ describe( 'Node', () => {
 
 			child.parent = parent;
 
-			expect( parent.getRoot() ).to.equal( parent );
-			expect( child.getRoot() ).to.equal( parent );
+			expect( parent.root ).to.equal( parent );
+			expect( child.root ).to.equal( parent );
 		} );
 	} );
 
@@ -196,7 +196,7 @@ describe( 'Node', () => {
 			const char = new Text( 'a' );
 			const parent = new Element( 'p', null, [ char ] );
 			const removeChildrenSpy = sinon.spy( parent, 'removeChildren' );
-			const index = char.getIndex();
+			const index = char.index;
 			char.remove();
 			removeChildrenSpy.restore();
 			sinon.assert.calledOnce( removeChildrenSpy );

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -106,13 +106,13 @@ describe( 'Position', () => {
 			const foo = new Text( 'foo' );
 			const docFrag = new DocumentFragment( foo );
 
-			expect( new Position( foo, 1 ).getRoot() ).to.equal( docFrag );
+			expect( new Position( foo, 1 ).root ).to.equal( docFrag );
 
 			const bar = new Text( 'bar' );
 			const p = new Element( 'p', null, bar );
 
-			expect( new Position( bar, 2 ).getRoot() ).to.equal( p );
-			expect( new Position( p, 0 ).getRoot() ).to.equal( p );
+			expect( new Position( bar, 2 ).root ).to.equal( p );
+			expect( new Position( p, 0 ).root ).to.equal( p );
 		} );
 	} );
 
@@ -336,13 +336,13 @@ describe( 'Position', () => {
 		it( 'should return true if it is at the start of it\'s parent', () => {
 			const foo = new Text( 'foo' );
 			const position = new Position( foo, 0 );
-			expect( position.isAtStart( position ) ).to.be.true;
+			expect( position.isAtStart ).to.be.true;
 		} );
 
 		it( 'should return false if it is not at the start of it\'s parent', () => {
 			const foo = new Text( 'foo' );
 			const position = new Position( foo, 1 );
-			expect( position.isAtStart( position ) ).to.be.false;
+			expect( position.isAtStart ).to.be.false;
 		} );
 	} );
 
@@ -351,16 +351,16 @@ describe( 'Position', () => {
 			const foo = new Text( 'foo' );
 			const p = new Element( 'p', null, foo );
 
-			expect( new Position( foo, 3 ).isAtEnd() ).to.be.true;
-			expect( new Position( p, 1 ).isAtEnd() ).to.be.true;
+			expect( new Position( foo, 3 ).isAtEnd ).to.be.true;
+			expect( new Position( p, 1 ).isAtEnd ).to.be.true;
 		} );
 
 		it( 'should return false if it is not at the end of it\'s parent', () => {
 			const foo = new Text( 'foo' );
 			const p = new Element( 'p', null, foo );
 
-			expect( new Position( foo, 2 ).isAtEnd() ).to.be.false;
-			expect( new Position( p, 0 ).isAtEnd() ).to.be.false;
+			expect( new Position( foo, 2 ).isAtEnd ).to.be.false;
+			expect( new Position( p, 0 ).isAtEnd ).to.be.false;
 		} );
 	} );
 
@@ -453,7 +453,7 @@ describe( 'Position', () => {
 		it( 'should return null if position is not inside EditableElement', () => {
 			const position = new Position( new Element( 'p' ), 0 );
 
-			expect( position.getEditableElement() ).to.be.null;
+			expect( position.editableElement ).to.be.null;
 		} );
 
 		it( 'should return EditableElement when position is placed inside', () => {
@@ -462,7 +462,7 @@ describe( 'Position', () => {
 			const editable = new EditableElement( document, 'div', null, p );
 			const position = new Position( p, 0 );
 
-			expect( position.getEditableElement() ).to.equal( editable );
+			expect( position.editableElement ).to.equal( editable );
 		} );
 	} );
 } );

--- a/tests/view/range.js
+++ b/tests/view/range.js
@@ -69,14 +69,14 @@ describe( 'Range', () => {
 			const viewRoot = new Element( 'div' );
 			const range = getRange( '<p>f{oo</p><p>ba}r</p>', { rootElement: viewRoot } );
 
-			expect( range.getRoot() ).to.equal( viewRoot );
+			expect( range.root ).to.equal( viewRoot );
 		} );
 
 		it( 'should return document fragment in which range is created', () => {
 			const viewFrag = new DocumentFragment();
 			const range = getRange( '<p>f{oo</p><p>ba}r</p>', { rootElement: viewFrag } );
 
-			expect( range.getRoot() ).to.equal( viewFrag );
+			expect( range.root ).to.equal( viewFrag );
 		} );
 	} );
 

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -122,7 +122,11 @@ describe( 'Renderer', () => {
 			renderer.isFocused = true;
 
 			// Fake selection editable - it is needed to render selection properly.
-			testUtils.sinon.stub( selection, 'getEditableElement', () => selectionEditable );
+			Object.defineProperty( selection, 'editableElement', {
+				get: function() {
+					return selectionEditable;
+				}
+			} );
 		} );
 
 		it( 'should update attributes', () => {
@@ -983,7 +987,7 @@ describe( 'Renderer', () => {
 
 		it( 'should handle focusing element', () => {
 			const domFocusSpy = testUtils.sinon.spy( domRoot, 'focus' );
-			const editable = selection.getEditableElement();
+			const editable = selection.editableElement;
 
 			renderer.render();
 

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -499,13 +499,13 @@ describe( 'Selection', () => {
 
 	describe( 'getEditableElement', () => {
 		it( 'should return null if no ranges in selection', () => {
-			expect( selection.getEditableElement() ).to.be.null;
+			expect( selection.editableElement ).to.be.null;
 		} );
 
 		it( 'should return null if selection is placed in container that is not EditableElement', () => {
 			selection.addRange( range1 );
 
-			expect( selection.getEditableElement() ).to.be.null;
+			expect( selection.editableElement ).to.be.null;
 		} );
 
 		it( 'should return EditableElement when selection is placed inside', () => {
@@ -517,7 +517,7 @@ describe( 'Selection', () => {
 
 			selection.addRange( Range.createFromParentsAndOffsets( element, 0, element, 0 ) );
 
-			expect( selection.getEditableElement() ).to.equal( root );
+			expect( selection.editableElement ).to.equal( root );
 		} );
 	} );
 

--- a/tests/view/textproxy.js
+++ b/tests/view/textproxy.js
@@ -44,7 +44,7 @@ describe( 'TextProxy', () => {
 
 	describe( 'getDocument', () => {
 		it( 'should return null if any parent has not set Document', () => {
-			expect( textProxy.getDocument() ).to.be.null;
+			expect( textProxy.document ).to.be.null;
 		} );
 
 		it( 'should return Document attached to the parent element', () => {
@@ -53,13 +53,13 @@ describe( 'TextProxy', () => {
 
 			wrapper.parent = root;
 
-			expect( textProxy.getDocument() ).to.equal( docMock );
+			expect( textProxy.document ).to.equal( docMock );
 		} );
 
 		it( 'should return null if element is inside DocumentFragment', () => {
 			new DocumentFragment( [ wrapper ] );
 
-			expect( textProxy.getDocument() ).to.be.null;
+			expect( textProxy.document ).to.be.null;
 		} );
 	} );
 
@@ -69,7 +69,7 @@ describe( 'TextProxy', () => {
 
 			wrapper.parent = root;
 
-			expect( textProxy.getRoot() ).to.equal( root );
+			expect( textProxy.root ).to.equal( root );
 		} );
 	} );
 

--- a/tests/view/writer/breakAt.js
+++ b/tests/view/writer/breakAt.js
@@ -20,7 +20,7 @@ describe( 'writer', () => {
 		let { view, selection } = parse( input );
 
 		const newPosition = breakAt( selection.getFirstPosition() );
-		expect( stringify( view.getRoot(), newPosition, { showType: true, showPriority: true } ) ).to.equal( expected );
+		expect( stringify( view.root, newPosition, { showType: true, showPriority: true } ) ).to.equal( expected );
 	}
 
 	describe( 'breakAt', () => {

--- a/tests/view/writer/breakrange.js
+++ b/tests/view/writer/breakrange.js
@@ -23,7 +23,7 @@ describe( 'writer', () => {
 		let { view, selection } = parse( input );
 
 		const newRange = breakRange( selection.getFirstRange() );
-		expect( stringify( view.getRoot(), newRange, { showType: true } ) ).to.equal( expected );
+		expect( stringify( view.root, newRange, { showType: true } ) ).to.equal( expected );
 	}
 
 	describe( 'breakRange', () => {

--- a/tests/view/writer/insert.js
+++ b/tests/view/writer/insert.js
@@ -26,7 +26,7 @@ describe( 'writer', () => {
 		let { view, selection } = parse( input );
 
 		const newRange = insert( selection.getFirstPosition(), nodesToInsert );
-		expect( stringify( view.getRoot(), newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
+		expect( stringify( view.root, newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
 	}
 
 	describe( 'insert', () => {

--- a/tests/view/writer/remove.js
+++ b/tests/view/writer/remove.js
@@ -55,7 +55,7 @@ describe( 'writer', () => {
 			const fragment = remove( range );
 
 			expect( fragment ).to.be.instanceof( DocumentFragment );
-			expect( fragment.getChildCount() ).to.equal( 0 );
+			expect( fragment.childCount ).to.equal( 0 );
 			expect( range.isCollapsed ).to.be.true;
 		} );
 

--- a/tests/view/writer/unwrap.js
+++ b/tests/view/writer/unwrap.js
@@ -27,7 +27,7 @@ describe( 'writer', () => {
 		let { view, selection } = parse( input );
 
 		const newRange = unwrap( selection.getFirstRange(), parse( unwrapAttribute ) );
-		expect( stringify( view.getRoot(), newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
+		expect( stringify( view.root, newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
 	}
 
 	describe( 'unwrap', () => {

--- a/tests/view/writer/wrap.js
+++ b/tests/view/writer/wrap.js
@@ -27,7 +27,7 @@ describe( 'writer', () => {
 		let { view, selection } = parse( input );
 		const newRange = wrap( selection.getFirstRange(), parse( wrapAttribute ) );
 
-		expect( stringify( view.getRoot(), newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
+		expect( stringify( view.root, newRange, { showType: true, showPriority: true } ) ).to.equal( expected );
 	}
 
 	describe( 'wrap', () => {


### PR DESCRIPTION
Fixes #518.

I changed multiple methods to getters and one getter to a method. Here are rules that I followed:
* must return value and can't get parameters (pretty obvious)
* must not create new objects
* must not change state of the object
* must always return same value or reference to same value ( `a.foo === a.foo` )
* should be arbitrary fast (no long loops)
* should not need and should not feel like it needs complex evaluation
* should naturally feel like a property, or i.e. have a counterpart property in DOM
* should not use non-native non-getters

Most of changes follows this rules, with one exception. `view.Position.getEditableElement` follows the rules so it was changed to a getter. There is also `view.Selection.getEditableElement` which is more complex and uses non-native non-getters, but for unification purposes, it also got converted to a getter.

`model.Document.rootNames` was creating an array, so it was changed to `model.Document.getRootNames()`.

Related PRs:
https://github.com/ckeditor/ckeditor5-enter/pull/19
https://github.com/ckeditor/ckeditor5-undo/pull/28
https://github.com/ckeditor/ckeditor5-editor-classic/pull/18