### PR TITLE
Rewrote filler management logic in the Rendrer

### DIFF
--- a/src/model/position.js
+++ b/src/model/position.js
@@ -104,7 +104,7 @@ export default class Position {
 	}
 
 	/**
-	 * Offset at which this position is located in it's {@link engine.model.Position#parent parent}. It is equal
+	 * Offset at which this position is located in its {@link engine.model.Position#parent parent}. It is equal
 	 * to the last item in position {@link engine.model.Position#path path}.
 	 *
 	 * @type {Number}

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -486,7 +486,8 @@ export default class DomConverter {
 			} else {
 				const viewBefore = this.getCorrespondingView( domParent.childNodes[ domOffset - 1 ] );
 
-				if ( viewBefore ) {
+				// TODO #663
+				if ( viewBefore && viewBefore.parent ) {
 					return new ViewPosition( viewBefore.parent, viewBefore.index + 1 );
 				}
 			}

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -15,6 +15,8 @@ import remove from '../../utils/dom/remove.js';
 import ObservableMixin from '../../utils/observablemixin.js';
 import CKEditorError from '../../utils/ckeditorerror.js';
 
+import log from '../../utils/log.js';
+
 /* global Range */
 
 /**
@@ -188,7 +190,7 @@ export default class Renderer {
 		if ( this._inlineFiller ) {
 			inlineFillerPosition = this._getInlineFillerPosition();
 		}
-		// Othewise, if it's needed, set it at the selection position.
+		// Othewise, if it's needed, create it at the selection position.
 		else if ( this._needsInlineFillerAtSelection() ) {
 			inlineFillerPosition = this.selection.getFirstPosition();
 
@@ -229,8 +231,14 @@ export default class Renderer {
 
 		const domPosition = this.domConverter.viewPositionToDom( fillerPosition );
 
+		/* istanbul ignore if */
 		if ( !domPosition || !startsWithFiller( domPosition.parent ) ) {
-			throw new CKEditorError( 'view-renderer-cannot-find-filler' );
+			/**
+			 * Cannot find filler node by its position.
+			 *
+			 * @error view-renderer-cannot-find-filler
+			 */
+			log.error( 'view-renderer-cannot-find-filler: Cannot find filler node by its position.' );
 		}
 
 		this._inlineFiller = domPosition.parent;

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -296,7 +296,15 @@ export default class Renderer {
 		// "FILLER{}"
 		// "FILLERadded-text{}"
 
-		const { parent: domParent } = this.domConverter.viewPositionToDom( this.selection.getFirstPosition() );
+		const selectionPosition = this.selection.getFirstPosition();
+
+		// If we cannot convert this position's parent it means that selection is in not yet rendered
+		// node, which means that the filler can't be there.
+		if ( !this.domConverter.getCorrespondingDom( selectionPosition.parent ) ) {
+			return false;
+		}
+
+		const { parent: domParent } = this.domConverter.viewPositionToDom( selectionPosition );
 
 		if ( this.domConverter.isText( domParent ) && startsWithFiller( domParent ) ) {
 			return true;

--- a/tests/view/document/jumpoverinlinefiller.html
+++ b/tests/view/document/jumpoverinlinefiller.html
@@ -1,1 +1,0 @@
-<div contenteditable="true" id="editor"></div>

--- a/tests/view/document/jumpoverinlinefiller.js
+++ b/tests/view/document/jumpoverinlinefiller.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document */
+/* globals document, Range */
 /* bender-tags: view, browser-only */
 
 import ViewRange from '/ckeditor5/engine/view/range.js';
@@ -11,19 +11,32 @@ import ViewDocument from '/ckeditor5/engine/view/document.js';
 import { INLINE_FILLER_LENGTH, isInlineFiller, startsWithFiller } from '/ckeditor5/engine/view/filler.js';
 
 import { keyCodes } from '/ckeditor5/utils/keyboard.js';
+import createElement from '/ckeditor5/utils/dom/createelement.js';
 
 import { parse, setData } from '/ckeditor5/engine/dev-utils/view.js';
 
 describe( 'Document', () => {
-	let viewDocument;
+	let viewDocument, domRoot;
 
-	before( () => {
+	beforeEach( () => {
+		domRoot = createElement( document, 'div', {
+			contenteditable: 'true'
+		} );
+		document.body.appendChild( domRoot );
+
 		viewDocument = new ViewDocument();
-		viewDocument.createRoot( document.getElementById( 'editor' ) ) ;
+		viewDocument.createRoot( domRoot );
 
 		document.getSelection().removeAllRanges();
 
 		viewDocument.isFocused = true;
+	} );
+
+	afterEach( () => {
+		// There's no destroy() method yet, so let's at least kill the observers.
+		viewDocument.disableObservers();
+
+		domRoot.parentElement.removeChild( domRoot );
 	} );
 
 	describe( 'jump over inline filler hack', () => {
@@ -33,10 +46,11 @@ describe( 'Document', () => {
 
 			viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowleft, domTarget: viewDocument.domRoots.get( 'main' ) } );
 
-			const domRange = document.getSelection().getRangeAt( 0 );
-			expect( isInlineFiller( domRange.startContainer ) ).to.be.true;
-			expect( domRange.startOffset ).to.equal( 0 );
-			expect( domRange.collapsed ).to.be.true;
+			const domSelection = document.getSelection();
+
+			expect( domSelection.anchorNode.data ).to.equal( 'foo' );
+			expect( domSelection.anchorOffset ).to.equal( 3 );
+			expect( domSelection.isCollapsed ).to.be.true;
 		} );
 
 		it( 'should do nothing when another key is pressed', () => {
@@ -45,10 +59,11 @@ describe( 'Document', () => {
 
 			viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowright, domTarget: viewDocument.domRoots.get( 'main' ) } );
 
-			const domRange = document.getSelection().getRangeAt( 0 );
-			expect( isInlineFiller( domRange.startContainer ) ).to.be.true;
-			expect( domRange.startOffset ).to.equal( INLINE_FILLER_LENGTH );
-			expect( domRange.collapsed ).to.be.true;
+			const domSelection = document.getSelection();
+
+			expect( isInlineFiller( domSelection.anchorNode ) ).to.be.true;
+			expect( domSelection.anchorOffset ).to.equal( INLINE_FILLER_LENGTH );
+			expect( domSelection.isCollapsed ).to.be.true;
 		} );
 
 		it( 'should do nothing if range is not collapsed', () => {
@@ -57,43 +72,57 @@ describe( 'Document', () => {
 
 			viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowleft, domTarget: viewDocument.domRoots.get( 'main' ) } );
 
-			const domRange = document.getSelection().getRangeAt( 0 );
-			expect( domRange.startContainer.data ).to.equal( 'x' );
-			expect( domRange.startOffset ).to.equal( 0 );
-			expect( domRange.endContainer.data ).to.equal( 'x' );
-			expect( domRange.endOffset ).to.equal( 1 );
+			const domSelection = document.getSelection();
+
+			expect( domSelection.anchorNode.data ).to.equal( 'x' );
+			expect( domSelection.anchorOffset ).to.equal( 0 );
+			expect( domSelection.focusNode.data ).to.equal( 'x' );
+			expect( domSelection.focusOffset ).to.equal( 1 );
 		} );
 
-		it( 'should do nothing if node does not start with filler', () => {
-			setData( viewDocument, '<container:p>foo<attribute:b>{}x</attribute:b>bar</container:p>' );
-			viewDocument.render();
+		// See #664
+		// it( 'should do nothing if node does not start with the filler', () => {
+		// 	setData( viewDocument, '<container:p>foo<attribute:b>{}x</attribute:b>bar</container:p>' );
+		// 	viewDocument.render();
 
-			viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowleft, domTarget: viewDocument.domRoots.get( 'main' ) } );
+		// 	viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowleft, domTarget: viewDocument.domRoots.get( 'main' ) } );
 
-			const domRange = document.getSelection().getRangeAt( 0 );
-			expect( domRange.startContainer.data ).to.equal( 'x' );
-			expect( domRange.startOffset ).to.equal( 0 );
-			expect( domRange.collapsed ).to.be.true;
-		} );
+		// 	const domSelection = document.getSelection();
 
-		it( 'should do nothing if caret is not directly before filler', () => {
+		// 	expect( domSelection.anchorNode.data ).to.equal( 'x' );
+		// 	expect( domSelection.anchorOffset ).to.equal( INLINE_FILLER_LENGTH );
+		// 	expect( domSelection.isCollapsed ).to.be.true;
+		// } );
+
+		it( 'should do nothing if caret is not directly before the filler', () => {
 			setData( viewDocument, '<container:p>foo<attribute:b>[]</attribute:b>bar</container:p>' );
 			viewDocument.render();
 
-			// '<container:p>foo<attribute:b>x{}</attribute:b>bar</container:p>'
+			// Insert a letter to the <b>: '<container:p>foo<attribute:b>x{}</attribute:b>bar</container:p>'
+			// Do this both in the view and in the DOM to simulate typing and to avoid rendering (which would remove the filler).
 			const viewB = viewDocument.selection.getFirstPosition().parent;
 			const viewTextX = parse( 'x' );
 			viewB.appendChildren( viewTextX );
 			viewDocument.selection.removeAllRanges();
 			viewDocument.selection.addRange( ViewRange.createFromParentsAndOffsets( viewTextX, 1, viewTextX, 1 ) );
+
+			const domB = viewDocument.getDomRoot( 'main' ).querySelector( 'b' );
+			const domSelection = document.getSelection();
+			domB.childNodes[ 0 ].data += 'x';
+
+			const domRange = new Range();
+			domSelection.removeAllRanges();
+			domRange.setStart( domB.childNodes[ 0 ], INLINE_FILLER_LENGTH + 1 );
+			domRange.collapse( true );
+			domSelection.addRange( domRange );
+
 			viewDocument.render();
 
 			viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowleft, domTarget: viewDocument.domRoots.get( 'main' ) } );
 
-			const domRange = document.getSelection().getRangeAt( 0 );
-			expect( startsWithFiller( domRange.startContainer ) ).to.be.true;
-			expect( domRange.startOffset ).to.equal( INLINE_FILLER_LENGTH + 1 );
-			expect( domRange.collapsed ).to.be.true;
+			expect( startsWithFiller( domSelection.anchorNode ) ).to.be.true;
+			expect( domSelection.anchorOffset ).to.equal( INLINE_FILLER_LENGTH + 1 );
+			expect( domSelection.isCollapsed ).to.be.true;
 		} );
 	} );
 } );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -637,6 +637,7 @@ describe( 'Renderer', () => {
 			selection.addRange( ViewRange.createFromParentsAndOffsets( viewP, 0, viewP, 0 ) );
 
 			renderer.markToSync( 'children', viewP );
+			renderer.markToSync( 'children', viewP2 );
 			renderer.render();
 
 			// Step 3: Check whether in the first paragrpah there's a <br> filler and that
@@ -771,6 +772,8 @@ describe( 'Renderer', () => {
 		it( 'should handle typing in empty attribute, do nothing if changes are already applied', () => {
 			const domSelection = document.getSelection();
 
+			// 1. Render <p><b>FILLER{}</b>foo</p>.
+
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p><attribute:b>[]</attribute:b>foo</container:p>' );
 
@@ -779,6 +782,8 @@ describe( 'Renderer', () => {
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
+
+			// 2. Check the DOM.
 
 			const domP = domRoot.childNodes[ 0 ];
 
@@ -797,7 +802,8 @@ describe( 'Renderer', () => {
 			expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( INLINE_FILLER_LENGTH );
 			expect( domSelection.getRangeAt( 0 ).collapsed ).to.be.true;
 
-			// Add text node to both DOM and View <p><b>x</b>foo</p>
+			// 3. Add text node to both the DOM and the view: <p><b>FILLERx</b>foo</p>.
+
 			domB.childNodes[ 0 ].data += 'x';
 
 			domSelection.removeAllRanges();
@@ -818,6 +824,8 @@ describe( 'Renderer', () => {
 		it( 'should handle typing in empty attribute as a children change, render if needed', () => {
 			const domSelection = document.getSelection();
 
+			// 1. Render <p><b>FILLER{}</b>foo</p>.
+
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p><attribute:b>[]</attribute:b>foo</container:p>' );
 
@@ -826,6 +834,8 @@ describe( 'Renderer', () => {
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
+
+			// 2. Check the DOM.
 
 			const domP = domRoot.childNodes[ 0 ];
 
@@ -844,7 +854,8 @@ describe( 'Renderer', () => {
 			expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( INLINE_FILLER_LENGTH );
 			expect( domSelection.getRangeAt( 0 ).collapsed ).to.be.true;
 
-			// Add text node only to View <p><b>x</b>foo</p>
+			// 3. Add text node only to the view: <p><b>x{}</b>foo</p>.
+
 			const viewText = new ViewText( 'x' );
 			viewB.appendChildren( viewText );
 			selection.removeAllRanges();
@@ -865,6 +876,8 @@ describe( 'Renderer', () => {
 		it( 'should handle typing in empty attribute as a text change, render if needed', () => {
 			const domSelection = document.getSelection();
 
+			// 1. Render <p><b>FILLER{}</b>foo</p>.
+
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p><attribute:b>[]</attribute:b>foo</container:p>' );
 
@@ -873,6 +886,8 @@ describe( 'Renderer', () => {
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
+
+			// 2. Check the DOM.
 
 			const domP = domRoot.childNodes[ 0 ];
 
@@ -891,7 +906,8 @@ describe( 'Renderer', () => {
 			expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( INLINE_FILLER_LENGTH );
 			expect( domSelection.getRangeAt( 0 ).collapsed ).to.be.true;
 
-			// Add text node only to View <p><b>x</b>foo</p>
+			// 3. Add text node only to the view: <p><b>x{}</b>foo</p>.
+
 			const viewText = new ViewText( 'x' );
 			viewB.appendChildren( viewText );
 			selection.removeAllRanges();
@@ -899,6 +915,8 @@ describe( 'Renderer', () => {
 
 			renderer.markToSync( 'text', viewText );
 			renderer.render();
+
+			// 4. Check the DOM.
 
 			expect( domB.childNodes.length ).to.equal( 1 );
 			expect( domB.childNodes[ 0 ].data ).to.equal( INLINE_FILLER + 'x' );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1048,7 +1048,7 @@ describe( 'Renderer', () => {
 
 			expect( () => {
 				renderer.render();
-			} ).to.throw();
+			} ).to.throw( CKEditorError, /^view-renderer-filler-was-lost/ );
 		} );
 
 		it( 'should handle focusing element', () => {


### PR DESCRIPTION
Fixes #659.

I completely rewrote the logic so it does not try to store the filler view position between subsequent renders, but rather its DOM text node. It's still super tricky unfortunately, because there are significant limitations how the `DomConverter` can be used (in general – it can't be used at the beginning of `render()`).