### PR TITLE
Fake selection

### DIFF
--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -209,3 +209,11 @@ export function clearAttributes() {
 		conversionApi.viewSelection.removeAllRanges();
 	};
 }
+
+/**
+ * Function factory, creates a converter that clears fake selection marking after the previous
+ * {@link engine.model.Selection model selection} conversion.
+ */
+export function clearFakeSelection() {
+	return ( evt, data, consumable, conversionApi ) => conversionApi.viewSelection.setFake( false );
+}

--- a/src/editingcontroller.js
+++ b/src/editingcontroller.js
@@ -11,7 +11,8 @@ import { convertSelectionChange } from './conversion/view-selection-to-model-con
 import {
 	convertRangeSelection,
 	convertCollapsedSelection,
-	clearAttributes
+	clearAttributes,
+	clearFakeSelection
 } from './conversion/model-selection-to-view-converters.js';
 
 import EmitterMixin from '../utils/emittermixin.js';
@@ -105,6 +106,7 @@ export default class EditingController {
 
 		// Attach default selection converters.
 		this.modelToView.on( 'selection', clearAttributes(), { priority: 'low' } );
+		this.modelToView.on( 'selection', clearFakeSelection(), { priority: 'low' } );
 		this.modelToView.on( 'selection', convertRangeSelection(), { priority: 'low' } );
 		this.modelToView.on( 'selection', convertCollapsedSelection(), { priority: 'low' } );
 	}

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -13,7 +13,7 @@ import MutationObserver from './observer/mutationobserver.js';
 import SelectionObserver from './observer/selectionobserver.js';
 import FocusObserver from './observer/focusobserver.js';
 import KeyObserver from './observer/keyobserver.js';
-import FakeSelectionObserver from './observer/fakeselecitonobserver.js';
+import FakeSelectionObserver from './observer/fakeselectionobserver.js';
 import mix from '../../utils/mix.js';
 import ObservableMixin from '../../utils/observablemixin.js';
 

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -13,6 +13,7 @@ import MutationObserver from './observer/mutationobserver.js';
 import SelectionObserver from './observer/selectionobserver.js';
 import FocusObserver from './observer/focusobserver.js';
 import KeyObserver from './observer/keyobserver.js';
+import FakeSelectionObserver from './observer/fakeselecitonobserver.js';
 import mix from '../../utils/mix.js';
 import ObservableMixin from '../../utils/observablemixin.js';
 
@@ -30,7 +31,8 @@ import ObservableMixin from '../../utils/observablemixin.js';
  * * {@link view.observer.MutationObserver},
  * * {@link view.observer.SelectionObserver},
  * * {@link view.observer.FocusObserver},
- * * {@link view.observer.KeyObserver}.
+ * * {@link view.observer.KeyObserver},
+ * * {@link view.observer.FakeSelectionObserver}.
  *
  * @memberOf engine.view
  * @mixes utils.EmitterMixin
