### PR TITLE
ViewSelection instance is passed with viewMutations in mutations events, if possible.

### DIFF
--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -238,7 +238,7 @@ export default class MutationObserver extends Observer {
  * Array of mutations.
  * For mutated texts it will be {@link engine.view.Document~MutatatedText} and for mutated elements it will be
  * {@link engine.view.Document~MutatatedElement}. You can recognize the type based on the `type` property.
- * @param {engine.view.Selection|null} View selection that is a result of converting DOM selection to view. Keep in
+ * @param {engine.view.Selection|null} viewSelection View selection that is a result of converting DOM selection to view. Keep in
  * mind that the DOM selection is already "updated", meaning that it already acknowledges changes done in mutation.
  */
 

--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -6,6 +6,7 @@
 /* globals window */
 
 import Observer from './observer.js';
+import ViewSelection from '../selection.js';
 import { startsWithFiller, getDataWithoutFiller } from '../filler.js';
 
 /**
@@ -191,8 +192,30 @@ export default class MutationObserver extends Observer {
 			} );
 		}
 
-		this.document.fire( 'mutations', viewMutations );
+		// Retrieve `domSelection` using `ownerDocument` of one of mutated nodes.
+		// There should not be simultaneous mutation in multiple documents, so it's fine.
+		const domSelection = domMutations[ 0 ].target.ownerDocument.getSelection();
 
+		let viewSelection = null;
+
+		if ( domSelection && domSelection.anchorNode ) {
+			// If `domSelection` is inside a dom node that is already bound to a view node from view tree, get
+			// corresponding selection in the view and pass it together with `viewMutations`. The `viewSelection` may
+			// be used by features handling mutations.
+			// Only one range is supported.
+
+			const viewSelectionAnchor = domConverter.domPositionToView( domSelection.anchorNode, domSelection.anchorOffset );
+			const viewSelectionFocus = domConverter.domPositionToView( domSelection.focusNode, domSelection.focusOffset );
+
+			// Anchor and focus has to be properly mapped to view.
+			if ( viewSelectionAnchor && viewSelectionFocus ) {
+				viewSelection = new ViewSelection();
+				viewSelection.collapse( viewSelectionAnchor );
+				viewSelection.setFocus( viewSelectionFocus );
+			}
+		}
+
+		this.document.fire( 'mutations', viewMutations, viewSelection );
 		this.document.render();
 	}
 }

--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -238,6 +238,8 @@ export default class MutationObserver extends Observer {
  * Array of mutations.
  * For mutated texts it will be {@link engine.view.Document~MutatatedText} and for mutated elements it will be
  * {@link engine.view.Document~MutatatedElement}. You can recognize the type based on the `type` property.
+ * @param {engine.view.Selection|null} View selection that is a result of converting DOM selection to view. Keep in
+ * mind that the DOM selection is already "updated", meaning that it already acknowledges changes done in mutation.
  */
 
 /**

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -343,6 +343,43 @@ export default class Selection {
 	}
 
 	/**
+	 * Sets {@link engine.view.Selection#focus} to the specified location.
+	 *
+	 * The location can be specified in the same form as {@link engine.view.Position.createAt} parameters.
+	 *
+	 * @fires engine.view.Selection#change:range
+	 * @param {engine.view.Item|engine.view.Position} itemOrPosition
+	 * @param {Number|'end'|'before'|'after'} [offset=0] Offset or one of the flags. Used only when
+	 * first parameter is a {@link engine.view.Item view item}.
+	 */
+	setFocus( itemOrPosition, offset ) {
+		if ( this.anchor === null ) {
+			/**
+			 * Cannot set selection focus if there are no ranges in selection.
+			 *
+			 * @error view-selection-setFocus-no-ranges
+			 */
+			throw new CKEditorError( 'view-selection-setFocus-no-ranges: Cannot set selection focus if there are no ranges in selection.' );
+		}
+
+		const newFocus = Position.createAt( itemOrPosition, offset );
+
+		if ( newFocus.compareWith( this.focus ) == 'same' ) {
+			return;
+		}
+
+		const anchor = this.anchor;
+
+		this._ranges.pop();
+
+		if ( newFocus.compareWith( anchor ) == 'before' ) {
+			this.addRange( new Range( newFocus, anchor ), true );
+		} else {
+			this.addRange( new Range( anchor, newFocus ) );
+		}
+	}
+
+	/**
 	 * Creates and returns an instance of `Selection` that is a clone of given selection, meaning that it has same
 	 * ranges and same direction as this selection.
 	 *

--- a/tests/view/observer/mutationobserver.js
+++ b/tests/view/observer/mutationobserver.js
@@ -132,6 +132,23 @@ describe( 'MutationObserver', () => {
 		expectDomEditorNotToChange();
 	} );
 
+	it( 'should fire mutations event with viewSelection param set to null, if dom selection cannot be mapped to view', ( done ) => {
+		const textNode = domEditor.ownerDocument.createTextNode( 'foo' );
+		domEditor.childNodes[ 0 ].appendChild( textNode );
+
+		const domSelection = document.getSelection();
+		domSelection.collapse( textNode, 3 );
+
+		viewDocument.on( 'mutations', ( evt, viewMutations, viewSelection ) => {
+			expect( viewSelection ).to.be.null;
+			done();
+		} );
+
+		mutationObserver.flush();
+
+		expectDomEditorNotToChange();
+	} );
+
 	it( 'should be able to observe multiple roots', () => {
 		const domAdditionalEditor = document.getElementById( 'additional' );
 

--- a/tests/view/observer/mutationobserver.js
+++ b/tests/view/observer/mutationobserver.js
@@ -113,6 +113,25 @@ describe( 'MutationObserver', () => {
 		expect( lastMutations[ 0 ].node ).to.equal( viewRoot );
 	} );
 
+	it( 'should fire mutations event with view selection instance, if dom selection can be mapped to view', ( done ) => {
+		const textNode = domEditor.childNodes[ 0 ].childNodes[ 0 ];
+		textNode.data = 'foom';
+
+		const domSelection = document.getSelection();
+		domSelection.collapse( textNode, 4 );
+
+		viewDocument.on( 'mutations', ( evt, viewMutations, viewSelection ) => {
+			expect( viewSelection.anchor.parent ).to.equal( viewRoot.getChild( 0 ).getChild( 0 ) );
+			expect( viewSelection.anchor.offset ).to.equal( 4 );
+
+			done();
+		} );
+
+		mutationObserver.flush();
+
+		expectDomEditorNotToChange();
+	} );
+
 	it( 'should be able to observe multiple roots', () => {
 		const domAdditionalEditor = document.getElementById( 'additional' );
 


### PR DESCRIPTION
This implements some ideas and fixes some issues described in #399.

This PR introduces `viewSelection` parameter to `mutations` event. `viewSelection` is instance of `engine.view.Selection` created basing on actual DOM selection. `viewSelection` is set only if DOM selection got correctly mapped to view. This means that it is available only when after mutations selection is placed in an already existing DOM node.

For now I feel this is enough. It solves an issue in `Typing` and right now we don't know whether anything else will use mutations.

Additionally, if DOM selection ends up in non-existing DOM node, we need to add a node in model anyway. This means that we should be able to handle setting model selection at that point.