### PR TITLE
T/629 Fix infinite selection change loop

### DIFF
--- a/src/model/range.js
+++ b/src/model/range.js
@@ -127,6 +127,17 @@ export default class Range {
 	}
 
 	/**
+	 * Two ranges are touching if their {@link engine.model.Range#start start} and
+	 * {@link engine.model.Range#end end} positions are {@link engine.model.Position#isTouching touching}.
+	 *
+	 * @param {engine.model.Range} otherRange Range to compare with.
+	 * @returns {Boolean} `true` if ranges are equal, `false` otherwise.
+	 */
+	isTouching( otherRange ) {
+		return this.start.isTouching( otherRange.start ) && this.end.isTouching( otherRange.end );
+	}
+
+	/**
 	 * Checks and returns whether this range intersects with given range.
 	 *
 	 * @param {engine.model.Range} otherRange Range to compare with.

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -125,25 +125,56 @@ export default class Selection {
 	}
 
 	/**
-	 * Checks whether, this selection is equal to given selection. Selections equal if they have the same ranges and directions.
+	 * Checks whether, this selection is equal to given selection. Selections are equal if they have same directions,
+	 * same number of ranges and all ranges from one selection equal to a range from other selection.
 	 *
 	 * @param {engine.model.Selection} otherSelection Selection to compare with.
 	 * @returns {Boolean} `true` if selections are equal, `false` otherwise.
 	 */
 	isEqual( otherSelection ) {
-		const rangeCount = this.rangeCount;
-
-		if ( rangeCount != otherSelection.rangeCount ) {
+		if ( !this.anchor.isEqual( otherSelection.anchor ) || !this.focus.isEqual( otherSelection.focus ) ) {
 			return false;
 		}
 
-		for ( let i = 0; i < this.rangeCount; i++ ) {
-			if ( !this._ranges[ i ].isEqual( otherSelection._ranges[ i ] ) ) {
-				return false;
-			}
+		if ( this.rangeCount != otherSelection.rangeCount ) {
+			return false;
 		}
 
-		return this.isBackward === otherSelection.isBackward;
+		// Every range from this selection...
+		return Array.from( this.getRanges() ).every( ( rangeA ) => {
+			// ...Has a range in other selection...
+			return Array.from( otherSelection.getRanges() ).some( ( rangeB ) => {
+				// That it is equal to.
+				return rangeA.isEqual( rangeB );
+			} );
+		} );
+	}
+
+	/**
+	 * Checks whether, this selection is touching given selection. Selections are touching if they have same directions,
+	 * same number of ranges and anchor, focus and all ranges from one selection are touching anchor, focus and ranges
+	 * from the other selection.
+	 *
+	 * @param {engine.model.Selection} otherSelection Selection to compare with.
+	 * @returns {Boolean} `true` if selections are equal, `false` otherwise.
+	 */
+	isTouching( otherSelection ) {
+		if ( !this.anchor.isTouching( otherSelection.anchor ) || !this.focus.isTouching( otherSelection.focus ) ) {
+			return false;
+		}
+
+		if ( this.rangeCount != otherSelection.rangeCount ) {
+			return false;
+		}
+
+		// Every range from this selection...
+		return Array.from( this.getRanges() ).every( ( rangeA ) => {
+			// ...Has a range in other selection...
+			return Array.from( otherSelection.getRanges() ).some( ( rangeB ) => {
+				// ...That it is touching.
+				return rangeA.isTouching( rangeB );
+			} );
+		} );
 	}
 
 	/**

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -126,7 +126,7 @@ export default class SelectionObserver extends Observer {
 		const domSelection = domDocument.defaultView.getSelection();
 		const newViewSelection = this.domConverter.domSelectionToView( domSelection );
 
-		if ( this.selection.isEqual( newViewSelection ) ) {
+		if ( newViewSelection && this.selection.isTouching( newViewSelection ) ) {
 			return;
 		}
 

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -91,6 +91,17 @@ export default class Range {
 	}
 
 	/**
+	 * Two ranges are touching if their {@link engine.view.Range#start start} and
+	 * {@link engine.view.Range#end end} positions are {@link engine.view.Position#isTouching touching}.
+	 *
+	 * @param {engine.view.Range} otherRange Range to compare with.
+	 * @returns {Boolean} `true` if ranges are equal, `false` otherwise.
+	 */
+	isTouching( otherRange ) {
+		return this.start.isTouching( otherRange.start ) && this.end.isTouching( otherRange.end );
+	}
+
+	/**
 	 * Checks whether this range contains given {@link engine.view.Position position}.
 	 *
 	 * @param {engine.view.Position} position Position to check.

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -283,15 +283,20 @@ export default class Selection {
 	}
 
 	/**
-	 * Checks whether, this selection is equal to given selection. Selections equal if they have the same ranges and directions.
+	 * Checks whether, this selection is equal to given selection. Selections are equal if they have same directions,
+	 * same number of ranges and all ranges from one selection equal to a range from other selection.
 	 *
 	 * @param {engine.view.Selection} otherSelection Selection to compare with.
 	 * @returns {Boolean} `true` if selections are equal, `false` otherwise.
 	 */
 	isEqual( otherSelection ) {
-		const rangeCount = this.rangeCount;
+		if ( this.rangeCount != otherSelection.rangeCount ) {
+			return false;
+		} else if ( this.rangeCount === 0 ) {
+			return true;
+		}
 
-		if ( rangeCount != otherSelection.rangeCount ) {
+		if ( !this.anchor.isEqual( otherSelection.anchor ) || !this.focus.isEqual( otherSelection.focus ) ) {
 			return false;
 		}
 
@@ -303,13 +308,50 @@ export default class Selection {
 			return false;
 		}
 
-		for ( let i = 0; i < this.rangeCount; i++ ) {
-			if ( !this._ranges[ i ].isEqual( otherSelection._ranges[ i ] ) ) {
-				return false;
-			}
+		// Every range from this selection...
+		return Array.from( this.getRanges() ).every( ( rangeA ) => {
+			// ...Has a range in other selection...
+			return Array.from( otherSelection.getRanges() ).some( ( rangeB ) => {
+				// That it is equal to.
+				return rangeA.isEqual( rangeB );
+			} );
+		} );
+	}
+
+	/**
+	 * Checks whether, this selection is touching given selection. Selections are touching if they have same directions,
+	 * same number of ranges and all ranges from one selection are touching a range from other selection.
+	 *
+	 * @param {engine.view.Selection} otherSelection Selection to compare with.
+	 * @returns {Boolean} `true` if selections are equal, `false` otherwise.
+	 */
+	isTouching( otherSelection ) {
+		if ( this.rangeCount != otherSelection.rangeCount ) {
+			return false;
+		} else if ( this.rangeCount === 0 ) {
+			return true;
 		}
 
-		return this._lastRangeBackward === otherSelection._lastRangeBackward;
+		if ( !this.anchor.isTouching( otherSelection.anchor ) || !this.focus.isTouching( otherSelection.focus ) ) {
+			return false;
+		}
+
+		if ( this.isFake != otherSelection.isFake ) {
+			return false;
+		}
+
+		if ( this.isFake && this.fakeSelectionLabel != otherSelection.fakeSelectionLabel ) {
+			return false;
+		}
+
+		// Every range from this selection...
+		return Array.from( this.getRanges() ).every( ( rangeA ) => {
+			// ...Has a range in other selection...
+			return Array.from( otherSelection.getRanges() ).some( ( rangeB ) => {
+				// ...That it is touching.
+				return rangeA.isTouching( rangeB );
+			} );
+		} );
 	}
 
 	/**

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -98,6 +98,56 @@ describe( 'Range', () => {
 		} );
 	} );
 
+	describe( 'isTouching', () => {
+		let foz, li1, bar, li2, ul, p;
+		// root
+		//  |- p
+		//  |- ul
+		//     |- li
+		//     |  |- f
+		//     |  |- o
+		//     |  |- z
+		//     |- li
+		//        |- b
+		//        |- a
+		//        |- r
+		beforeEach( () => {
+			foz = new Text( 'foz' );
+			li1 = new Element( 'li', [], foz );
+			bar = new Text( 'bar' );
+			li2 = new Element( 'li', [], bar );
+
+			ul = new Element( 'ul', [], [ li1, li2 ] );
+			p = new Element( 'p', [], new Text( 'xxx' ) );
+
+			root.insertChildren( 0, [ p, ul ] );
+		} );
+
+		it( 'should return true if both start and end range positions are touching', () => {
+			range = Range.createIn( p );
+			let touchingRange = Range.createFromParentsAndOffsets( root, 0, li1, 0 );
+
+			expect( touchingRange.isTouching( range ) ).to.be.true;
+			expect( range.isTouching( touchingRange ) ).to.be.true;
+		} );
+
+		it( 'should return false if start position is not touching other range start position', () => {
+			range = Range.createIn( p );
+			let touchingRange = Range.createFromParentsAndOffsets( root, 1, li1, 0 );
+
+			expect( touchingRange.isTouching( range ) ).to.be.false;
+			expect( range.isTouching( touchingRange ) ).to.be.false;
+		} );
+
+		it( 'should return false if end position is not touching other range end position', () => {
+			range = Range.createIn( p );
+			let touchingRange = Range.createFromParentsAndOffsets( root, 0, root, 0 );
+
+			expect( touchingRange.isTouching( range ) ).to.be.false;
+			expect( range.isTouching( touchingRange ) ).to.be.false;
+		} );
+	} );
+
 	describe( 'isIntersecting', () => {
 		it( 'should return true if given range is equal', () => {
 			let otherRange = Range.createFromRange( range );

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -671,7 +671,7 @@ describe( 'Selection', () => {
 			selection.addRange( range2 );
 
 			const otherSelection = new Selection();
-			otherSelection.addRange( range1 );
+			otherSelection.addRange( range2 );
 
 			expect( selection.isEqual( otherSelection ) ).to.be.false;
 		} );
@@ -692,6 +692,103 @@ describe( 'Selection', () => {
 			otherSelection.addRange( range1, true );
 
 			expect( selection.isEqual( otherSelection ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'isTouching', () => {
+		let foz, li1, bar, li2, ul, p;
+		// root
+		//  |- p
+		//  |- ul
+		//     |- li
+		//     |  |- f
+		//     |  |- o
+		//     |  |- z
+		//     |- li
+		//        |- b
+		//        |- a
+		//        |- r
+		beforeEach( () => {
+			foz = new Text( 'foz' );
+			li1 = new Element( 'li', [], foz );
+			bar = new Text( 'bar' );
+			li2 = new Element( 'li', [], bar );
+
+			ul = new Element( 'ul', [], [ li1, li2 ] );
+			p = new Element( 'p', [], new Text( 'xxx' ) );
+
+			root.insertChildren( 0, [ p, ul ] );
+		} );
+
+		it( 'should return true if ranges in selections are touching and have same direction and touching anchor and focus', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeP, rangeTouchingLi1 ] );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.true;
+			expect( otherSelection.isTouching( selection ) ).to.be.true;
+		} );
+
+		it( 'should return true if order of ranges is different (except of last added range)', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeLi2 = Range.createIn( li2 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi2, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeLi2, rangeP, rangeTouchingLi1 ] );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.true;
+			expect( otherSelection.isTouching( selection ) ).to.be.true;
+		} );
+
+		it( 'should return false if direction is different', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeP, rangeTouchingLi1 ], true );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.false;
+			expect( otherSelection.isTouching( selection ) ).to.be.false;
+		} );
+
+		it( 'should return false if anchor and focus is different', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeTouchingLi1, rangeP ] );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.false;
+			expect( otherSelection.isTouching( selection ) ).to.be.false;
+		} );
+
+		it( 'should return false if there are more ranges in one of selections', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeTouchingLi1 ] );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.false;
+			expect( otherSelection.isTouching( selection ) ).to.be.false;
 		} );
 	} );
 

--- a/tests/view/document/jumpoverinlinefiller.js
+++ b/tests/view/document/jumpoverinlinefiller.js
@@ -90,9 +90,11 @@ describe( 'Document', () => {
 
 			viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowleft, domTarget: viewDocument.domRoots.get( 'main' ) } );
 
+			const domText = viewDocument.domConverter.getCorrespondingDom( viewDocument.selection.anchor.parent );
+
 			const domRange = document.getSelection().getRangeAt( 0 );
-			expect( startsWithFiller( domRange.startContainer ) ).to.be.true;
-			expect( domRange.startOffset ).to.equal( INLINE_FILLER_LENGTH + 1 );
+			expect( startsWithFiller( domText ) ).to.be.true;
+			expect( domText.data.length ).to.equal( INLINE_FILLER_LENGTH + 1 );
 			expect( domRange.collapsed ).to.be.true;
 		} );
 	} );

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -217,6 +217,86 @@ describe( 'Position', () => {
 		} );
 	} );
 
+	describe( 'isTouching', () => {
+		// root
+		//  |- p
+		//  |- ul
+		//     |- li
+		//     |  |- foz
+		//     |- li
+		//        |- bar
+		let root, otherRoot, foz, li1, bar, li2, ul, p;
+
+		before( () => {
+			root = new Element( 'div' );
+			otherRoot = new Element( 'div' );
+
+			foz = new Text( 'foz' );
+			li1 = new Element( 'li', [], foz );
+			bar = new Text( 'bar' );
+			li2 = new Element( 'li', [], bar );
+			ul = new Element( 'ul', [], [ li1, li2 ] );
+			p = new Element( 'p' );
+
+			root.insertChildren( 0, [ p, ul ] );
+		} );
+
+		it( 'should return true if positions are same', () => {
+			let position = new Position( li2, 1 );
+			let result = position.isTouching( new Position( li2, 1 ) );
+
+			expect( result ).to.be.true;
+		} );
+
+		it( 'should return true if given position is in next node and there are no whole nodes before it', () => {
+			let positionA = new Position( root, 1 );
+			let positionB = new Position( foz, 0 );
+
+			expect( positionA.isTouching( positionB ) ).to.be.true;
+			expect( positionB.isTouching( positionA ) ).to.be.true;
+		} );
+
+		it( 'should return true if given position is in previous node and there are no whole nodes after it', () => {
+			let positionA = new Position( root, 2 );
+			let positionB = new Position( bar, 3 );
+
+			expect( positionA.isTouching( positionB ) ).to.be.true;
+			expect( positionB.isTouching( positionA ) ).to.be.true;
+		} );
+
+		it( 'should return true if positions are in different sub-trees but there are no whole nodes between them', () => {
+			let positionA = new Position( foz, 3 );
+			let positionB = new Position( bar, 0 );
+
+			expect( positionA.isTouching( positionB ) ).to.be.true;
+			expect( positionB.isTouching( positionA ) ).to.be.true;
+		} );
+
+		it( 'should return false if there are whole nodes between positions', () => {
+			let positionA = new Position( root, 2 );
+			let positionB = new Position( foz, 3 );
+
+			expect( positionA.isTouching( positionB ) ).to.be.false;
+			expect( positionB.isTouching( positionA ) ).to.be.false;
+		} );
+
+		it( 'should return false if there are whole nodes between positions', () => {
+			let positionA = new Position( foz, 3 );
+			let positionB = new Position( bar, 1 );
+
+			expect( positionA.isTouching( positionB ) ).to.be.false;
+			expect( positionB.isTouching( positionA ) ).to.be.false;
+		} );
+
+		it( 'should return false if positions are in different roots', () => {
+			let positionA = new Position( foz, 3 );
+			let positionB = new Position( otherRoot, 0 );
+
+			expect( positionA.isTouching( positionB ) ).to.be.false;
+			expect( positionB.isTouching( positionA ) ).to.be.false;
+		} );
+	} );
+
 	describe( 'isBefore', () => {
 		it( 'should return false for same positions', () => {
 			const node = new Node();

--- a/tests/view/range.js
+++ b/tests/view/range.js
@@ -135,6 +135,55 @@ describe( 'Range', () => {
 		} );
 	} );
 
+	describe( 'isTouching', () => {
+		// root
+		//  |- p
+		//  |- ul
+		//     |- li
+		//     |  |- foz
+		//     |- li
+		//        |- bar
+		let root, otherRoot, foz, li1, bar, li2, ul, p;
+
+		before( () => {
+			root = new Element( 'div' );
+			otherRoot = new Element( 'div' );
+
+			foz = new Text( 'foz' );
+			li1 = new Element( 'li', [], foz );
+			bar = new Text( 'bar' );
+			li2 = new Element( 'li', [], bar );
+			ul = new Element( 'ul', [], [ li1, li2 ] );
+			p = new Element( 'p', [], new Text( 'xxx' ) );
+
+			root.insertChildren( 0, [ p, ul ] );
+		} );
+
+		it( 'should return true if both start and end range positions are touching', () => {
+			let range = Range.createIn( p );
+			let touchingRange = Range.createFromParentsAndOffsets( root, 0, li1, 0 );
+
+			expect( touchingRange.isTouching( range ) ).to.be.true;
+			expect( range.isTouching( touchingRange ) ).to.be.true;
+		} );
+
+		it( 'should return false if start position is not touching other range start position', () => {
+			let range = Range.createIn( p );
+			let touchingRange = Range.createFromParentsAndOffsets( root, 1, li1, 0 );
+
+			expect( touchingRange.isTouching( range ) ).to.be.false;
+			expect( range.isTouching( touchingRange ) ).to.be.false;
+		} );
+
+		it( 'should return false if end position is not touching other range end position', () => {
+			let range = Range.createIn( p );
+			let touchingRange = Range.createFromParentsAndOffsets( root, 0, root, 0 );
+
+			expect( touchingRange.isTouching( range ) ).to.be.false;
+			expect( range.isTouching( touchingRange ) ).to.be.false;
+		} );
+	} );
+
 	describe( 'containsPosition', () => {
 		let viewRoot, range;
 

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -462,7 +462,10 @@ describe( 'Selection', () => {
 		} );
 
 		it( 'should return false if one selection is fake', () => {
+			selection.addRange( range1 );
+
 			const otherSelection = new Selection();
+			otherSelection.addRange( range1 );
 			otherSelection.setFake( true );
 
 			expect( selection.isEqual( otherSelection ) ).to.be.false;
@@ -486,6 +489,146 @@ describe( 'Selection', () => {
 			selection.addRange( range1 );
 
 			expect( selection.isEqual( otherSelection ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'isTouching', () => {
+		// root
+		//  |- p
+		//  |- ul
+		//     |- li
+		//     |  |- foz
+		//     |- li
+		//        |- bar
+		let root, otherRoot, foz, li1, bar, li2, ul, p;
+
+		before( () => {
+			root = new Element( 'div' );
+			otherRoot = new Element( 'div' );
+
+			foz = new Text( 'foz' );
+			li1 = new Element( 'li', [], foz );
+			bar = new Text( 'bar' );
+			li2 = new Element( 'li', [], bar );
+			ul = new Element( 'ul', [], [ li1, li2 ] );
+			p = new Element( 'p', [], new Text( 'xxx' ) );
+
+			root.insertChildren( 0, [ p, ul ] );
+		} );
+
+		it( 'should return true if ranges in selections are touching and have same direction and touching anchor and focus', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeP, rangeTouchingLi1 ] );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.true;
+			expect( otherSelection.isTouching( selection ) ).to.be.true;
+		} );
+
+		it( 'should return true if order of ranges is different (except of last added range)', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeLi2 = Range.createIn( li2 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi2, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeLi2, rangeP, rangeTouchingLi1 ] );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.true;
+			expect( otherSelection.isTouching( selection ) ).to.be.true;
+		} );
+
+		it( 'should return false if direction is different', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeP, rangeTouchingLi1 ], true );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.false;
+			expect( otherSelection.isTouching( selection ) ).to.be.false;
+		} );
+
+		it( 'should return false if anchor and focus is different', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeTouchingLi1, rangeP ] );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.false;
+			expect( otherSelection.isTouching( selection ) ).to.be.false;
+		} );
+
+		it( 'should return false if there are more ranges in one of selections', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeTouchingLi1 ] );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.false;
+			expect( otherSelection.isTouching( selection ) ).to.be.false;
+		} );
+
+		it( 'should return false if one selection is fake', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeP, rangeTouchingLi1 ] );
+			otherSelection.setFake( true );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.false;
+		} );
+
+		it( 'should return true if both selection are fake', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+			selection.setFake( true );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeP, rangeTouchingLi1 ] );
+			otherSelection.setFake( true );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.true;
+		} );
+
+		it( 'should return false if both selection are fake but have different label', () => {
+			let rangeP = Range.createIn( p );
+			let rangeLi1 = Range.createIn( li1 );
+			let rangeTouchingLi1 = Range.createFromParentsAndOffsets( ul, 0, ul, 1 );
+
+			selection.setRanges( [ rangeP, rangeLi1 ] );
+			selection.setFake( true, { label: 'foo' } );
+
+			const otherSelection = new Selection();
+			otherSelection.setRanges( [ rangeP, rangeTouchingLi1 ] );
+			otherSelection.setFake( true, { label: 'bar' } );
+
+			expect( selection.isTouching( otherSelection ) ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #629.

The problem with selection was that during conversion chain: `DOM -> view (1) -> model -> view (2) -> DOM` view (1) selection was different than view (2) selection because there was a difference how model -> view and DOM -> view selection is converted. This caused an infinite loop of selection fixing.

I changed one of conditions that was responsible for breaking the loop. The condition looked whether view (1) and view (2) are equal. Now I check whether they are touching. If they are, the selection is not converted any further.

To do so, I needed to implement `isTouching` in model range, selection and view position, range selection.