@@ -107,6 +109,7 @@ export default class Document {
 		this.addObserver( SelectionObserver );
 		this.addObserver( FocusObserver );
 		this.addObserver( KeyObserver );
+		this.addObserver( FakeSelectionObserver );
 
 		injectQuirksHandling( this );
 

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -98,8 +98,8 @@ export default class DomConverter {
 	}
 
 	/**
-	 * Binds given DOM element that represents fake selection to {engine.view.Selection view selection}.
-	 * View selection copy is stored and can be retrieved by {engine.view.DomConverter#fakeSelectionToView} method.
+	 * Binds given DOM element that represents fake selection to {@link engine.view.Selection view selection}.
+	 * View selection copy is stored and can be retrieved by {@link engine.view.DomConverter#fakeSelectionToView} method.
 	 *
 	 * @param {HTMLElement} domElement
 	 * @param {engine.view.Selection} viewSelection
@@ -109,7 +109,7 @@ export default class DomConverter {
 	}
 
 	/**
-	 * Returns {engine.view.Selection view selection} instance corresponding to given DOM element that represents fake
+	 * Returns {@link engine.view.Selection view selection} instance corresponding to given DOM element that represents fake
 	 * selection. Returns `undefined` if binding to given DOM element does not exists.
 	 *
 	 * @param {HTMLElement} domElement

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -391,7 +391,13 @@ export default class DomConverter {
 		// DOM selection might be placed in fake selection container.
 		// If container contains fake selection - return corresponding view selection.
 		if ( domSelection.rangeCount === 1 ) {
-			const container = domSelection.getRangeAt( 0 ).startContainer;
+			let container = domSelection.getRangeAt( 0 ).startContainer;
+
+			// The DOM selection might be moved to the text node inside the fake selection container.
+			if ( this.isText( container ) ) {
+				container = container.parentNode;
+			}
+
 			const viewSelection = this.fakeSelectionToView( container );
 
 			if ( viewSelection ) {

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -92,7 +92,7 @@ export default class DomConverter {
 		 * Holds mapping between fake selection containers and corresponding view selections.
 		 *
 		 * @private
-		 * @type {WeakMap} engine.view.DomConverter#_fakeSelectionMapping
+		 * @member {WeakMap} engine.view.DomConverter#_fakeSelectionMapping
 		 */
 		this._fakeSelectionMapping = new WeakMap();
 	}

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -87,6 +87,36 @@ export default class DomConverter {
 		 * @member {WeakMap} engine.view.DomConverter#_viewToDomMapping
 		 */
 		this._viewToDomMapping = new WeakMap();
+
+		/**
+		 * Holds mapping between fake selection containers and corresponding view selections.
+		 *
+		 * @private
+		 * @type {WeakMap} engine.view.DomConverter#_fakeSelectionMapping
+		 */
+		this._fakeSelectionMapping = new WeakMap();
+	}
+
+	/**
+	 * Binds given DOM element that represents fake selection to {engine.view.Selection view selection}.
+	 * View selection copy is stored and can be retrieved by {engine.view.DomConverter#fakeSelectionToView} method.
+	 *
+	 * @param {HTMLElement} domElement
+	 * @param {engine.view.Selection} viewSelection
+	 */
+	bindFakeSelection( domElement, viewSelection ) {
+		this._fakeSelectionMapping.set( domElement, ViewSelection.createFromSelection( viewSelection ) );
+	}
+
+	/**
+	 * Returns {engine.view.Selection view selection} instance corresponding to given DOM element that represents fake
+	 * selection. Returns `undefined` if binding to given DOM element does not exists.
+	 *
+	 * @param {HTMLElement} domElement
+	 * @returns {engine.view.Selection|undefined}
+	 */
+	fakeSelectionToView( domElement ) {
+		return this._fakeSelectionMapping.get( domElement );
 	}
 
 	/**
@@ -358,8 +388,18 @@ export default class DomConverter {
 	 * @returns {engine.view.Selection} View selection.
 	 */
 	domSelectionToView( domSelection ) {
-		const viewSelection = new ViewSelection();
+		// DOM selection might be placed in fake selection container.
+		// If container contains fake selection - return corresponding view selection.
+		if ( domSelection.rangeCount === 1 ) {
+			const container = domSelection.getRangeAt( 0 ).startContainer;
+			const viewSelection = this.fakeSelectionToView( container );
 
+			if ( viewSelection ) {
+				return viewSelection;
+			}
+		}
+
+		const viewSelection = new ViewSelection();
 		const isBackward = this.isDomSelectionBackward( domSelection );
 
 		for ( let i = 0; i < domSelection.rangeCount; i++ ) {

--- a/src/view/observer/domeventobserver.js
+++ b/src/view/observer/domeventobserver.js
@@ -23,8 +23,8 @@ import DomEventData from './domeventdata.js';
  *				return 'click';
  *			}
  *
- *			onDomEvent( domEvt ) {
- *				this.fire( 'click' );
+ *			onDomEvent( domEvent ) {
+ *				this.fire( 'click', domEvent );
  *			}
  *		}
  *

--- a/src/view/observer/fakeselecitonobserver.js
+++ b/src/view/observer/fakeselecitonobserver.js
@@ -1,0 +1,70 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import Observer from './observer.js';
+import ViewSelection from '../selection.js';
+import { keyCodes } from '../../../utils/keyboard.js';
+
+/**
+ * Fake selection observer class. If view selection is fake it is placed in dummy DOM container. This observer listens
+ * on {@link engine.view.Document#keydown keydown} events and handles moving fake view selection to the correct place
+ * if arrow keys are pressed.
+ * Fires {@link engine.view.Document#selectionChage selectionChage event} simulating natural behaviour of
+ * {@link engine.view.observer.SelectionObserver SelectionObserver}.
+ *
+ * @memberOf engine.view.observer
+ * @extends engine.view.observer.Observer
+ * @fires engine.view.Document#selectionChage
+ */
+export default class FakeSelectionObserver extends Observer {
+	constructor( document ) {
+		super( document );
+
+		document.on( 'keydown', ( eventInfo, data ) => {
+			const selection = document.selection;
+
+			if ( selection.isFake && _isArrowKeyCode( data.keyCode ) ) {
+				// Prevents default keydown handling - no selection change will occur.
+				data.preventDefault();
+
+				const newSelection = ViewSelection.createFromSelection( selection );
+				newSelection.setFake( false );
+
+				// Left or up arrow pressed - move selection to start.
+				if ( data.keyCode == keyCodes.arrowleft || data.keyCode == keyCodes.arrowup ) {
+					newSelection.collapseToStart();
+				}
+
+				// Right or down arro pressed - move selection to end.
+				if ( data.keyCode == keyCodes.arrowright || data.keyCode == keyCodes.arrowdown ) {
+					newSelection.collapseToEnd();
+				}
+
+				document.fire( 'selectionChange', {
+					oldSelection: selection,
+					newSelection: newSelection,
+					domSelection: null
+				} );
+			}
+		}, { priority: 'lowest' } );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	observe() {}
+}
+
+// Checks if one of the arrow keys is pressed.
+//
+// @private
+// @param {Number} keyCode
+// @returns {Boolean}
+function _isArrowKeyCode( keyCode ) {
+	return keyCode == keyCodes.arrowright ||
+		keyCode == keyCodes.arrowleft ||
+		keyCode == keyCodes.arrowup ||
+		keyCode == keyCodes.arrowdown;
+}

--- a/src/view/observer/fakeselectionobserver.js
+++ b/src/view/observer/fakeselectionobserver.js
@@ -11,7 +11,7 @@ import { keyCodes } from '../../../utils/keyboard.js';
  * Fake selection observer class. If view selection is fake it is placed in dummy DOM container. This observer listens
  * on {@link engine.view.Document#keydown keydown} events and handles moving fake view selection to the correct place
  * if arrow keys are pressed.
- * Fires {@link engine.view.Document#selectionChage selectionChage event} simulating natural behaviour of
+ * Fires {@link engine.view.Document#selectionChage selectionChange event} simulating natural behaviour of
  * {@link engine.view.observer.SelectionObserver SelectionObserver}.
  *
  * @memberOf engine.view.observer
@@ -25,11 +25,18 @@ export default class FakeSelectionObserver extends Observer {
 	 */
 	constructor( document ) {
 		super( document );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	observe() {
+		const document = this.document;
 
 		document.on( 'keydown', ( eventInfo, data ) => {
 			const selection = document.selection;
 
-			if ( selection.isFake && _isArrowKeyCode( data.keyCode ) ) {
+			if ( selection.isFake && _isArrowKeyCode( data.keyCode ) && this.isEnabled ) {
 				// Prevents default key down handling - no selection change will occur.
 				data.preventDefault();
 
@@ -37,11 +44,6 @@ export default class FakeSelectionObserver extends Observer {
 			}
 		}, { priority: 'lowest' } );
 	}
-
-	/**
-	 * @inheritDoc
-	 */
-	observe() {}
 
 	/**
 	 * Handles collapsing view selection according to given key code. If left or up key is provided - new selection will be

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -124,7 +124,6 @@ export default class SelectionObserver extends Observer {
 		// If there were mutations then the view will be re-rendered by the mutation observer and selection
 		// will be updated, so selections will equal and event will not be fired, as expected.
 		const domSelection = domDocument.defaultView.getSelection();
-
 		const newViewSelection = this.domConverter.domSelectionToView( domSelection );
 
 		if ( this.selection.isEqual( newViewSelection ) ) {

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -466,7 +466,7 @@ export default class Renderer {
 			this._fakeSelectionContainer = domDocument.createElement( 'div' );
 			this._fakeSelectionContainer.style.position = 'fixed';
 			this._fakeSelectionContainer.style.top = 0;
-			this._fakeSelectionContainer.style.left = '-1000px';
+			this._fakeSelectionContainer.style.left = '-9999px';
 		}
 
 		// Add fake container if not already added.

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -462,30 +462,22 @@ export default class Renderer {
 		const domDocument = domRoot.ownerDocument;
 
 		// Create fake selection container if one does not exist.
-		if ( this._fakeSelectionContainer === null ) {
+		if ( !this._fakeSelectionContainer ) {
 			this._fakeSelectionContainer = domDocument.createElement( 'div' );
 			this._fakeSelectionContainer.style.position = 'fixed';
 			this._fakeSelectionContainer.style.top = 0;
 			this._fakeSelectionContainer.style.left = '-9999px';
+			this._fakeSelectionContainer.appendChild( domDocument.createTextNode( '\u00A0' ) );
 		}
 
 		// Add fake container if not already added.
-		if ( this._fakeSelectionContainer.parentElement === null ) {
+		if ( !this._fakeSelectionContainer.parentElement ) {
 			domRoot.appendChild( this._fakeSelectionContainer );
 		}
 
 		// Update contents.
 		const content = this.selection.fakeSelectionLabel || '\u00A0';
-		const textNode = this._fakeSelectionContainer.firstChild;
-
-		if ( !textNode || content !== textNode.textContent ) {
-			if ( textNode ) {
-				this._fakeSelectionContainer.removeChild( textNode );
-			}
-
-			const newTextNode = domDocument.createTextNode( content );
-			this._fakeSelectionContainer.appendChild( newTextNode );
-		}
+		this._fakeSelectionContainer.firstChild.data = content;
 
 		// Update selection.
 		const domSelection = domDocument.getSelection();
@@ -552,9 +544,8 @@ export default class Renderer {
 	_removeFakeSelection() {
 		const container = this._fakeSelectionContainer;
 
-		if ( container !== null ) {
+		if ( container ) {
 			container.remove();
-			container.textContent = '';
 		}
 	}
 

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -450,6 +450,12 @@ export default class Renderer {
 		}
 	}
 
+	/**
+	 * Updates fake selection.
+	 *
+	 * @private
+	 * @param {HTMLElement} domRoot Valid DOM root where fake selection container should be added.
+	 */
 	_updateFakeSelection( domRoot ) {
 		const domDocument = domRoot.ownerDocument;
 
@@ -478,6 +484,12 @@ export default class Renderer {
 		domSelection.addRange( domRange );
 	}
 
+	/**
+	 * Updates DOM selection.
+	 *
+	 * @private
+	 * @param {HTMLElement} domRoot Valid DOM root where DOM selection should be rendered.
+	 */
 	_updateDomSelection( domRoot ) {
 		const domSelection = domRoot.ownerDocument.defaultView.getSelection();
 		const oldViewSelection = domSelection && this.domConverter.domSelectionToView( domSelection );
@@ -498,6 +510,11 @@ export default class Renderer {
 		domSelection.extend( focus.parent, focus.offset );
 	}
 
+	/**
+	 * Removes DOM selection.
+	 *
+	 * @private
+	 */
 	_removeDomSelection() {
 		for ( let doc of this.domDocuments ) {
 			const domSelection = doc.getSelection();
@@ -513,6 +530,11 @@ export default class Renderer {
 		}
 	}
 
+	/**
+	 * Removes fake selection.
+	 *
+	 * @private
+	 */
 	_removeFakeSelection() {
 		const container = this._fakeSelectionContainer;
 

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -464,10 +464,13 @@ export default class Renderer {
 		// Create fake selection container if one does not exist.
 		if ( this._fakeSelectionContainer === null ) {
 			this._fakeSelectionContainer = domDocument.createElement( 'div' );
+			this._fakeSelectionContainer.style.position = 'fixed';
+			this._fakeSelectionContainer.style.top = 0;
+			this._fakeSelectionContainer.style.left = '-1000px';
 		}
 
 		// Add fake container if not already added.
-		if (  this._fakeSelectionContainer.parentElement === null ) {
+		if ( this._fakeSelectionContainer.parentElement === null ) {
 			domRoot.appendChild( this._fakeSelectionContainer );
 		}
 
@@ -484,6 +487,9 @@ export default class Renderer {
 		const domRange = new Range();
 		domRange.selectNodeContents( this._fakeSelectionContainer );
 		domSelection.addRange( domRange );
+
+		// Bind fake selection container with current selection.
+		this.domConverter.bindFakeSelection( this._fakeSelectionContainer, this.selection );
 	}
 
 	/**

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -475,10 +475,16 @@ export default class Renderer {
 		}
 
 		// Update contents.
-		const content = this.selection.fakeSelectionLabel || '&nbsp;';
+		const content = this.selection.fakeSelectionLabel || '\u00A0';
+		const textNode = this._fakeSelectionContainer.firstChild;
 
-		if ( content !== this._fakeSelectionContainer.innerHTML ) {
-			this._fakeSelectionContainer.innerHTML = content;
+		if ( !textNode || content !== textNode.textContent ) {
+			if ( textNode ) {
+				this._fakeSelectionContainer.removeChild( textNode );
+			}
+
+			const newTextNode = domDocument.createTextNode( content );
+			this._fakeSelectionContainer.appendChild( newTextNode );
 		}
 
 		// Update selection.

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -15,6 +15,8 @@ import remove from '../../utils/dom/remove.js';
 import ObservableMixin from '../../utils/observablemixin.js';
 import CKEditorError from '../../utils/ckeditorerror.js';
 
+/* global Range */
+
 /**
  * Renderer updates DOM structure and selection, to make them a reflection of the view structure and selection.
  *
@@ -472,8 +474,8 @@ export default class Renderer {
 		// Update contents.
 		const content = this.selection.fakeSelectionLabel || '&nbsp;';
 
-		if ( content !== this._fakeSelectionContainer.textContent ) {
-			this._fakeSelectionContainer.textContent = content;
+		if ( content !== this._fakeSelectionContainer.innerHTML ) {
+			this._fakeSelectionContainer.innerHTML = content;
 		}
 
 		// Update selection.

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -64,8 +64,10 @@ export default class Selection {
 	}
 
 	/**
-	 * Sets this selection instance to be marked as `fake`. This means only that selection will not be rendered
-	 * as real selection.
+	 * Sets this selection instance to be marked as `fake`. A fake selection does not render as browser native selection
+	 * over selected elements and is hidden to the user. This way, no native selection UI artifacts are displayed to
+	 * the user and selection over elements can be represented in other way, for example by applying proper CSS class.
+	 *
 	 * Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM (and be
 	 * properly handled by screen readers).
 	 *
@@ -81,6 +83,7 @@ export default class Selection {
 	/**
 	 * Returns true if selection instance is marked as `fake`.
 	 *
+	 * @see {@link engine.view.Selection#setFake}
 	 * @returns {Boolean}
 	 */
 	get isFake() {
@@ -90,6 +93,7 @@ export default class Selection {
 	/**
 	 * Returns fake selection label.
 	 *
+	 * @see {@link engine.view.Selection#setFake}
 	 * @returns {String}
 	 */
 	get fakeSelectionLabel() {

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -45,6 +45,55 @@ export default class Selection {
 		 * @member {Boolean} engine.view.Selection#_lastRangeBackward
 		 */
 		this._lastRangeBackward = false;
+
+		/**
+		 * Specifies whether selection instance is fake.
+		 *
+		 * @private
+		 * @member {Boolean} engine.view.Selection#_isFake
+		 */
+		this._isFake = false;
+
+		/**
+		 * Fake selection's label.
+		 *
+		 * @private
+		 * @member {String} engine.view.Selection#_fakeSelectionLabel
+		 */
+		this._fakeSelectionLabel = '';
+	}
+
+	/**
+	 * Sets this selection instance to be marked as `fake`. This means only that selection will not be rendered
+	 * as real selection.
+	 * Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM (and be
+	 * properly handled by screen readers).
+	 *
+	 * @param {Boolean} [value=true] If set to true selection will be marked as `fake`.
+	 * @param {Object} [options] Additional options.
+	 * @param {String} [options.label=''] Fake selection label.
+	 */
+	setFake( value = true, options = {} ) {
+		this._isFake = value;
+		this._fakeSelectionLabel = value ? options.label || '' : '';
+	}
+
+	/**
+	 * Returns true if selection instance is marked as `fake`.
+	 *
+	 * @returns {Boolean}
+	 */
+	get isFake() {
+		return this._isFake;
+	}
+
+	/**
+	 * Returns fake selection label.
+	 *
+	 * @returns {String}
+	 */
+	get fakeSelectionLabel() {
+		return this._fakeSelectionLabel;
 	}
 
 	/**
@@ -239,6 +288,14 @@ export default class Selection {
 			return false;
 		}
 
+		if ( this.isFake != otherSelection.isFake ) {
+			return false;
+		}
+
+		if ( this.isFake && this.fakeSelectionLabel != otherSelection.fakeSelectionLabel ) {
+			return false;
+		}
+
 		for ( let i = 0; i < this.rangeCount; i++ ) {
 			if ( !this._ranges[ i ].isEqual( otherSelection._ranges[ i ] ) ) {
 				return false;
@@ -292,6 +349,9 @@ export default class Selection {
 	 * @param {engine.view.Selection} otherSelection
 	 */
 	setTo( otherSelection ) {
+		this._isFake = otherSelection._isFake;
+		this._fakeSelectionLabel = otherSelection._fakeSelectionLabel;
+
 		this.setRanges( otherSelection.getRanges(), otherSelection.isBackward );
 	}
 

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -78,6 +78,8 @@ export default class Selection {
 	setFake( value = true, options = {} ) {
 		this._isFake = value;
 		this._fakeSelectionLabel = value ? options.label || '' : '';
+
+		this.fire( 'change' );
 	}
 
 	/**

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -71,6 +71,7 @@ export default class Selection {
 	 * Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM (and be
 	 * properly handled by screen readers).
 	 *
+	 * @fires engine.view.Selection#change
 	 * @param {Boolean} [value=true] If set to true selection will be marked as `fake`.
 	 * @param {Object} [options] Additional options.
 	 * @param {String} [options.label=''] Fake selection label.

--- a/tests/conversion/model-selection-to-view-converters.js
+++ b/tests/conversion/model-selection-to-view-converters.js
@@ -21,7 +21,8 @@ import {
 	convertRangeSelection,
 	convertCollapsedSelection,
 	convertSelectionAttribute,
-	clearAttributes
+	clearAttributes,
+	clearFakeSelection
 } from '/ckeditor5/engine/conversion/model-selection-to-view-converters.js';
 
 import {
@@ -307,6 +308,17 @@ describe( 'clean-up', () => {
 
 			const viewString = stringifyView( viewRoot, viewSelection, { showType: false } );
 			expect( viewString ).to.equal( '<div>f{}oobar</div>' );
+		} );
+	} );
+
+	describe( 'clearFakeSelection', () => {
+		it( 'should clear fake selection', () => {
+			dispatcher.on( 'selection', clearFakeSelection() );
+			viewSelection.setFake( true );
+
+			dispatcher.convertSelection( modelSelection );
+
+			expect( viewSelection.isFake ).to.be.false;
 		} );
 	} );
 } );

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -12,6 +12,7 @@ import MutationObserver from '/ckeditor5/engine/view/observer/mutationobserver.j
 import SelectionObserver from '/ckeditor5/engine/view/observer/selectionobserver.js';
 import FocusObserver from '/ckeditor5/engine/view/observer/focusobserver.js';
 import KeyObserver from '/ckeditor5/engine/view/observer/keyobserver.js';
+import FakeSelectionObserver from '/ckeditor5/engine/view/observer/fakeselectionobserver.js';
 import Renderer from '/ckeditor5/engine/view/renderer.js';
 import ViewRange from '/ckeditor5/engine/view/range.js';
 import DomConverter from '/ckeditor5/engine/view/domconverter.js';
@@ -22,7 +23,7 @@ import log from '/ckeditor5/utils/log.js';
 testUtils.createSinonSandbox();
 
 describe( 'Document', () => {
-	const DEFAULT_OBSERVERS_COUNT = 4;
+	const DEFAULT_OBSERVERS_COUNT = 5;
 	let ObserverMock, ObserverMockGlobalCount, instantiated, enabled;
 
 	beforeEach( () => {
@@ -72,6 +73,7 @@ describe( 'Document', () => {
 			expect( viewDocument.getObserver( SelectionObserver ) ).to.be.instanceof( SelectionObserver );
 			expect( viewDocument.getObserver( FocusObserver ) ).to.be.instanceof( FocusObserver );
 			expect( viewDocument.getObserver( KeyObserver ) ).to.be.instanceof( KeyObserver );
+			expect( viewDocument.getObserver( FakeSelectionObserver ) ).to.be.instanceof( FakeSelectionObserver );
 		} );
 	} );
 

--- a/tests/view/domconverter/binding.js
+++ b/tests/view/domconverter/binding.js
@@ -7,6 +7,8 @@
 /* bender-tags: view, domconverter, browser-only */
 
 import ViewElement from '/ckeditor5/engine/view/element.js';
+import ViewSelection from '/ckeditor5/engine/view/selection.js';
+import ViewRange from '/ckeditor5/engine/view/range.js';
 import DomConverter from '/ckeditor5/engine/view/domconverter.js';
 import ViewDocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
 import { INLINE_FILLER } from '/ckeditor5/engine/view/filler.js';
@@ -332,6 +334,36 @@ describe( 'DomConverter', () => {
 			const viewText = converter.domToView( domText );
 
 			expect( converter.getCorrespondingDomText( viewText ) ).to.be.null;
+		} );
+	} );
+
+	describe( 'bindFakeSelection', () => {
+		let domEl, selection, viewElement;
+
+		beforeEach( () => {
+			viewElement = new ViewElement();
+			domEl = document.createElement( 'div' );
+			selection = new ViewSelection();
+			selection.addRange( ViewRange.createIn( viewElement ) );
+			converter.bindFakeSelection( domEl, selection );
+		} );
+
+		it( 'should bind DOM element to selection', () => {
+			const bindSelection = converter.fakeSelectionToView( domEl );
+			expect( bindSelection ).to.be.defined;
+			expect( bindSelection.isEqual( selection ) ).to.be.true;
+		} );
+
+		it( 'should keep a copy of selection', () => {
+			const selectionCopy = ViewSelection.createFromSelection( selection );
+
+			selection.addRange( ViewRange.createIn( new ViewElement() ), true );
+			const bindSelection = converter.fakeSelectionToView( domEl );
+
+			expect( bindSelection ).to.be.defined;
+			expect( bindSelection ).to.not.equal( selection );
+			expect( bindSelection.isEqual( selection ) ).to.be.false;
+			expect( bindSelection.isEqual( selectionCopy ) ).to.be.true;
 		} );
 	} );
 } );

--- a/tests/view/domconverter/dom-to-view.js
+++ b/tests/view/domconverter/dom-to-view.js
@@ -675,5 +675,25 @@ describe( 'DomConverter', () => {
 
 			expect( bindViewSelection.isEqual( viewSelection ) ).to.be.true;
 		} );
+
+		it( 'should return fake selection if selection is placed inside text node', () => {
+			const domContainer = document.createElement( 'div' );
+			const domSelection = document.getSelection();
+			domContainer.innerHTML = 'fake selection container';
+			document.body.appendChild( domContainer );
+
+			const viewSelection = new ViewSelection();
+			viewSelection.addRange( ViewRange.createIn( new ViewElement() ) );
+			converter.bindFakeSelection( domContainer, viewSelection );
+
+			const domRange = new Range();
+			domRange.selectNodeContents( domContainer.firstChild );
+			domSelection.removeAllRanges();
+			domSelection.addRange( domRange );
+
+			const bindViewSelection = converter.domSelectionToView( domSelection );
+
+			expect( bindViewSelection.isEqual( viewSelection ) ).to.be.true;
+		} );
 	} );
 } );

--- a/tests/view/domconverter/dom-to-view.js
+++ b/tests/view/domconverter/dom-to-view.js
@@ -7,6 +7,8 @@
 /* bender-tags: view, domconverter, browser-only */
 
 import ViewElement from '/ckeditor5/engine/view/element.js';
+import ViewRange from '/ckeditor5/engine/view/range.js';
+import ViewSelection from '/ckeditor5/engine/view/selection.js';
 import DomConverter from '/ckeditor5/engine/view/domconverter.js';
 import ViewDocumentFragment from '/ckeditor5/engine/view/documentfragment.js';
 import { INLINE_FILLER, INLINE_FILLER_LENGTH, NBSP_FILLER } from '/ckeditor5/engine/view/filler.js';
@@ -652,6 +654,26 @@ describe( 'DomConverter', () => {
 			const viewSelection = converter.domSelectionToView( domSelection );
 
 			expect( viewSelection.rangeCount ).to.equal( 0 );
+		} );
+
+		it( 'should return fake selection', () => {
+			const domContainer = document.createElement( 'div' );
+			const domSelection = document.getSelection();
+			domContainer.innerHTML = 'fake selection container';
+			document.body.appendChild( domContainer );
+
+			const viewSelection = new ViewSelection();
+			viewSelection.addRange( ViewRange.createIn( new ViewElement() ) );
+			converter.bindFakeSelection( domContainer, viewSelection );
+
+			const domRange = new Range();
+			domRange.selectNodeContents( domContainer );
+			domSelection.removeAllRanges();
+			domSelection.addRange( domRange );
+
+			const bindViewSelection = converter.domSelectionToView( domSelection );
+
+			expect( bindViewSelection.isEqual( viewSelection ) ).to.be.true;
 		} );
 	} );
 } );

--- a/tests/view/manual/fakeselection.html
+++ b/tests/view/manual/fakeselection.html
@@ -3,6 +3,10 @@
 		padding: 5px;
 		border: solid 1px #000;
 	}
+
+	#editor strong {
+		cursor: pointer;
+	}
 </style>
 
 <p>Scroll down.</p>
@@ -11,7 +15,6 @@
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
 
 <div contenteditable="true" id="editor"></div>
-<button id="create-fake">Create fake selection over "bar"</button>
 
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/tests/view/manual/fakeselection.html
+++ b/tests/view/manual/fakeselection.html
@@ -7,6 +7,14 @@
 	#editor strong {
 		cursor: pointer;
 	}
+
+	#editor strong.selected {
+		background-color: #dadada;
+	}
+
+	#editor strong.selected.focused {
+		background-color: yellow;
+	}
 </style>
 
 <p>Scroll down.</p>

--- a/tests/view/manual/fakeselection.html
+++ b/tests/view/manual/fakeselection.html
@@ -1,2 +1,17 @@
+<style>
+	#editor {
+		padding: 5px;
+		border: solid 1px #000;
+	}
+</style>
+
+<p>Scroll down.</p>
+
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+
 <div contenteditable="true" id="editor"></div>
 <button id="create-fake">Create fake selection over "bar"</button>
+
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/tests/view/manual/fakeselection.html
+++ b/tests/view/manual/fakeselection.html
@@ -1,15 +1,2 @@
-<head>
-	<link rel="stylesheet" href="%APPS_DIR%ckeditor/build/modules/amd/theme/ckeditor.css">
-</head>
-
-<div id="editor">
-	<p> this is an <span>editor</span> instance <span>foo bar</span></p>
-	<img src="http://a.cksource.com/e/1/img/logo-ckeditor-h100.png" />
-	<p>some text after image and <span>two widgets</span><span>one after another</span> the end</p>
-	<p><span>only widget in block</span></p>
-	<p>another line</p>
-</div>
-
-<div style="height: 1500px; width: 1500px; background: #eee; outline: 2px dashed #ddd; margin: 1em 0; padding: 1em;">
-	* I'm a dummy div to enable scrolling in this test. *
-</div>
+<div contenteditable="true" id="editor"></div>
+<button id="create-fake">Create fake selection over "bar"</button>

--- a/tests/view/manual/fakeselection.html
+++ b/tests/view/manual/fakeselection.html
@@ -1,0 +1,15 @@
+<head>
+	<link rel="stylesheet" href="%APPS_DIR%ckeditor/build/modules/amd/theme/ckeditor.css">
+</head>
+
+<div id="editor">
+	<p> this is an <span>editor</span> instance <span>foo bar</span></p>
+	<img src="http://a.cksource.com/e/1/img/logo-ckeditor-h100.png" />
+	<p>some text after image and <span>two widgets</span><span>one after another</span> the end</p>
+	<p><span>only widget in block</span></p>
+	<p>another line</p>
+</div>
+
+<div style="height: 1500px; width: 1500px; background: #eee; outline: 2px dashed #ddd; margin: 1em 0; padding: 1em;">
+	* I'm a dummy div to enable scrolling in this test. *
+</div>

--- a/tests/view/manual/fakeselection.js
+++ b/tests/view/manual/fakeselection.js
@@ -28,8 +28,8 @@ viewDocument.selection.on( 'change', () => {
 	}
 } );
 
-viewDocument.on( 'click', ( info, domEvent ) => {
-	if ( domEvent.target == viewStrong ) {
+viewDocument.on( 'click', ( evt, data ) => {
+	if ( data.target == viewStrong ) {
 		const range = ViewRange.createOn( viewStrong );
 		viewDocument.selection.setRanges( [ range ] );
 		viewDocument.selection.setFake( true, { label: 'fake selection over bar' } );

--- a/tests/view/manual/fakeselection.js
+++ b/tests/view/manual/fakeselection.js
@@ -1,196 +1,39 @@
 /**
- * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md.
  */
 
-/* globals console:false, document, window */
+/* globals document */
 
-import ClassicEditor from '/ckeditor5/editor-classic/classic.js';
-import testUtils from '/tests/utils/_utils/utils.js';
-import Feature from '/ckeditor5/core/feature.js';
-import buildModelConverter from '/ckeditor5/engine/conversion/buildmodelconverter.js';
-import buildViewConverter from '/ckeditor5/engine/conversion/buildviewconverter.js';
-import ViewContainerElement from '/ckeditor5/engine/view/containerelement.js';
+import ViewDocument from '/ckeditor5/engine/view/document.js';
 import ViewRange from '/ckeditor5/engine/view/range.js';
-import ModelElement from '/ckeditor5/engine/model/element.js';
-import ModelRange from '/ckeditor5/engine/model/range.js';
-import ModelLiveRange from '/ckeditor5/engine/model/liverange.js';
-import ClickObserver from '/ckeditor5/engine/view/observer/clickobserver.js';
+import { setData } from '/ckeditor5/engine/dev-utils/view.js';
 
-let editor, editable, observer;
+const viewDocument = new ViewDocument();
+const domEditable = document.getElementById( 'editor' );
+const viewRoot = viewDocument.createRoot( domEditable );
+let viewStrong;
 
-class Test extends Feature {
-	/**
-	 * @inheritDoc
-	 */
-	init() {
-		const editor = this.editor;
-		const data = editor.data;
-		const editing = editor.editing;
-		const view  = editing.view;
-		const document = editor.document;
-		const selected = new Set();
+document.getElementById( 'create-fake' ).addEventListener( 'click', () => {
+	const viewP = viewRoot.getChild( 0 );
+	viewStrong = viewP.getChild( 1 );
+	const range = ViewRange.createOn( viewStrong );
+	viewDocument.selection.setRanges( [ range ] );
+	viewDocument.selection.setFake( true, { label: 'fake selection over bar' } );
+	viewStrong.setStyle( 'background-color', 'yellow' );
+	viewDocument.focus();
+} );
 
-		// Handle clicks on view elements.
-		view.addObserver( ClickObserver );
-		editor.editing.view.on( 'click', ( eventInfo, domEventData ) => {
-			const target = domEventData.target;
+viewDocument.on( 'selectionChange', ( evt, data ) => {
+	viewDocument.selection.setTo( data.newSelection );
+	viewDocument.render();
+} );
 
-			if ( target.name == 'span' ) {
-				const viewRange = ViewRange.createOn( target );
-				const modelRange = ModelLiveRange.createFromRange( editing.mapper.toModelRange( viewRange ) );
-
-				// Put selection around span element.
-				// TODO: Do we need this inside enq changes? Batch needed?
-				document.enqueueChanges( ( ) => {
-					document.selection.setRanges( [ modelRange ] );
-				} );
-			}
-		} );
-
-		// Handle selection conversion.
-		editing.modelToView.on( 'selection', ( evt, data, consumable, conversionApi ) => {
-			const viewSelection = conversionApi.viewSelection;
-			const range = data.selection.getFirstRange();
-			const nodeAfterStart = range.start.nodeAfter;
-
-			// remove selection from all selected widgets
-			for ( let viewElement of selected ) {
-				viewElement.setStyle( 'border', '2px solid yellow' );
-			}
-
-			// This could be just one element instead of set.
-			selected.clear();
-
-			if ( !data.selection.isCollapsed && nodeAfterStart && nodeAfterStart.name == 'span' && ModelRange.createOn( nodeAfterStart ).isEqual( range ) ) {
-				viewSelection.setFake( true, { label: 'span fake selection' } );
-				const viewElement = conversionApi.mapper.toViewElement( nodeAfterStart );
-				viewElement.setStyle( 'border', '2px solid red' );
-				selected.add( viewElement );
-			}
-		}, { priority: 'low' } );
-
-		// Allow bold attribute on all inline nodes.
-		// document.schema.allow( { name: '$inline', attributes: [ 'span' ] } );
-		document.schema.registerItem( 'span', '$inline' );
-		document.schema.allow( { name: 'span', inside: '$block' } );
-
-		// Build converter from model to view for data and editing pipelines.
-		buildModelConverter().for( data.modelToView, editing.modelToView )
-			.fromElement( 'span' )
-			// .toElement( new ViewContainerElement( 'span' ) );
-			.toElement( () => {
-				const element = new ViewContainerElement( 'span', {
-					contenteditable: 'false',
-					style: 'background-color: yellow; color: black; border: 2px solid yellow;'
-				} );
-
-				return widgetize( element );
-			} );
-
-		// Build converter from view to model for data pipeline.
-		buildViewConverter().for( data.viewToModel )
-			.fromElement( 'span' )
-			.toElement( 'span' );
+viewDocument.selection.on( 'change', () => {
+	if ( viewStrong && !viewDocument.selection.isFake ) {
+		viewStrong.removeStyle( 'background-color' );
 	}
-}
+} );
 
-class BasicImage extends Feature {
-	/**
-	 * @inheritDoc
-	 */
-	init() {
-		const editor = this.editor;
-		const data = editor.data;
-		const editing = editor.editing;
-		const view  = editing.view;
-		const document = editor.document;
-		const selected = new Set();
-
-		// Handle clicks on view elements.
-		view.addObserver( ClickObserver );
-		editor.editing.view.on( 'click', ( eventInfo, domEventData ) => {
-			const target = domEventData.target;
-
-			if ( target.name == 'img' ) {
-				const viewRange = ViewRange.createOn( target );
-				const modelRange = ModelLiveRange.createFromRange( editing.mapper.toModelRange( viewRange ) );
-
-				document.enqueueChanges( ( ) => {
-					document.selection.setRanges( [ modelRange ] );
-				} );
-			}
-		} );
-
-		// Handle selection conversion.
-		editing.modelToView.on( 'selection', ( evt, data, consumable, conversionApi ) => {
-			const viewSelection = conversionApi.viewSelection;
-			const range = data.selection.getFirstRange();
-			const nodeAfterStart = range.start.nodeAfter;
-
-			// remove selection from all selected widgets
-			for ( let viewElement of selected ) {
-				viewElement.setStyle( 'border', '2px solid yellow' );
-			}
-
-			// This could be just one element instead of set.
-			selected.clear();
-
-			if ( !data.selection.isCollapsed && nodeAfterStart && nodeAfterStart.name == 'image' && ModelRange.createOn( nodeAfterStart ).isEqual( range ) ) {
-				viewSelection.setFake( true, { label: 'image fake selection' } );
-				const viewElement = conversionApi.mapper.toViewElement( nodeAfterStart );
-				viewElement.setStyle( 'border', '2px solid red' );
-				selected.add( viewElement );
-			}
-		}, { priority: 'low' } );
-
-		// Allow bold attribute on all inline nodes.
-		// document.schema.allow( { name: '$inline', attributes: [ 'span' ] } );
-		document.schema.registerItem( 'image', '$block' );
-		document.schema.allow( { name: 'image', attributes: [ 'src', 'alt' ] } );
-
-		// Build converter from model to view for data and editing pipelines.
-		buildModelConverter().for( data.modelToView, editing.modelToView )
-			.fromElement( 'image' )
-			.toElement( ( data ) => {
-				return widgetize( new ViewContainerElement( 'img', {
-					src: data.item.getAttribute( 'src' ),
-					alt: data.item.getAttribute( 'alt' ),
-					style: 'border: 2px solid yellow'
-				} ) );
-			} );
-
-		// Build converter from view to model for data pipeline.
-		buildViewConverter().for( data.viewToModel )
-			.fromElement( 'img' ).consuming( { name: true, attributes: [ 'src', 'alt' ] } )
-			.toElement( ( viewElement ) => new ModelElement( 'image', {
-				src: viewElement.getAttribute( 'src' ),
-				alt: viewElement.getAttribute( 'alt' )
-			} ) );
-	}
-}
-
-function initEditor() {
-	ClassicEditor.create( document.querySelector( '#editor' ), {
-		features: [ 'enter', 'typing', 'paragraph', 'undo', 'heading', Test, BasicImage ],
-		toolbar: [ 'headings' ]
-	} )
-		.then( newEditor => {
-			window.editor = editor = newEditor;
-			window.editable = editable = editor.editing.view.getRoot();
-
-			observer = testUtils.createObserver();
-			observer.observe( 'Editable', editable, [ 'isFocused' ] );
-		} )
-		.catch( err => {
-			console.error( err.stack );
-		} );
-}
-
-initEditor();
-
-function widgetize( element ) {
-	element.isWidget = true;
-
-	return element;
-}
+setData( viewDocument, '<container:p>{}foo<strong>bar</strong>baz</container:p>' );
+viewDocument.focus();

--- a/tests/view/manual/fakeselection.js
+++ b/tests/view/manual/fakeselection.js
@@ -1,0 +1,196 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console:false, document, window */
+
+import ClassicEditor from '/ckeditor5/editor-classic/classic.js';
+import testUtils from '/tests/utils/_utils/utils.js';
+import Feature from '/ckeditor5/core/feature.js';
+import buildModelConverter from '/ckeditor5/engine/conversion/buildmodelconverter.js';
+import buildViewConverter from '/ckeditor5/engine/conversion/buildviewconverter.js';
+import ViewContainerElement from '/ckeditor5/engine/view/containerelement.js';
+import ViewRange from '/ckeditor5/engine/view/range.js';
+import ModelElement from '/ckeditor5/engine/model/element.js';
+import ModelRange from '/ckeditor5/engine/model/range.js';
+import ModelLiveRange from '/ckeditor5/engine/model/liverange.js';
+import ClickObserver from '/ckeditor5/engine/view/observer/clickobserver.js';
+
+let editor, editable, observer;
+
+class Test extends Feature {
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		const editor = this.editor;
+		const data = editor.data;
+		const editing = editor.editing;
+		const view  = editing.view;
+		const document = editor.document;
+		const selected = new Set();
+
+		// Handle clicks on view elements.
+		view.addObserver( ClickObserver );
+		editor.editing.view.on( 'click', ( eventInfo, domEventData ) => {
+			const target = domEventData.target;
+
+			if ( target.name == 'span' ) {
+				const viewRange = ViewRange.createOn( target );
+				const modelRange = ModelLiveRange.createFromRange( editing.mapper.toModelRange( viewRange ) );
+
+				// Put selection around span element.
+				// TODO: Do we need this inside enq changes? Batch needed?
+				document.enqueueChanges( ( ) => {
+					document.selection.setRanges( [ modelRange ] );
+				} );
+			}
+		} );
+
+		// Handle selection conversion.
+		editing.modelToView.on( 'selection', ( evt, data, consumable, conversionApi ) => {
+			const viewSelection = conversionApi.viewSelection;
+			const range = data.selection.getFirstRange();
+			const nodeAfterStart = range.start.nodeAfter;
+
+			// remove selection from all selected widgets
+			for ( let viewElement of selected ) {
+				viewElement.setStyle( 'border', '2px solid yellow' );
+			}
+
+			// This could be just one element instead of set.
+			selected.clear();
+
+			if ( !data.selection.isCollapsed && nodeAfterStart && nodeAfterStart.name == 'span' && ModelRange.createOn( nodeAfterStart ).isEqual( range ) ) {
+				viewSelection.setFake( true, { label: 'span fake selection' } );
+				const viewElement = conversionApi.mapper.toViewElement( nodeAfterStart );
+				viewElement.setStyle( 'border', '2px solid red' );
+				selected.add( viewElement );
+			}
+		}, { priority: 'low' } );
+
+		// Allow bold attribute on all inline nodes.
+		// document.schema.allow( { name: '$inline', attributes: [ 'span' ] } );
+		document.schema.registerItem( 'span', '$inline' );
+		document.schema.allow( { name: 'span', inside: '$block' } );
+
+		// Build converter from model to view for data and editing pipelines.
+		buildModelConverter().for( data.modelToView, editing.modelToView )
+			.fromElement( 'span' )
+			// .toElement( new ViewContainerElement( 'span' ) );
+			.toElement( () => {
+				const element = new ViewContainerElement( 'span', {
+					contenteditable: 'false',
+					style: 'background-color: yellow; color: black; border: 2px solid yellow;'
+				} );
+
+				return widgetize( element );
+			} );
+
+		// Build converter from view to model for data pipeline.
+		buildViewConverter().for( data.viewToModel )
+			.fromElement( 'span' )
+			.toElement( 'span' );
+	}
+}
+
+class BasicImage extends Feature {
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		const editor = this.editor;
+		const data = editor.data;
+		const editing = editor.editing;
+		const view  = editing.view;
+		const document = editor.document;
+		const selected = new Set();
+
+		// Handle clicks on view elements.
+		view.addObserver( ClickObserver );
+		editor.editing.view.on( 'click', ( eventInfo, domEventData ) => {
+			const target = domEventData.target;
+
+			if ( target.name == 'img' ) {
+				const viewRange = ViewRange.createOn( target );
+				const modelRange = ModelLiveRange.createFromRange( editing.mapper.toModelRange( viewRange ) );
+
+				document.enqueueChanges( ( ) => {
+					document.selection.setRanges( [ modelRange ] );
+				} );
+			}
+		} );
+
+		// Handle selection conversion.
+		editing.modelToView.on( 'selection', ( evt, data, consumable, conversionApi ) => {
+			const viewSelection = conversionApi.viewSelection;
+			const range = data.selection.getFirstRange();
+			const nodeAfterStart = range.start.nodeAfter;
+
+			// remove selection from all selected widgets
+			for ( let viewElement of selected ) {
+				viewElement.setStyle( 'border', '2px solid yellow' );
+			}
+
+			// This could be just one element instead of set.
+			selected.clear();
+
+			if ( !data.selection.isCollapsed && nodeAfterStart && nodeAfterStart.name == 'image' && ModelRange.createOn( nodeAfterStart ).isEqual( range ) ) {
+				viewSelection.setFake( true, { label: 'image fake selection' } );
+				const viewElement = conversionApi.mapper.toViewElement( nodeAfterStart );
+				viewElement.setStyle( 'border', '2px solid red' );
+				selected.add( viewElement );
+			}
+		}, { priority: 'low' } );
+
+		// Allow bold attribute on all inline nodes.
+		// document.schema.allow( { name: '$inline', attributes: [ 'span' ] } );
+		document.schema.registerItem( 'image', '$block' );
+		document.schema.allow( { name: 'image', attributes: [ 'src', 'alt' ] } );
+
+		// Build converter from model to view for data and editing pipelines.
+		buildModelConverter().for( data.modelToView, editing.modelToView )
+			.fromElement( 'image' )
+			.toElement( ( data ) => {
+				return widgetize( new ViewContainerElement( 'img', {
+					src: data.item.getAttribute( 'src' ),
+					alt: data.item.getAttribute( 'alt' ),
+					style: 'border: 2px solid yellow'
+				} ) );
+			} );
+
+		// Build converter from view to model for data pipeline.
+		buildViewConverter().for( data.viewToModel )
+			.fromElement( 'img' ).consuming( { name: true, attributes: [ 'src', 'alt' ] } )
+			.toElement( ( viewElement ) => new ModelElement( 'image', {
+				src: viewElement.getAttribute( 'src' ),
+				alt: viewElement.getAttribute( 'alt' )
+			} ) );
+	}
+}
+
+function initEditor() {
+	ClassicEditor.create( document.querySelector( '#editor' ), {
+		features: [ 'enter', 'typing', 'paragraph', 'undo', 'heading', Test, BasicImage ],
+		toolbar: [ 'headings' ]
+	} )
+		.then( newEditor => {
+			window.editor = editor = newEditor;
+			window.editable = editable = editor.editing.view.getRoot();
+
+			observer = testUtils.createObserver();
+			observer.observe( 'Editable', editable, [ 'isFocused' ] );
+		} )
+		.catch( err => {
+			console.error( err.stack );
+		} );
+}
+
+initEditor();
+
+function widgetize( element ) {
+	element.isWidget = true;
+
+	return element;
+}

--- a/tests/view/manual/fakeselection.js
+++ b/tests/view/manual/fakeselection.js
@@ -6,6 +6,7 @@
 /* globals document, console */
 
 import ViewDocument from '/ckeditor5/engine/view/document.js';
+import ClickObserver from '/ckeditor5/engine/view/observer/clickobserver.js';
 import ViewRange from '/ckeditor5/engine/view/range.js';
 import { setData } from '/ckeditor5/engine/dev-utils/view.js';
 
@@ -14,20 +15,7 @@ const domEditable = document.getElementById( 'editor' );
 const viewRoot = viewDocument.createRoot( domEditable );
 let viewStrong;
 
-// Prevent focus stealing. Simulates how editor buttons work.
-document.getElementById( 'create-fake' ).addEventListener( 'mousedown', ( evt ) => {
-	evt.preventDefault();
-} );
-
-document.getElementById( 'create-fake' ).addEventListener( 'click', () => {
-	const viewP = viewRoot.getChild( 0 );
-	viewStrong = viewP.getChild( 1 );
-
-	const range = ViewRange.createOn( viewStrong );
-	viewDocument.selection.setRanges( [ range ] );
-	viewDocument.selection.setFake( true, { label: 'fake selection over bar' } );
-	viewStrong.setStyle( 'background-color', 'yellow' );
-} );
+viewDocument.addObserver( ClickObserver );
 
 viewDocument.on( 'selectionChange', ( evt, data ) => {
 	viewDocument.selection.setTo( data.newSelection );
@@ -40,6 +28,17 @@ viewDocument.selection.on( 'change', () => {
 	}
 } );
 
+viewDocument.on( 'click', ( info, domEvent ) => {
+	if ( domEvent.target == viewStrong ) {
+		const range = ViewRange.createOn( viewStrong );
+		viewDocument.selection.setRanges( [ range ] );
+		viewDocument.selection.setFake( true, { label: 'fake selection over bar' } );
+		viewStrong.setStyle( 'background-color', 'yellow' );
+
+		viewDocument.render();
+	}
+} );
+
 viewDocument.on( 'focus', () => {
 	console.log( 'The document was focused' );
 } );
@@ -48,5 +47,8 @@ viewDocument.on( 'blur', () => {
 	console.log( 'The document was blurred' );
 } );
 
-setData( viewDocument, '<container:p>{}foo<strong>bar</strong>baz</container:p>' );
+setData( viewDocument, '<container:p>{}foo<strong contenteditable="false">bar</strong>baz</container:p>' );
+const viewP = viewRoot.getChild( 0 );
+viewStrong = viewP.getChild( 1 );
+
 viewDocument.focus();

--- a/tests/view/manual/fakeselection.js
+++ b/tests/view/manual/fakeselection.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document */
+/* globals document, console */
 
 import ViewDocument from '/ckeditor5/engine/view/document.js';
 import ViewRange from '/ckeditor5/engine/view/range.js';
@@ -14,14 +14,19 @@ const domEditable = document.getElementById( 'editor' );
 const viewRoot = viewDocument.createRoot( domEditable );
 let viewStrong;
 
+// Prevent focus stealing. Simulates how editor buttons work.
+document.getElementById( 'create-fake' ).addEventListener( 'mousedown', ( evt ) => {
+	evt.preventDefault();
+} );
+
 document.getElementById( 'create-fake' ).addEventListener( 'click', () => {
 	const viewP = viewRoot.getChild( 0 );
 	viewStrong = viewP.getChild( 1 );
+
 	const range = ViewRange.createOn( viewStrong );
 	viewDocument.selection.setRanges( [ range ] );
 	viewDocument.selection.setFake( true, { label: 'fake selection over bar' } );
 	viewStrong.setStyle( 'background-color', 'yellow' );
-	viewDocument.focus();
 } );
 
 viewDocument.on( 'selectionChange', ( evt, data ) => {
@@ -33,6 +38,14 @@ viewDocument.selection.on( 'change', () => {
 	if ( viewStrong && !viewDocument.selection.isFake ) {
 		viewStrong.removeStyle( 'background-color' );
 	}
+} );
+
+viewDocument.on( 'focus', () => {
+	console.log( 'The document was focused' );
+} );
+
+viewDocument.on( 'blur', () => {
+	console.log( 'The document was blurred' );
 } );
 
 setData( viewDocument, '<container:p>{}foo<strong>bar</strong>baz</container:p>' );

--- a/tests/view/manual/fakeselection.js
+++ b/tests/view/manual/fakeselection.js
@@ -6,7 +6,7 @@
 /* globals document, console */
 
 import ViewDocument from '/ckeditor5/engine/view/document.js';
-import ClickObserver from '/ckeditor5/engine/view/observer/clickobserver.js';
+import DomEventObserver from '/ckeditor5/engine/view/observer/domeventobserver.js';
 import ViewRange from '/ckeditor5/engine/view/range.js';
 import { setData } from '/ckeditor5/engine/dev-utils/view.js';
 
@@ -15,36 +15,57 @@ const domEditable = document.getElementById( 'editor' );
 const viewRoot = viewDocument.createRoot( domEditable );
 let viewStrong;
 
-viewDocument.addObserver( ClickObserver );
+// Add mouseup oberver.
+viewDocument.addObserver( class extends DomEventObserver {
+	get domEventType() {
+		return [ 'mousedown', 'mouseup' ];
+	}
+
+	onDomEvent( domEvent ) {
+		this.fire( domEvent.type, domEvent );
+	}
+} );
 
 viewDocument.on( 'selectionChange', ( evt, data ) => {
 	viewDocument.selection.setTo( data.newSelection );
 	viewDocument.render();
 } );
 
+viewDocument.on( 'mouseup', ( evt, data ) => {
+	if ( data.target == viewStrong ) {
+		console.log( 'Making selection around the <strong>.' );
+
+		const range = ViewRange.createOn( viewStrong );
+		viewDocument.selection.setRanges( [ range ] );
+		viewDocument.selection.setFake( true, { label: 'fake selection over bar' } );
+
+		viewDocument.render();
+
+		data.preventDefault();
+	}
+} );
+
 viewDocument.selection.on( 'change', () => {
-	if ( viewStrong && !viewDocument.selection.isFake ) {
+	if ( !viewStrong ) {
+		return;
+	}
+
+	const firstPos = viewDocument.selection.getFirstPosition();
+	const lastPos = viewDocument.selection.getLastPosition();
+
+	if ( firstPos && lastPos && firstPos.nodeAfter == viewStrong && lastPos.nodeBefore == viewStrong ) {
+		viewStrong.setStyle( 'background-color', 'yellow' );
+	} else {
 		viewStrong.removeStyle( 'background-color' );
 	}
 } );
 
-viewDocument.on( 'click', ( evt, data ) => {
-	if ( data.target == viewStrong ) {
-		const range = ViewRange.createOn( viewStrong );
-		viewDocument.selection.setRanges( [ range ] );
-		viewDocument.selection.setFake( true, { label: 'fake selection over bar' } );
-		viewStrong.setStyle( 'background-color', 'yellow' );
-
-		viewDocument.render();
-	}
-} );
-
 viewDocument.on( 'focus', () => {
-	console.log( 'The document was focused' );
+	console.log( 'The document was focused.' );
 } );
 
 viewDocument.on( 'blur', () => {
-	console.log( 'The document was blurred' );
+	console.log( 'The document was blurred.' );
 } );
 
 setData( viewDocument, '<container:p>{}foo<strong contenteditable="false">bar</strong>baz</container:p>' );

--- a/tests/view/manual/fakeselection.js
+++ b/tests/view/manual/fakeselection.js
@@ -54,17 +54,23 @@ viewDocument.selection.on( 'change', () => {
 	const lastPos = viewDocument.selection.getLastPosition();
 
 	if ( firstPos && lastPos && firstPos.nodeAfter == viewStrong && lastPos.nodeBefore == viewStrong ) {
-		viewStrong.setStyle( 'background-color', 'yellow' );
+		viewStrong.addClass( 'selected' );
 	} else {
-		viewStrong.removeStyle( 'background-color' );
+		viewStrong.removeClass( 'selected' );
 	}
 } );
 
 viewDocument.on( 'focus', () => {
+	viewStrong.addClass( 'focused' );
+	viewDocument.render();
+
 	console.log( 'The document was focused.' );
 } );
 
 viewDocument.on( 'blur', () => {
+	viewStrong.removeClass( 'focused' );
+	viewDocument.render();
+
 	console.log( 'The document was blurred.' );
 } );
 

--- a/tests/view/manual/fakeselection.md
+++ b/tests/view/manual/fakeselection.md
@@ -2,9 +2,14 @@
 @bender-tags: view
 
 ## Fake selection
+
 1. Click button to create fake selection over `bar` before each of following steps:
-   1. Press left arrow key - collapsed selection should appear before `bar`
-   1. Press up arrow key - collapsed selection should appear before `bar`
-   1. Press right arrow key - collapsed selection should appear after `bar`
-   1. Press down arrow key - collapsed selection should appear after `bar`
+   1. Press left/up arrow key - collapsed selection should appear before `bar`
+   1. Press right/down arrow key - collapsed selection should appear after `bar`
 1. Open console and check if `<div style="position: fixed; top: 0px; left: -1000px;">fake selection over bar</div>` is added to editable when fake selection is present. It should be removed when fake selection is not present.
+
+Notes:
+
+* Focus shouldn't disappear from the editable element.
+* No #blur event should be logged on the console.
+* The viewport shouldn't scroll when selecting the `bar`.

--- a/tests/view/manual/fakeselection.md
+++ b/tests/view/manual/fakeselection.md
@@ -1,0 +1,4 @@
+@bender-ui: collapsed
+@bender-tags: view
+
+## Fake selection

--- a/tests/view/manual/fakeselection.md
+++ b/tests/view/manual/fakeselection.md
@@ -3,10 +3,10 @@
 
 ## Fake selection
 
-1. Click button to create fake selection over `bar` before each of following steps:
+1. Click on bold `bar` to create fake selection over it before each of following steps:
    1. Press left/up arrow key - collapsed selection should appear before `bar`
    1. Press right/down arrow key - collapsed selection should appear after `bar`
-1. Open console and check if `<div style="position: fixed; top: 0px; left: -1000px;">fake selection over bar</div>` is added to editable when fake selection is present. It should be removed when fake selection is not present.
+1. Open console and check if `<div style="position: fixed; top: 0px; left: -9999px;">fake selection over bar</div>` is added to editable when fake selection is present. It should be removed when fake selection is not present.
 
 Notes:
 

--- a/tests/view/manual/fakeselection.md
+++ b/tests/view/manual/fakeselection.md
@@ -3,13 +3,21 @@
 
 ## Fake selection
 
-1. Click on bold `bar` to create fake selection over it before each of following steps:
-   1. Press left/up arrow key - collapsed selection should appear before `bar`
-   1. Press right/down arrow key - collapsed selection should appear after `bar`
-1. Open console and check if `<div style="position: fixed; top: 0px; left: -9999px;">fake selection over bar</div>` is added to editable when fake selection is present. It should be removed when fake selection is not present.
+Click on bold `bar` to create fake selection over it before each of following steps:
+   * Press left/up arrow key - collapsed selection should appear before `bar`
+   * Press right/down arrow key - collapsed selection should appear after `bar`
 
 Notes:
 
-* Focus shouldn't disappear from the editable element.
-* No #blur event should be logged on the console.
-* The viewport shouldn't scroll when selecting the `bar`.
+- Focus shouldn't disappear from the editable element.
+- No #blur event should be logged on the console.
+- The viewport shouldn't scroll when selecting the `bar`.
+
+-----
+
+Open console and check if `<div style="position: fixed; top: 0px; left: -9999px;">fake selection over bar</div>` is added to editable when fake selection is present. It should be removed when fake selection is not present.
+
+-----
+
+Click on bold `bar` to create fake selection over it. Click outside editable and check if yellow fake selection turns to gray one.
+

--- a/tests/view/manual/fakeselection.md
+++ b/tests/view/manual/fakeselection.md
@@ -2,3 +2,9 @@
 @bender-tags: view
 
 ## Fake selection
+1. Click button to create fake selection over `bar` before each of following steps:
+   1. Press left arrow key - collapsed selection should appear before `bar`
+   1. Press up arrow key - collapsed selection should appear before `bar`
+   1. Press right arrow key - collapsed selection should appear after `bar`
+   1. Press down arrow key - collapsed selection should appear after `bar`
+1. Open console and check if `<div style="position: fixed; top: 0px; left: -1000px;">fake selection over bar</div>` is added to editable when fake selection is present. It should be removed when fake selection is not present.

--- a/tests/view/observer/fakeselectionobserver.js
+++ b/tests/view/observer/fakeselectionobserver.js
@@ -1,0 +1,136 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals document */
+
+import FakeSelectionObserver from '/ckeditor5/engine/view/observer/fakeselectionobserver.js';
+import ViewDocument from '/ckeditor5/engine/view/document.js';
+import DomEventData from '/ckeditor5/engine/view/observer/domeventdata.js';
+import { keyCodes } from '/ckeditor5/utils/keyboard.js';
+import { setData, stringify } from '/ckeditor5/engine/dev-utils/view.js';
+
+describe( 'FakeSelectionObserver', () => {
+	let observer;
+	let viewDocument;
+	let root;
+
+	beforeEach( () => {
+		viewDocument = new ViewDocument();
+		root = viewDocument.createRoot( document.getElementById( 'main' ) );
+		observer = viewDocument.getObserver( FakeSelectionObserver );
+		viewDocument.selection.setFake();
+	} );
+
+	it( 'should do nothing if selection is not fake', () => {
+		viewDocument.selection.setFake( false );
+
+		return checkEventPrevention( keyCodes.arrowleft, false );
+	} );
+
+	it( 'should do nothing if is disabled', () => {
+		observer.disable();
+
+		return checkEventPrevention( keyCodes.arrowleft, false );
+	} );
+
+	it( 'should prevent default for left arrow key', ( ) => {
+		return checkEventPrevention( keyCodes.arrowleft );
+	} );
+
+	it( 'should prevent default for right arrow key', ( ) => {
+		return checkEventPrevention( keyCodes.arrowright );
+	} );
+
+	it( 'should prevent default for up arrow key', ( ) => {
+		return checkEventPrevention( keyCodes.arrowup );
+	} );
+
+	it( 'should prevent default for down arrow key', ( ) => {
+		return checkEventPrevention( keyCodes.arrowdown );
+	} );
+
+	it( 'should fire selectionChange event with new selection when left arrow key is pressed', () => {
+		return checkSelectionChange(
+			'<container:p>foo[<strong>bar</strong>]baz</container:p>',
+			keyCodes.arrowleft,
+			'<container:p>foo[]<strong>bar</strong>baz</container:p>'
+		);
+	} );
+
+	it( 'should fire selectionChange event with new selection when right arrow key is pressed', () => {
+		return checkSelectionChange(
+			'<container:p>foo[<strong>bar</strong>]baz</container:p>',
+			keyCodes.arrowright,
+			'<container:p>foo<strong>bar</strong>[]baz</container:p>'
+		);
+	} );
+
+	it( 'should fire selectionChange event with new selection when up arrow key is pressed', () => {
+		return checkSelectionChange(
+			'<container:p>foo[<strong>bar</strong>]baz</container:p>',
+			keyCodes.arrowup,
+			'<container:p>foo[]<strong>bar</strong>baz</container:p>'
+		);
+	} );
+
+	it( 'should fire selectionChange event with new selection when down arrow key is pressed', () => {
+		return checkSelectionChange(
+			'<container:p>foo[<strong>bar</strong>]baz</container:p>',
+			keyCodes.arrowdown,
+			'<container:p>foo<strong>bar</strong>[]baz</container:p>'
+		);
+	} );
+
+	// Checks if preventDefault method was called by FakeSelectionObserver for specified key code.
+	//
+	// @param {Number} keyCode
+	// @param {Boolean} shouldPrevent If set to true method checks if event was prevented.
+	// @returns {Promise}
+	function checkEventPrevention( keyCode, shouldPrevent = true ) {
+		return new Promise( resolve => {
+			const data = {
+				keyCode,
+				preventDefault: sinon.spy(),
+			};
+
+			viewDocument.once( 'keydown', () => {
+				if ( shouldPrevent ) {
+					sinon.assert.calledOnce( data.preventDefault );
+				} else {
+					sinon.assert.notCalled( data.preventDefault );
+				}
+
+				resolve();
+			}, { priority: 'lowest' } );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, { target: document.body }, data ) );
+		} );
+	}
+
+	// Checks if proper selectionChange event is fired by FakeSelectionObserver for specified key.
+	//
+	// @param {String} initialData
+	// @param {Number} keyCode
+	// @param {String} output
+	// @returns {Promise}
+	function checkSelectionChange( initialData, keyCode, output ) {
+		return new Promise( resolve => {
+			viewDocument.once( 'selectionChange', ( eventInfo, data ) => {
+				expect( stringify( root.getChild( 0 ), data.newSelection, { showType: true } ) ).to.equal( output );
+				resolve();
+			} );
+
+			setData( viewDocument, initialData );
+			viewDocument.selection.setFake();
+
+			const data = {
+				keyCode,
+				preventDefault: sinon.spy(),
+			};
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, { target: document.body }, data ) );
+		} );
+	}
+} );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1027,7 +1027,7 @@ describe( 'Renderer', () => {
 				const container = domRoot.childNodes[ 1 ];
 				expect( container.childNodes.length ).to.equal( 1 );
 				const textNode = container.childNodes[ 0 ];
-				expect( container.innerHTML ).to.equal( '&nbsp;' );
+				expect( textNode.textContent ).to.equal( '\u00A0' );
 				const domSelection = domRoot.ownerDocument.getSelection();
 				expect( domSelection.anchorNode ).to.equal( textNode );
 				expect( domSelection.anchorOffset ).to.equal( 0 );
@@ -1070,7 +1070,9 @@ describe( 'Renderer', () => {
 				expect( domRoot.childNodes.length ).to.equal( 2 );
 				const newContainer = domRoot.childNodes[ 1 ];
 				expect( newContainer ).equals( container );
-				expect( newContainer.innerText ).to.equal( label );
+				expect( newContainer.childNodes.length ).to.equal( 1 );
+				const textNode = newContainer.childNodes[ 0 ];
+				expect( textNode.textContent ).to.equal( label );
 			} );
 
 			it( 'should reuse fake selection container #2', () => {
@@ -1091,7 +1093,27 @@ describe( 'Renderer', () => {
 				expect( domRoot.childNodes.length ).to.equal( 2 );
 				const newContainer = domRoot.childNodes[ 1 ];
 				expect( newContainer ).equals( container );
-				expect( newContainer.innerText ).to.equal( 'label 2' );
+				expect( newContainer.childNodes.length ).to.equal( 1 );
+				const textNode = newContainer.childNodes[ 0 ];
+				expect( textNode.textContent ).to.equal( 'label 2' );
+			} );
+
+			it( 'should reuse fake selection container #3', () => {
+				selection.setFake( true, { label: 'label 1' } );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 2 );
+				const container = domRoot.childNodes[ 1 ];
+
+				selection.setFake( true, { label: 'label 2' } );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 2 );
+				const newContainer = domRoot.childNodes[ 1 ];
+				expect( newContainer ).equals( container );
+				expect( newContainer.childNodes.length ).to.equal( 1 );
+				const textNode = newContainer.childNodes[ 0 ];
+				expect( textNode.textContent ).to.equal( 'label 2' );
 			} );
 
 			it( 'should style fake selection container properly', () => {

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1093,6 +1093,30 @@ describe( 'Renderer', () => {
 				expect( newContainer ).equals( container );
 				expect( newContainer.innerText ).to.equal( 'label 2' );
 			} );
+
+			it( 'should style fake selection container properly', () => {
+				selection.setFake( true, { label: 'fake selection' } );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 2 );
+				const container = domRoot.childNodes[ 1 ];
+
+				expect( container.style.position ).to.equal( 'fixed' );
+				expect( container.style.top ).to.equal( '0px' );
+				expect( container.style.left ).to.equal( '-1000px' );
+			} );
+
+			it( 'should bind fake selection container to view selection', () => {
+				selection.setFake( true, { label: 'fake selection' } );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 2 );
+				const container = domRoot.childNodes[ 1 ];
+
+				const bindSelection = renderer.domConverter.fakeSelectionToView( container );
+				expect( bindSelection ).to.be.defined;
+				expect( bindSelection.isEqual( selection ) ).to.be.true;
+			} );
 		} );
 	} );
 } );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1009,14 +1009,14 @@ describe( 'Renderer', () => {
 				expect( domRoot.childNodes.length ).to.equal( 2 );
 				const container = domRoot.childNodes[ 1 ];
 				expect( domConverter.getCorrespondingViewElement( container ) ).to.be.undefined;
-				expect( container.textContent ).to.equal( label );
+				expect( container.childNodes.length ).to.equal( 1 );
+				const textNode = container.childNodes[ 0 ];
+				expect( textNode.textContent ).to.equal( label );
 				const domSelection = domRoot.ownerDocument.getSelection();
-				expect( domSelection.rangeCount ).to.equal( 1 );
-				const domRange = domSelection.getRangeAt( 0 );
-				expect( domRange.startContainer ).to.equal( container );
-				expect( domRange.startOffset ).to.equal( 0 );
-				expect( domRange.endContainer ).to.equal( container );
-				expect( domRange.endOffset ).to.equal( 1 );
+				expect( domSelection.anchorNode ).to.equal( textNode );
+				expect( domSelection.anchorOffset ).to.equal( 0 );
+				expect( domSelection.focusNode ).to.equal( textNode );
+				expect( domSelection.focusOffset ).to.equal( label.length );
 			} );
 
 			it( 'should render &nbsp; if no selection label is provided', () => {
@@ -1025,14 +1025,14 @@ describe( 'Renderer', () => {
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
 				const container = domRoot.childNodes[ 1 ];
-				expect( container.textContent ).to.equal( '&nbsp;' );
+				expect( container.childNodes.length ).to.equal( 1 );
+				const textNode = container.childNodes[ 0 ];
+				expect( container.innerHTML ).to.equal( '&nbsp;' );
 				const domSelection = domRoot.ownerDocument.getSelection();
-				expect( domSelection.rangeCount ).to.equal( 1 );
-				const domRange = domSelection.getRangeAt( 0 );
-				expect( domRange.startContainer ).to.equal( container );
-				expect( domRange.startOffset ).to.equal( 0 );
-				expect( domRange.endContainer ).to.equal( container );
-				expect( domRange.endOffset ).to.equal( 1 );
+				expect( domSelection.anchorNode ).to.equal( textNode );
+				expect( domSelection.anchorOffset ).to.equal( 0 );
+				expect( domSelection.focusNode ).to.equal( textNode );
+				expect( domSelection.focusOffset ).to.equal( 1 );
 			} );
 
 			it( 'should remove fake selection container when selection is no longer fake', () => {
@@ -1044,14 +1044,15 @@ describe( 'Renderer', () => {
 
 				expect( domRoot.childNodes.length ).to.equal( 1 );
 				const domParagraph = domRoot.childNodes[ 0 ];
+				expect( domParagraph.childNodes.length ).to.equal( 1 );
+				const textNode = domParagraph.childNodes[ 0 ];
 				expect( domParagraph.tagName.toLowerCase() ).to.equal( 'p' );
 				const domSelection = domRoot.ownerDocument.getSelection();
-				expect( domSelection.rangeCount ).to.equal( 1 );
-				const domRange = domSelection.getRangeAt( 0 );
-				expect( domRange.startContainer ).to.equal( domParagraph );
-				expect( domRange.startOffset ).to.equal( 0 );
-				expect( domRange.endContainer ).to.equal( domParagraph );
-				expect( domRange.endOffset ).to.equal( 1 );
+
+				expect( domSelection.anchorNode ).to.equal( textNode );
+				expect( domSelection.anchorOffset ).to.equal( 0 );
+				expect( domSelection.focusNode ).to.equal( textNode );
+				expect( domSelection.focusOffset ).to.equal( 7 );
 			} );
 
 			it( 'should reuse fake selection container #1', () => {

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1103,7 +1103,7 @@ describe( 'Renderer', () => {
 
 				expect( container.style.position ).to.equal( 'fixed' );
 				expect( container.style.top ).to.equal( '0px' );
-				expect( container.style.left ).to.equal( '-1000px' );
+				expect( container.style.left ).to.equal( '-9999px' );
 			} );
 
 			it( 'should bind fake selection container to view selection', () => {

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1053,6 +1053,45 @@ describe( 'Renderer', () => {
 				expect( domRange.endContainer ).to.equal( domParagraph );
 				expect( domRange.endOffset ).to.equal( 1 );
 			} );
+
+			it( 'should reuse fake selection container #1', () => {
+				const label = 'fake selection label';
+
+				selection.setFake( true, { label } );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 2 );
+				const container = domRoot.childNodes[ 1 ];
+
+				selection.setFake( true, { label } );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 2 );
+				const newContainer = domRoot.childNodes[ 1 ];
+				expect( newContainer ).equals( container );
+				expect( newContainer.innerText ).to.equal( label );
+			} );
+
+			it( 'should reuse fake selection container #2', () => {
+				selection.setFake( true, { label: 'label 1' } );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 2 );
+				const container = domRoot.childNodes[ 1 ];
+
+				selection.setFake( false );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 1 );
+
+				selection.setFake( true, { label: 'label 2' } );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 2 );
+				const newContainer = domRoot.childNodes[ 1 ];
+				expect( newContainer ).equals( container );
+				expect( newContainer.innerText ).to.equal( 'label 2' );
+			} );
 		} );
 	} );
 } );

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -460,6 +460,33 @@ describe( 'Selection', () => {
 
 			expect( selection.isEqual( otherSelection ) ).to.be.false;
 		} );
+
+		it( 'should return false if one selection is fake', () => {
+			const otherSelection = new Selection();
+			otherSelection.setFake( true );
+
+			expect( selection.isEqual( otherSelection ) ).to.be.false;
+		} );
+
+		it( 'should return true if both selection are fake', () => {
+			const otherSelection = new Selection();
+			otherSelection.addRange( range1 );
+			otherSelection.setFake( true );
+			selection.setFake( true );
+			selection.addRange( range1 );
+
+			expect( selection.isEqual( otherSelection ) ).to.be.true;
+		} );
+
+		it( 'should return false if both selection are fake but have different label', () => {
+			const otherSelection = new Selection();
+			otherSelection.addRange( range1 );
+			otherSelection.setFake( true , { label: 'foo bar baz' } );
+			selection.setFake( true );
+			selection.addRange( range1 );
+
+			expect( selection.isEqual( otherSelection ) ).to.be.false;
+		} );
 	} );
 
 	describe( 'removeAllRanges', () => {
@@ -537,6 +564,16 @@ describe( 'Selection', () => {
 			otherSelection.addRange( range1 );
 
 			selection.setTo( otherSelection );
+		} );
+
+		it( 'should set fake state and label', () => {
+			const otherSelection = new Selection();
+			const label = 'foo bar baz';
+			otherSelection.setFake( true, { label } );
+			selection.setTo( otherSelection );
+
+			expect( selection.isFake ).to.be.true;
+			expect( selection.fakeSelectionLabel ).to.equal( label );
 		} );
 	} );
 
@@ -688,6 +725,42 @@ describe( 'Selection', () => {
 			for ( let i = 0; i < selectionRanges.length; i++ ) {
 				expect( selectionRanges[ i ].isEqual( snapshotRanges[ i ] ) ).to.be.true;
 			}
+		} );
+	} );
+
+	describe( 'isFake', () => {
+		it( 'should be false for newly created instance', () => {
+			expect( selection.isFake ).to.be.false;
+		} );
+	} );
+
+	describe( 'setFake', () => {
+		it( 'should allow to set selection to fake', () => {
+			selection.setFake( true );
+
+			expect( selection.isFake ).to.be.true;
+		} );
+
+		it( 'should allow to set fake selection label', () => {
+			const label = 'foo bar baz';
+			selection.setFake( true, { label } );
+
+			expect( selection.fakeSelectionLabel ).to.equal( label );
+		} );
+
+		it( 'should not set label when set to false', () => {
+			const label = 'foo bar baz';
+			selection.setFake( false, { label } );
+
+			expect( selection.fakeSelectionLabel ).to.equal( '' );
+		} );
+
+		it( 'should reset label when set to false', () => {
+			const label = 'foo bar baz';
+			selection.setFake( true, { label } );
+			selection.setFake( false );
+
+			expect( selection.fakeSelectionLabel ).to.equal( '' );
 		} );
 	} );
 } );

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -762,5 +762,16 @@ describe( 'Selection', () => {
 
 			expect( selection.fakeSelectionLabel ).to.equal( '' );
 		} );
+
+		it( 'should fire change event', ( done ) => {
+			selection.once( 'change', () => {
+				expect( selection.isFake ).to.be.true;
+				expect( selection.fakeSelectionLabel ).to.equal( 'foo bar baz' );
+
+				done();
+			} );
+
+			selection.setFake( true, { label: 'foo bar baz' } );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #627 
- added marking selection as fake in view selection,
- added fake selection rendering to view renderer,
- created `FakeSelectionObserver` with basic arrow keys handling when selection is fake,
- added `FakeSelectionObserver` to default view document observers,
- added mapping between DOM element and fake view selection to `DomConverter`,
- added `clearFakeSelection` converter to  `model-selection-to-view-converters.js`,
