### PR TITLE
T/643 Markers in engine

### DIFF
--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -84,21 +84,21 @@ export default class EditingController {
 		 * @private
 		 * @member {utils.EmitterMixin} #_listenter
 		 */
-		this._listenter = Object.create( EmitterMixin );
+		this._listener = Object.create( EmitterMixin );
 
 		// Convert changes in model to view.
-		this._listenter.listenTo( this.model, 'change', ( evt, type, changes ) => {
+		this._listener.listenTo( this.model, 'change', ( evt, type, changes ) => {
 			this.modelToView.convertChange( type, changes );
 		}, { priority: 'low' } );
 
 		// Convert model selection to view.
-		this._listenter.listenTo( this.model, 'changesDone', () => {
+		this._listener.listenTo( this.model, 'changesDone', () => {
 			this.modelToView.convertSelection( model.selection );
 			this.view.render();
 		}, { priority: 'low' } );
 
 		// Convert view selection to model.
-		this._listenter.listenTo( this.view, 'selectionChange', convertSelectionChange( model, this.mapper ) );
+		this._listener.listenTo( this.view, 'selectionChange', convertSelectionChange( model, this.mapper ) );
 
 		// Attach default content converters.
 		this.modelToView.on( 'insert:$text', insertText(), { priority: 'lowest' } );
@@ -146,6 +146,6 @@ export default class EditingController {
 	 */
 	destroy() {
 		this.view.destroy();
-		this._listenter.stopListening();
+		this._listener.stopListening();
 	}
 }

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -56,9 +56,9 @@ import CKEditorError from '../../utils/ckeditorerror.js';
  *		buildModelConverter().for( dispatcher ).fromAttribute( 'bold' ).toElement( 'strong' );
  *
  * 4. Model marker to view element converter. This is a converter that converts markers from given group to view attribute element.
- * Markers, basically, are {@link engine.model.LiveRange} instances, that are named. In this conversion, model range is
+ * Markers, basically, are {@link module:engine/model/liverange~LiveRange} instances, that are named. In this conversion, model range is
  * converted to view range, then that view range is wrapped (or unwrapped, if range is removed) in a view attribute element.
- * To learn more about markers, see {@link engine.model.MarkersCollection}.
+ * To learn more about markers, see {@link module:engine/model/markerscollection~MarkersCollection}.
  *
  *		const viewSpanSearchResult = new ViewAttributeElement( 'span', { class: 'search-result' } );
  *		buildModelConverter().for( dispatcher ).fromMarker( 'searchResult' ).toElement( viewSpanSearchResult );
@@ -153,7 +153,7 @@ class ModelConverterBuilder {
 	 *
 	 * @chainable
 	 * @param {String} markerName Name of marker to convert.
-	 * @returns {engine.conversion.ModelConverterBuilder}
+	 * @returns {module:engine/conversion/modelconverterbuilder~ModelConverterBuilder}
 	 */
 	fromMarker( markerName ) {
 		this._from = {

--- a/src/conversion/mapper.js
+++ b/src/conversion/mapper.js
@@ -466,6 +466,8 @@ mix( Mapper, EmitterMixin );
  * @param {Object} data Data pipeline object that can store and pass data between callbacks. The callback should add
  * `viewPosition` value to that object with calculated {@link module:engine/view/position~Position view position}.
  * @param {module:engine/model/position~Position} data.modelPosition Model position to be mapped.
+ * @param {module:engine/view/position~Position} data.viewPosition View position that is a result of mapping
+ * `modelPosition` using `Mapper` default algorithm.
  * @param {module:engine/conversion/mapper~Mapper} data.mapper Mapper instance that fired the event.
  */
 
@@ -490,5 +492,7 @@ mix( Mapper, EmitterMixin );
  * @param {Object} data Data pipeline object that can store and pass data between callbacks. The callback should add
  * `modelPosition` value to that object with calculated {@link module:engine/model/position~Position model position}.
  * @param {module:engine/view/position~Position} data.viewPosition View position to be mapped.
+ * @param {module:engine/model/position~Position} data.modelPosition Model position that is a result of mapping
+ * `viewPosition` using `Mapper` default algorithm.
  * @param {module:engine/conversion/mapper~Mapper} data.mapper Mapper instance that fired the event.
  */

--- a/src/conversion/mapper.js
+++ b/src/conversion/mapper.js
@@ -170,8 +170,8 @@ export default class Mapper {
 	 * Maps model position to view position using default mapper algorithm.
 	 *
 	 * @private
-	 * @param {engine.model.Position} modelPosition
-	 * @returns {engine.view.Position} View position mapped from model position.
+	 * @param {module:engine/model/position~Position} modelPosition
+	 * @returns {module:engine/view/position~Position} View position mapped from model position.
 	 */
 	_defaultToViewPosition( modelPosition ) {
 		let viewContainer = this._modelToViewMapping.get( modelPosition.parent );
@@ -202,8 +202,8 @@ export default class Mapper {
 	 * Maps view position to model position using default mapper algorithm.
 	 *
 	 * @private
-	 * @param {engine.view.Position} viewPosition
-	 * @returns {engine.model.Position} Model position mapped from view position.
+	 * @param {module:engine/view/position~Position} viewPosition
+	 * @returns {module:engine/model/position~Position} Model position mapped from view position.
 	 */
 	_defaultToModelPosition( viewPosition ) {
 		let viewBlock = viewPosition.parent;

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -281,18 +281,18 @@ export function unwrapItem( elementCreator ) {
  *			|-  b}                                        |   |- ab
  *			|-  c                                         |- c
  *
- * The wrapping node depends on passed parameter. If {@link engine.view.AttributeElement} was passed, it will be cloned and
- * the copy will become the wrapping element. If `Function` is provided, it is passed all the parameters of the
- * {@link engine.conversion.ModelConversionDispatcher#event:addMarker addMarker event}. It's expected that the
- * function returns a {@link engine.view.AttributeElement}. The result of the function will be the wrapping element.
- * When provided `Function` does not return element, then will be no conversion.
+ * The wrapping node depends on passed parameter. If {@link module:engine/view/attributeelement~AttributeElement} was passed, it
+ * will be cloned and the copy will become the wrapping element. If `Function` is provided, it is passed all the parameters of the
+ * {@link module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:addMarker addMarker event}. It's expected
+ * that the function returns a {@link module:engine/view/attributeelement~AttributeElement}. The result of the function will be the
+ * wrapping element. When provided `Function` does not return element, then will be no conversion.
  *
  * The converter automatically consumes corresponding value from consumables list, stops the event (see
- * {@link engine.conversion.ModelConversionDispatcher}).
+ * {@link module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher}).
  *
  *		modelDispatcher.on( 'addMarker:searchResult', wrapRange( new ViewAttributeElement( 'span', { class: 'searchResult' } ) ) );
  *
- * @param {engine.view.AttributeElement|Function} elementCreator View attribute element, or function returning
+ * @param {module:engine/view/attributeelement~AttributeElement|Function} elementCreator View attribute element, or function returning
  * a view attribute element, which will be used for wrapping.
  * @returns {Function} Wrap range converter.
  */
@@ -326,19 +326,20 @@ export function wrapRange( elementCreator ) {
  * Function factory, creates a converter that converts removing of a model marker to view attribute element.
  * This converter will unwrap view nodes from corresponding view range.
  *
- * The view element that will be unwrapped depends on passed parameter. If {@link engine.view.AttributeElement} was passed,
- * it will be used to look for similar element in the view for unwrapping. If `Function` is provided, it is passed all
- * the parameters of the {@link engine.conversion.ModelConversionDispatcher#event:removeMarker removeMarker event}. It's
- * expected that the function returns a {@link engine.view.AttributeElement}. The result of the function will be used to
- * look for similar element in the view for unwrapping.
+ * The view element that will be unwrapped depends on passed parameter. If {@link module:engine/view/attributeelement~AttributeElement}
+ * was passed, it will be used to look for similar element in the view for unwrapping. If `Function` is provided, it is passed all
+ * the parameters of the
+ * {@link module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:removeMarker removeMarker event}.
+ * It's expected that the function returns a {@link module:/engine/view/attributeelement~AttributeElement}. The result of
+ * the function will be used to look for similar element in the view for unwrapping.
  *
  * The converter automatically consumes corresponding value from consumables list, stops the event (see
- * {@link engine.conversion.ModelConversionDispatcher}) and bind model and view elements.
+ * {@link module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher}) and bind model and view elements.
  *
  *		modelDispatcher.on( 'removeMarker:searchResult', unwrapRange( new ViewAttributeElement( 'span', { class: 'searchResult' } ) ) );
  *
- * @see engine.conversion.modelToView.wrapRange
- * @param {engine.view.AttributeElement|Function} elementCreator View attribute element, or function returning
+ * @see module:engine/conversion/model-to-view-converters~wrapRange
+ * @param {module:engine/view/attributeelement~AttributeElement|Function} elementCreator View attribute element, or function returning
  * a view attribute element, which will be used for unwrapping.
  * @returns {Function} Unwrap range converter.
  */
@@ -376,9 +377,9 @@ export function unwrapRange( elementCreator ) {
 
 // Takes given `viewPosition` and returns a widest possible range that contains this position and all view elements
 // before that position and after that position which has zero length in model (in most cases empty `ViewAttributeElement`s).
-// @param {engine.view.Position} viewPosition Position to start from when looking for furthest zero length position.
-// @param {engine.conversion.Mapper} mapper Mapper to use when looking for furthest zero length position.
-// @returns {engine.view.Range}
+// @param {module:engine/view/position~Position} viewPosition Position to start from when looking for furthest zero length position.
+// @param {module:engine/conversion/mapper~Mapper} mapper Mapper to use when looking for furthest zero length position.
+// @returns {module:engine/view/range~Range}
 function enlargeViewPosition( viewPosition, mapper ) {
 	const start = ViewPosition.createFromPosition( viewPosition );
 	const end = ViewPosition.createFromPosition( viewPosition );

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -192,7 +192,7 @@ export function removeAttribute( attributeCreator ) {
  *			|- c                                          |- c
  *
  * The wrapping node depends on passed parameter. If {@link module:engine/view/element~Element} was passed, it will be cloned and
- * the copy will become the wrapping element. If `Function` is provided, it is passed all the parameters of the
+ * the copy will become the wrapping element. If `Function` is provided, it is passed attribute value and then all the parameters of the
  * {@link module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:addAttribute addAttribute event}.
  * It's expected that the function returns a {@link module:engine/view/element~Element}.
  * The result of the function will be the wrapping element.
@@ -271,7 +271,13 @@ export function unwrapItem( elementCreator ) {
 }
 
 /**
- * Function factory, creates a converter that converts new model marker to view attribute element.
+ * Function factory, creates a converter that wraps model range.
+ *
+ * In contrary to {@link module:engine/conversion/model-to-view-converters~wrapItem}, this converter's input is a
+ * {@link module:engine/model/range~Range model range} (not changed model item). The model range is mapped
+ * to {@link module:engine/view/range~Range view range} and then, view items within that view range are wrapped in a
+ * {@link module:engine/view/attributeelement~AttributeElement view attribute element}. Note, that `elementCreator`
+ * function of this converter takes different parameters that `elementCreator` of `wrapItem`.
  *
  * Let's assume following model and view. `{}` represents a range that is added as a marker with `searchResult` name.
  * The range represents a result of search `ab` string in the model document. The range has to be visualized in view.
@@ -525,7 +531,7 @@ export function moveInOutOfMarker( markersCollection ) {
 
 			if ( wasInMarker && !isInMarker ) {
 				conversionApi.dispatcher.convertMarker( 'removeMarker', name, movedRange );
-			} else if ( !wasInMarker && isInMarker ) {
+			} else if ( isInMarker ) {
 				conversionApi.dispatcher.convertMarker( 'addMarker', name, movedRange );
 			}
 		}

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -527,12 +527,12 @@ export function moveInOutOfMarker( markersCollection ) {
 
 		for ( let [ name, range ] of markersCollection ) {
 			const wasInMarker = range.containsPosition( sourcePos ) || range.start.isEqual( sourcePos ) || range.end.isEqual( sourcePos );
-			const isInMarker = range.containsPosition( movedRange.start );
+			const common = movedRange.getIntersection( range );
 
-			if ( wasInMarker && !isInMarker ) {
+			if ( wasInMarker && common === null ) {
 				conversionApi.dispatcher.convertMarker( 'removeMarker', name, movedRange );
-			} else if ( isInMarker ) {
-				conversionApi.dispatcher.convertMarker( 'addMarker', name, movedRange );
+			} else if ( common !== null ) {
+				conversionApi.dispatcher.convertMarker( 'addMarker', name, common );
 			}
 		}
 	};

--- a/src/conversion/modelconsumable.js
+++ b/src/conversion/modelconsumable.js
@@ -121,8 +121,10 @@ export default class ModelConsumable {
 	 *		modelConsumable.add( modelElement, 'removeAttribute:bold' ); // Add `bold` attribute removal on `modelElement` change.
 	 *		modelConsumable.add( modelSelection, 'selection' ); // Add `modelSelection` to consumable values.
 	 *		modelConsumable.add( modelSelection, 'selectionAttribute:bold' ); // Add `bold` attribute on `modelSelection` to consumables.
+	 *		modelConsumable.add( modelRange, 'range' ); // Add `modelRange` to consumable values.
 	 *
-	 * @param {module:engine/model/item~Item|module:engine/model/selection~Selection} item Model item or selection that has the consumable.
+	 * @param {module:engine/model/item~Item|module:engine/model/selection~Selection|module:engine/model/range~Range} item
+	 * Model item, range or selection that has the consumable.
 	 * @param {String} type Consumable type.
 	 */
 	add( item, type ) {
@@ -145,9 +147,10 @@ export default class ModelConsumable {
 	 *		modelConsumable.consume( modelElement, 'removeAttribute:bold' ); // Remove `bold` attribute removal on `modelElement` change.
 	 *		modelConsumable.consume( modelSelection, 'selection' ); // Remove `modelSelection` from consumable values.
 	 *		modelConsumable.consume( modelSelection, 'selectionAttribute:bold' ); // Remove `bold` on `modelSelection` from consumables.
+	 *		modelConsumable.consume( modelRange, 'range' ); // Remove 'modelRange' from consumable values.
 	 *
-	 * @param {module:engine/model/item~Item|module:engine/model/selection~Selection} item
-	 * Model item or selection from which consumable will be consumed.
+	 * @param {module:engine/model/item~Item|module:engine/model/selection~Selection|module:engine/model/range~Range} item
+	 * Model item, range or selection from which consumable will be consumed.
 	 * @param {String} type Consumable type.
 	 * @returns {Boolean} `true` if consumable value was available and was consumed, `false` otherwise.
 	 */
@@ -173,8 +176,10 @@ export default class ModelConsumable {
 	 *		modelConsumable.test( modelElement, 'removeAttribute:bold' ); // Check for `bold` attribute removal on `modelElement` change.
 	 *		modelConsumable.test( modelSelection, 'selection' ); // Check if `modelSelection` is consumable.
 	 *		modelConsumable.test( modelSelection, 'selectionAttribute:bold' ); // Check if `bold` on `modelSelection` is consumable.
+	 *		modelConsumable.test( modelRange, 'range' ); // Check if `modelRange` is consumable.
 	 *
-	 * @param {module:engine/model/item~Item|module:engine/model/selection~Selection} item Model item or selection that will be tested.
+	 * @param {module:engine/model/item~Item|module:engine/model/selection~Selection|module:engine/model/range~Range} item
+	 * Model item, range or selection to be tested.
 	 * @param {String} type Consumable type.
 	 * @returns {null|Boolean} `null` if such consumable was never added, `false` if the consumable values was
 	 * already consumed or `true` if it was added and not consumed yet.
@@ -207,8 +212,10 @@ export default class ModelConsumable {
 	 *		modelConsumable.revert( modelElement, 'removeAttribute:bold' ); // Revert consuming `bold` attribute remove from `modelElement`.
 	 *		modelConsumable.revert( modelSelection, 'selection' ); // Revert consuming `modelSelection`.
 	 *		modelConsumable.revert( modelSelection, 'selectionAttribute:bold' ); // Revert consuming `bold` from `modelSelection`.
+	 *		modelConsumable.revert( modelRange, 'range' ); // Revert consuming `modelRange`.
 	 *
-	 * @param {module:engine/model/item~Item|module:engine/model/selection~Selection} item Model item or selection that will be reverted.
+	 * @param {module:engine/model/item~Item|module:engine/model/selection~Selection|module:engine/model/range~Range} item
+	 * Model item, range or selection to be reverted.
 	 * @param {String} type Consumable type.
 	 * @returns {null|Boolean} `true` if consumable has been reversed, `false` otherwise. `null` if the consumable has
 	 * never been added.

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -216,15 +216,15 @@ export default class ModelConversionDispatcher {
 		const consumable = this._createConsumableForType( range, 'move' );
 
 		const items = Array.from( range.getItems( { shallow: true } ) );
-		const rangeSize = range.end.offset - range.start.offset;
 		const inSameParent = sourcePosition.parent == range.start.parent;
+		const targetsAfter = range.start.isAfter( sourcePosition );
 
 		let offset = 0;
 
 		for ( let item of items ) {
 			const data = {
 				sourcePosition: sourcePosition,
-				targetPosition: inSameParent ? range.start.getShiftedBy( rangeSize ) : range.start.getShiftedBy( offset ),
+				targetPosition: inSameParent && targetsAfter ? range.end : range.start.getShiftedBy( offset ),
 				item: item
 			};
 

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -213,7 +213,7 @@ export default class ModelConversionDispatcher {
 	 */
 	convertMove( sourcePosition, range ) {
 		// Keep in mind that move dispatcher expects flat range.
-		const consumable = this._createConsumableForRange( range, 'move' );
+		const consumable = this._createConsumableForType( range, 'move' );
 
 		const items = Array.from( range.getItems( { shallow: true } ) );
 		const rangeSize = range.end.offset - range.start.offset;
@@ -243,7 +243,7 @@ export default class ModelConversionDispatcher {
 	 * graveyard root}).
 	 */
 	convertRemove( sourcePosition, range ) {
-		const consumable = this._createConsumableForRange( range, 'remove' );
+		const consumable = this._createConsumableForType( range, 'remove' );
 
 		for ( let item of range.getItems( { shallow: true } ) ) {
 			const data = {
@@ -269,7 +269,7 @@ export default class ModelConversionDispatcher {
 	 */
 	convertAttribute( type, range, key, oldValue, newValue ) {
 		// Create a list with attributes to consume.
-		const consumable = this._createConsumableForRange( range, type + ':' + key );
+		const consumable = this._createConsumableForType( range, type + ':' + key );
 
 		// Create a separate attribute event for each node in the range.
 		for ( let value of range ) {
@@ -360,7 +360,7 @@ export default class ModelConversionDispatcher {
 	 * @param {String} type Consumable type.
 	 * @returns {module:engine/conversion/modelconsumable~ModelConsumable} Values to consume.
 	 */
-	_createConsumableForRange( range, type ) {
+	_createConsumableForType( range, type ) {
 		const consumable = new Consumable();
 
 		for ( let item of range.getItems() ) {

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -328,6 +328,13 @@ export default class ModelConversionDispatcher {
 		}
 	}
 
+	convertMarker( type, name, range ) {
+		const consumable = this._createRangeConsumable( range );
+		const data = { name, range };
+
+		this.fire( type + ':' + name, data, consumable, this.conversionApi );
+	}
+
 	/**
 	 * Creates {@link module:engine/conversion/modelconsumable~ModelConsumable} with values to consume from given range, assuming that
 	 * given range has just been inserted to the model.
@@ -385,6 +392,14 @@ export default class ModelConversionDispatcher {
 		for ( let key of selection.getAttributeKeys() ) {
 			consumable.add( selection, 'selectionAttribute:' + key );
 		}
+
+		return consumable;
+	}
+
+	_createRangeConsumable( range ) {
+		const consumable = new Consumable();
+
+		consumable.add( range, 'range' );
 
 		return consumable;
 	}

--- a/src/dev-utils/model.js
+++ b/src/dev-utils/model.js
@@ -36,7 +36,7 @@ import {
 	convertCollapsedSelection,
 	convertSelectionAttribute
 } from '../conversion/model-selection-to-view-converters.js';
-import { insertText, insertElement, wrap } from '../conversion/model-to-view-converters.js';
+import { insertText, insertElement, wrapItem } from '../conversion/model-to-view-converters.js';
 import isPlainObject from '../../utils/lib/lodash/isPlainObject.js';
 
 /**
@@ -214,7 +214,7 @@ export function stringify( node, selectionOrPositionOrRange = null ) {
 	mapper.bindElements( node.root, viewDocumentFragment );
 
 	modelToView.on( 'insert:$text', insertText() );
-	modelToView.on( 'addAttribute', wrap( ( value, data ) => {
+	modelToView.on( 'addAttribute', wrapItem( ( value, data ) => {
 		if ( data.item instanceof ModelTextProxy ) {
 			return new ViewAttributeElement( 'model-text-with-attributes', { [ data.attributeKey ]: stringifyAttributeValue( value ) } );
 		}

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -87,7 +87,7 @@ export default class Document {
 		 * Document's markers' collection.
 		 *
 		 * @readonly
-		 * @member {module:engine/model/markerscollection~MarkersCollection} engine.model.Document#markers
+		 * @member {module:engine/model/markerscollection~MarkersCollection}
 		 */
 		this.markers = new MarkersCollection();
 

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -19,6 +19,7 @@ import History from './history.js';
 import LiveSelection from './liveselection.js';
 import Schema from './schema.js';
 import TreeWalker from './treewalker.js';
+import MarkersCollection from './markerscollection.js';
 import clone from '../../utils/lib/lodash/clone.js';
 import EmitterMixin from '../../utils/emittermixin.js';
 import CKEditorError from '../../utils/ckeditorerror.js';
@@ -75,12 +76,20 @@ export default class Document {
 		/**
 		 * Document's history.
 		 *
-		 * **Note:** Be aware that deltas applied to the stored deltas might be removed or changed.
+		 * **Note:** Be aware that deltas applied to the document might get removed or changed.
 		 *
 		 * @readonly
 		 * @member {module:engine/model/history~History}
 		 */
 		this.history = new History( this );
+
+		/**
+		 * Document's markers' collection.
+		 *
+		 * @readonly
+		 * @member {module:engine/model/markerscollection~MarkersCollection} engine.model.Document#markers
+		 */
+		this.markers = new MarkersCollection();
 
 		/**
 		 * Array of pending changes. See: {@link #enqueueChanges}.

--- a/src/model/markerscollection.js
+++ b/src/model/markerscollection.js
@@ -32,8 +32,6 @@ import mix from '../../utils/mix.js';
  * a given node (i.e. a character is bold no matter if it gets moved or content around it changes). Markers on the
  * other hand are continuous ranges (i.e. if a character from inside of marker range is moved somewhere else, marker
  * range is shrunk and the character does not have any attribute or information that it was in the marked range).
- *
- * @memberOf engine.model
  */
 export default class MarkersCollection {
 	/**

--- a/src/model/markerscollection.js
+++ b/src/model/markerscollection.js
@@ -1,0 +1,142 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import LiveRange from './liverange.js';
+import Range from './range.js';
+import EmitterMixin from '../../utils/emittermixin.js';
+import CKEditorError from '../../utils/ckeditorerror.js';
+import mix from '../../utils/mix.js';
+
+/**
+ * Manages and stores markers.
+ *
+ * Markers are simply {@link module:engine/model/liverange~LiveRange live ranges} added to `MarkersCollection`.
+ * Markers are used to represent information connected with model document. In contrary to
+ * {@link module:engine/model/node~Node nodes}, which are bits of data, markers are marking a part of model document.
+ * Each live range/marker is added with `name` parameter. Name is used to group and identify markers. Multiple live
+ * ranges can be added under the same name.
+ *
+ * Whenever live range is added or removed from markers collection, markers collection fires `addMarker` and `removeMarker`
+ * events. Same happens when a live range is changed due to changes in the model (both events are fired, `removeMarker` first,
+ * then `addMarker`).
+ *
+ * Markers can be converted to view by adding appropriate converters for
+ * {@link module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:addMarker addMarker} and
+ * {@link module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:removeMarker removeMarker}
+ * events, or by building converters for {@link module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher}
+ * using {@link module:engine/conversion/buildmodelconverter~buildModelConverter model converter builder}.
+ *
+ * Markers are similar to adding and converting attributes on nodes. The difference is that attribute is connected to
+ * a given node (i.e. a character is bold no matter if it gets moved or content around it changes). Markers on the
+ * other hand are continuous ranges (i.e. if a character from inside of marker range is moved somewhere else, marker
+ * range is shrunk and the character does not have any attribute or information that it was in the marked range).
+ *
+ * @memberOf engine.model
+ */
+export default class MarkersCollection {
+	/**
+	 * Creates a markers collection.
+	 */
+	constructor() {
+		/**
+		 * Stores range to marker name bindings for added ranges.
+		 *
+		 * @private
+		 * @member {Map} #_markerNames
+		 */
+		this._markerNames = new Map();
+	}
+
+	/**
+	 * Sets a name for given live range and adds it to the markers collection. Multiple live ranges may have same name.
+	 * Markers can also be grouped while still having different names, i.e.: `search:22`, `search:37`.
+	 *
+	 * Throws, if given `liveRange` is not an instance of {@link module:engine/model/liverange~LiveRange}.
+	 *
+	 * Throws, if given {@link module:engine/model/liverange~LiveRange LiveRange} instance is already added to the collection.
+	 *
+	 * `MarkersCollection` instance listens to `change` event of all live ranges added to it and fires `removeMarker`
+	 * and `addMarker` events when the live range changes.
+	 *
+	 * @param {module:engine/model/liverange~LiveRange} liveRange Live range to be added as a marker to markers collection.
+	 * @param {String} markerName Name to be associated with given `liveRange`.
+	 */
+	addRange( liveRange, markerName ) {
+		if ( this._markerNames.has( liveRange ) ) {
+			/**
+			 * Given range instance was already added.
+			 *
+			 * @error markers-collection-add-range-range-already-added
+			 */
+			throw new CKEditorError( 'markers-collection-add-range-already-added: Given range instance was already added.' );
+		}
+
+		if ( !( liveRange instanceof LiveRange ) ) {
+			/**
+			 * Added range is not an instance of LiveRange.
+			 *
+			 * @error markers-collection-add-range-not-live-range
+			 */
+			throw new CKEditorError( 'markers-collection-add-range-not-live-range: Added range is not an instance of LiveRange.' );
+		}
+
+		this._markerNames.set( liveRange, markerName );
+		this.fire( 'addMarker', markerName, Range.createFromRange( liveRange ) );
+	}
+
+	/**
+	 * Removes a live range from markers collection and makes markers collection stop listening to that live range
+	 * `change` event.
+	 *
+	 * @param {module:engine/model/liverange~LiveRange} liveRange Live range to be removed from markers collection.
+	 * @returns {Boolean} `true` is passed `liveRange` was found and removed from the markers collection, `false` otherwise.
+	 */
+	removeRange( liveRange ) {
+		const markerName = this._markerNames.get( liveRange );
+
+		if ( markerName ) {
+			this._markerNames.delete( liveRange );
+			this.fire( 'removeMarker', markerName, Range.createFromRange( liveRange ) );
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Substitutes given `oldLiveRange`, that was already added to the markers collection, with given `newLiveRange`.
+	 *
+	 * This method is basically a wrapper for using {@link module:engine/model/markerscollection~MarkersCollection#removeRange removeRange}
+	 * followed by using {@link module:engine/model/markerscollection~MarkersCollection#addRange addRange}.
+	 *
+	 * **Note**: this method does not change properties of `oldLiveRange`.
+	 *
+	 * @param {module:engine/model/liverange~LiveRange} oldLiveRange Live range to be changed.
+	 * @param {module:engine/model/liverange~LiveRange} newLiveRange Live range to be added.
+	 * @returns {Boolean} `true` if `oldLiveRange` was found and changed, `false` otherwise.
+	 */
+	updateRange( oldLiveRange, newLiveRange ) {
+		const markerName = this._markerNames.get( oldLiveRange );
+
+		if ( markerName ) {
+			this.removeRange( oldLiveRange );
+			this.addRange( newLiveRange, markerName );
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Destroys markers collection.
+	 */
+	destroy() {
+		this.stopListening();
+	}
+}
+
+mix( MarkersCollection, EmitterMixin );

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -470,8 +470,8 @@ export default class Range {
 		} else {
 			const range = Range.createFromRange( this );
 
-			let insertBeforeStart = range.isCollapsed ? isSticky : !isSticky;
-			let insertBeforeEnd = isSticky;
+			let insertBeforeStart = range.isCollapsed ? true : !isSticky;
+			let insertBeforeEnd = range.isCollapsed ? true : isSticky;
 
 			range.start = range.start._getTransformedByInsertion( insertPosition, howMany, insertBeforeStart );
 			range.end = range.end._getTransformedByInsertion( insertPosition, howMany, insertBeforeEnd );

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -372,8 +372,8 @@ export default class Range {
 	/**
 	 * Returns a range that is a result of transforming this range by given `delta`.
 	 *
-	 * @param {engine.model.Delta} delta Delta to transform range by.
-	 * @returns {Array.<engine.model.Range>} Range which is the result of transformation.
+	 * @param {module:engine/model/delta~Delta} delta Delta to transform range by.
+	 * @returns {Array.<module:engine/model/range~Range>} Range which is the result of transformation.
 	 */
 	getTransformedByDelta( delta ) {
 		let ranges = [ Range.createFromRange( this ) ];
@@ -406,10 +406,10 @@ export default class Range {
 	 *
 	 * @protected
 	 * @param {'insert'|'move'|'remove'|'reinsert'} type Change type.
-	 * @param {engine.model.Position} targetPosition Position before the first changed node.
+	 * @param {module:engine/model/position~Position} targetPosition Position before the first changed node.
 	 * @param {Number} howMany How many nodes has been changed.
-	 * @param {engine.model.Position} sourcePosition Source position of changes.
-	 * @returns {Array.<engine.model.Range>}
+	 * @param {module:engine/model/position~Position} sourcePosition Source position of changes.
+	 * @returns {Array.<module:engine/model/range~Range>}
 	 */
 	_getTransformedByDocumentChange( type, targetPosition, howMany, sourcePosition ) {
 		if ( type == 'insert' ) {
@@ -606,8 +606,8 @@ export default class Range {
 	 * Combines all ranges from the passed array into a one range. At least one range has to be passed.
 	 * Passed ranges must not have common parts.
 	 *
-	 * The first range from the array is a reference range. If other ranges {@link engine.model.Position.isTouching are touching}
-	 * the reference range, they will get combined into one range.
+	 * The first range from the array is a reference range. If other ranges
+	 * {@link module:engine/model/position~Position#isTouching are touching} the reference range, they will get combined into one range.
 	 *
 	 *		[  ][]  [    ][ ][  ref range  ][ ][]  [  ]  // Passed ranges, shown sorted. "Ref range" was the first range in original array.
 	 *		        [      returned range       ]  [  ]  // The combined range.
@@ -615,8 +615,8 @@ export default class Range {
 	 *	            [                           ]        // The result of the function if the third-to-seventh range was a reference range.
 	 *	                                           [  ]  // The result of the function if the last range was a reference range.
 	 *
-	 * @param {Array.<engine.model.Range>} ranges Ranges to combine.
-	 * @returns {engine.model.Range} Combined range.
+	 * @param {Array.<module:engine/model/range~Range>} ranges Ranges to combine.
+	 * @returns {module:engine/model/range~Range} Combined range.
 	 */
 	static createFromRanges( ranges ) {
 		if ( ranges.length === 0 ) {

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -111,7 +111,7 @@ export default class Element extends Node {
 		 * Custom properties can be added to element instance, will be cloned but not rendered into DOM.
 		 *
 		 * @protected
-		 * @memeber {Map} engine.view.Element#_customProperties.
+		 * @memeber {Map}
 		 */
 		this._customProperties = new Map();
 	}

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -275,7 +275,7 @@ export function mergeContainers( position ) {
 /**
  * Breaks given `range` on a set of {@link module:engine/view/range~Range ranges}, that each are contained within a
  * {@link module:engine/view/containerelement~ContainerElement container element}. After `range` is broken, it's "pieces" can
- * be used by {@link module:engine/view/writer~writer} (which expects that passed ranges are contained within on container element).
+ * be used by other {@link module:engine/view/writer~writer} (which expect that passed ranges are contained within one container element).
  *
  * @function module:engine/view/writer~writer.breakViewRangePerContainer
  * @param {module:engine/view/range~Range} range Range to break.

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -275,7 +275,8 @@ export function mergeContainers( position ) {
 /**
  * Breaks given `range` on a set of {@link module:engine/view/range~Range ranges}, that each are contained within a
  * {@link module:engine/view/containerelement~ContainerElement container element}. After `range` is broken, it's "pieces" can
- * be used by other {@link module:engine/view/writer~writer} (which expect that passed ranges are contained within one container element).
+ * be used by other {@link module:engine/view/writer~writer} methods (which expect that passed ranges are contained within
+ * one container element).
  *
  * @function module:engine/view/writer~writer.breakViewRangePerContainer
  * @param {module:engine/view/range~Range} range Range to break.

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -1142,19 +1142,19 @@ function isContainerOrFragment( node ) {
 	return node instanceof ContainerElement || node instanceof DocumentFragment;
 }
 
-// Checks if {@link engine.view.Range#start range start} and {@link engine.view.Range#end range end} are placed
-// inside same {@link engine.view.ContainerElement container}.
-// Throws {@link utils.CKEditorError CKEditorError} `view-writer-invalid-range-container` when validation fails.
+// Checks if {@link module:engine/view/range~Range#start range start} and {@link module:engine/view/range~Range#end range end} are placed
+// inside same {@link module:engine/view/containerelement~ContainerElement container element}.
+// Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `view-writer-invalid-range-container` when validation fails.
 //
-// @param {engine.view.Range} range
+// @param {module:engine/view/range~Range} range
 function validateRangeContainer( range ) {
 	const startContainer = getParentContainer( range.start );
 	const endContainer = getParentContainer( range.end );
 
 	if ( !startContainer || !endContainer || startContainer !== endContainer ) {
 		/**
-		 * Range container is invalid. This can happen if {@link engine.view.Range#start range start} and
-		 * {@link engine.view.Range#end range end} positions are not placed inside same container or
+		 * Range container is invalid. This can happen if {@link module:engine/view/range~Range#start range start} and
+		 * {@link module:engine/view/range~Range#end range end} positions are not placed inside same container or
 		 * parent container for these positions cannot be found.
 		 *
 		 * @error view-writer-invalid-range-container

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -379,11 +379,22 @@ export function remove( range ) {
  * {@link module:engine/view/range~Range#start start} and {@link module:engine/view/range~Range#end end} positions.
  */
 export function move( sourceRange, targetPosition ) {
-	if ( sourceRange.start.parent == targetPosition.parent ) {
-		targetPosition.offset -= sourceRange.end.offset - sourceRange.start.offset;
-	}
+	let nodes;
 
-	const nodes = remove( sourceRange );
+	if ( targetPosition.isAfter( sourceRange.end ) ) {
+		targetPosition = _breakAttributes( targetPosition, true );
+
+		const parent = targetPosition.parent;
+		const countBefore = parent.childCount;
+
+		sourceRange = _breakAttributesRange( sourceRange, true );
+
+		nodes = remove( sourceRange );
+
+		targetPosition.offset += ( parent.childCount - countBefore );
+	} else {
+		nodes = remove( sourceRange );
+	}
 
 	return insert( targetPosition, nodes );
 }

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -406,32 +406,6 @@ describe( 'EditingController', () => {
 
 			editing.modelToView.convertMarker.restore();
 		} );
-
-		it( 'should not start marker conversion if content is moved inside the marker', () => {
-			model.enqueueChanges( () => {
-				model.batch().insert( ModelPosition.createAt( model.getRoot(), 'end' ), new ModelElement( 'paragraph' ) );
-			} );
-
-			const markerRange = ModelLiveRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 4 );
-			const consumableMock = {
-				consume: () => true,
-				test: () => true
-			};
-
-			model.markers.add( 'name', markerRange );
-
-			sinon.spy( editing.modelToView, 'convertMarker' );
-
-			editing.modelToView.fire( 'move', {
-				sourcePosition: ModelPosition.createAt( modelRoot, 3 ),
-				targetPosition: ModelPosition.createAt( modelRoot, 1 ),
-				item: modelRoot.getChild( 1 )
-			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
-
-			expect( editing.modelToView.convertMarker.called ).to.be.false;
-
-			editing.modelToView.convertMarker.restore();
-		} );
 	} );
 
 	describe( 'destroy', () => {

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -17,6 +17,7 @@ import buildModelConverter from 'ckeditor5/engine/conversion/buildmodelconverter
 
 import ModelDocument from 'ckeditor5/engine/model/document.js';
 import ModelPosition from 'ckeditor5/engine/model/position.js';
+import ModelElement from 'ckeditor5/engine/model/element.js';
 import ModelRange from 'ckeditor5/engine/model/range.js';
 import ModelLiveRange from 'ckeditor5/engine/model/liverange.js';
 import ModelDocumentFragment from 'ckeditor5/engine/model/documentfragment.js';
@@ -109,7 +110,7 @@ describe( 'EditingController', () => {
 	describe( 'conversion', () => {
 		let model, modelRoot, viewRoot, domRoot, editing, listener;
 
-		before( () => {
+		beforeEach( () => {
 			listener = Object.create( EmitterMixin );
 
 			model = new ModelDocument();
@@ -125,15 +126,7 @@ describe( 'EditingController', () => {
 			model.schema.registerItem( 'div', '$block' );
 			buildModelConverter().for( editing.modelToView ).fromElement( 'paragraph' ).toElement( 'p' );
 			buildModelConverter().for( editing.modelToView ).fromElement( 'div' ).toElement( 'div' );
-		} );
 
-		after( () => {
-			document.body.removeChild( domRoot );
-			listener.stopListening();
-			editing.destroy();
-		} );
-
-		beforeEach( () => {
 			// Note: The below code is highly overcomplicated due to #455.
 			model.selection.removeAllRanges();
 			modelRoot.removeChildren( 0, modelRoot.childCount );
@@ -152,6 +145,12 @@ describe( 'EditingController', () => {
 				model.selection.addRange( ModelRange.createFromParentsAndOffsets(
 					modelRoot.getChild( 0 ), 1, modelRoot.getChild( 0 ), 1 ) );
 			} );
+		} );
+
+		afterEach( () => {
+			document.body.removeChild( domRoot );
+			listener.stopListening();
+			editing.destroy();
 		} );
 
 		it( 'should convert insertion', () => {
@@ -259,11 +258,11 @@ describe( 'EditingController', () => {
 
 			sinon.spy( editing.modelToView, 'convertMarker' );
 
-			model.markers.fire( 'addMarker', range, 'name' );
+			model.markers.fire( 'add', range, 'name' );
 
 			expect( editing.modelToView.convertMarker.calledWithExactly( 'addMarker', range, 'name' ) ).to.be.true;
 
-			model.markers.fire( 'removeMarker', range, 'name' );
+			model.markers.fire( 'remove', range, 'name' );
 
 			expect( editing.modelToView.convertMarker.calledWithExactly( 'removeMarker', range, 'name' ) ).to.be.true;
 
@@ -273,28 +272,53 @@ describe( 'EditingController', () => {
 		it( 'should forward add marker event if content is inserted into a marker range', () => {
 			const markerRange = ModelLiveRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
 			const innerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
+			const consumableMock = {
+				consume: () => true,
+				test: () => true
+			};
 
-			model.markers.addRange( markerRange, 'name' );
+			model.markers.add( 'name', markerRange );
 
 			sinon.spy( editing.modelToView, 'convertMarker' );
 
 			editing.modelToView.fire( 'insert', {
 				range: innerRange
-			} );
+			}, consumableMock, { dispatcher: editing.modelToView } );
 
 			expect( editing.modelToView.convertMarker.calledWithExactly( 'addMarker', 'name', innerRange ) ).to.be.true;
 
 			editing.modelToView.convertMarker.restore();
 		} );
 
-		it( 'should forward remove marker event if part of marker range is moved', () => {
+		it( 'should not start marker conversion if content is not inserted into any marker range', () => {
+			const markerRange = ModelLiveRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
+			const insertRange = ModelRange.createFromParentsAndOffsets( modelRoot, 6, modelRoot, 8 );
+			const consumableMock = {
+				consume: () => true,
+				test: () => true
+			};
+
+			model.markers.add( 'name', markerRange );
+
+			sinon.spy( editing.modelToView, 'convertMarker' );
+
+			editing.modelToView.fire( 'insert', {
+				range: insertRange
+			}, consumableMock, { dispatcher: editing.modelToView } );
+
+			expect( editing.modelToView.convertMarker.called ).to.be.false;
+
+			editing.modelToView.convertMarker.restore();
+		} );
+
+		it( 'should forward remove marker event if part of marker range is moved - intersecting', () => {
 			const markerRange = ModelLiveRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 1 );
 			const consumableMock = {
 				consume: () => true,
 				test: () => true
 			};
 
-			model.markers.addRange( markerRange, 'name' );
+			model.markers.add( 'name', markerRange );
 
 			sinon.spy( editing.modelToView, 'convertMarker' );
 
@@ -302,7 +326,33 @@ describe( 'EditingController', () => {
 				sourcePosition: ModelPosition.createAt( modelRoot, 1 ),
 				targetPosition: ModelPosition.createAt( modelRoot, 2 ),
 				item: modelRoot.getChild( 2 )
-			}, consumableMock, { mapper: editing.mapper } );
+			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
+
+			expect( editing.modelToView.convertMarker.calledWith( 'removeMarker', 'name' ) ).to.be.true;
+
+			editing.modelToView.convertMarker.restore();
+		} );
+
+		it( 'should forward remove marker event if part of marker range is moved - inside', () => {
+			model.enqueueChanges( () => {
+				model.batch().insert( ModelPosition.createAt( model.getRoot(), 'end' ), new ModelElement( 'paragraph' ) );
+			} );
+
+			const markerRange = ModelLiveRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 2 );
+			const consumableMock = {
+				consume: () => true,
+				test: () => true
+			};
+
+			model.markers.add( 'name', markerRange );
+
+			sinon.spy( editing.modelToView, 'convertMarker' );
+
+			editing.modelToView.fire( 'move', {
+				sourcePosition: ModelPosition.createAt( modelRoot, 1 ),
+				targetPosition: ModelPosition.createAt( modelRoot, 3 ),
+				item: modelRoot.getChild( 3 )
+			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
 
 			expect( editing.modelToView.convertMarker.calledWith( 'removeMarker', 'name' ) ).to.be.true;
 
@@ -310,23 +360,75 @@ describe( 'EditingController', () => {
 		} );
 
 		it( 'should forward add marker event if content is moved into a marker range', () => {
+			model.enqueueChanges( () => {
+				model.batch().insert( ModelPosition.createAt( model.getRoot(), 'end' ), new ModelElement( 'paragraph' ) );
+			} );
+
 			const markerRange = ModelLiveRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
 			const consumableMock = {
 				consume: () => true,
 				test: () => true
 			};
 
-			model.markers.addRange( markerRange, 'name' );
+			model.markers.add( 'name', markerRange );
+
+			sinon.spy( editing.modelToView, 'convertMarker' );
+
+			editing.modelToView.fire( 'move', {
+				sourcePosition: ModelPosition.createAt( modelRoot, 3 ),
+				targetPosition: ModelPosition.createAt( modelRoot, 1 ),
+				item: modelRoot.getChild( 1 )
+			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
+
+			expect( editing.modelToView.convertMarker.calledWith( 'addMarker', 'name' ) ).to.be.true;
+
+			editing.modelToView.convertMarker.restore();
+		} );
+
+		it( 'should not start marker conversion if moved content does not affect the marker', () => {
+			const markerRange = ModelLiveRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 1 );
+			const consumableMock = {
+				consume: () => true,
+				test: () => true
+			};
+
+			model.markers.add( 'name', markerRange );
 
 			sinon.spy( editing.modelToView, 'convertMarker' );
 
 			editing.modelToView.fire( 'move', {
 				sourcePosition: ModelPosition.createAt( modelRoot, 2 ),
+				targetPosition: ModelPosition.createAt( modelRoot, 0 ),
+				item: modelRoot.getChild( 2 )
+			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
+
+			expect( editing.modelToView.convertMarker.called ).to.be.false;
+
+			editing.modelToView.convertMarker.restore();
+		} );
+
+		it( 'should not start marker conversion if content is moved inside the marker', () => {
+			model.enqueueChanges( () => {
+				model.batch().insert( ModelPosition.createAt( model.getRoot(), 'end' ), new ModelElement( 'paragraph' ) );
+			} );
+
+			const markerRange = ModelLiveRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 4 );
+			const consumableMock = {
+				consume: () => true,
+				test: () => true
+			};
+
+			model.markers.add( 'name', markerRange );
+
+			sinon.spy( editing.modelToView, 'convertMarker' );
+
+			editing.modelToView.fire( 'move', {
+				sourcePosition: ModelPosition.createAt( modelRoot, 3 ),
 				targetPosition: ModelPosition.createAt( modelRoot, 1 ),
 				item: modelRoot.getChild( 1 )
-			}, consumableMock, { mapper: editing.mapper } );
+			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
 
-			expect( editing.modelToView.convertMarker.calledWith( 'addMarker', 'name' ) ).to.be.true;
+			expect( editing.modelToView.convertMarker.called ).to.be.false;
 
 			editing.modelToView.convertMarker.restore();
 		} );

--- a/tests/conversion/advanced-converters.js
+++ b/tests/conversion/advanced-converters.js
@@ -32,8 +32,8 @@ import {
 	insertText,
 	setAttribute,
 	removeAttribute,
-	wrap,
-	unwrap,
+	wrapItem,
+	unwrapItem,
 	move,
 	remove,
 	eventNameToConsumableType
@@ -334,8 +334,8 @@ describe( 'image with caption converters', () => {
 describe( 'custom attribute handling for given element', () => {
 	beforeEach( () => {
 		// NORMAL LINK MODEL TO VIEW CONVERTERS
-		modelDispatcher.on( 'addAttribute:linkHref', wrap( ( value ) => new ViewAttributeElement( 'a', { href: value } ) ) );
-		modelDispatcher.on( 'addAttribute:linkTitle', wrap( ( value ) => new ViewAttributeElement( 'a', { title: value } ) ) );
+		modelDispatcher.on( 'addAttribute:linkHref', wrapItem( ( value ) => new ViewAttributeElement( 'a', { href: value } ) ) );
+		modelDispatcher.on( 'addAttribute:linkTitle', wrapItem( ( value ) => new ViewAttributeElement( 'a', { title: value } ) ) );
 
 		const changeLinkAttribute = function( elementCreator ) {
 			return ( evt, data, consumable, conversionApi ) => {
@@ -364,12 +364,12 @@ describe( 'custom attribute handling for given element', () => {
 
 		modelDispatcher.on(
 			'removeAttribute:linkHref',
-			unwrap( ( value ) => new ViewAttributeElement( 'a', { href: value } ) )
+			unwrapItem( ( value ) => new ViewAttributeElement( 'a', { href: value } ) )
 		);
 
 		modelDispatcher.on(
 			'removeAttribute:linkTitle',
-			unwrap( ( value ) => new ViewAttributeElement( 'a', { title: value } ) )
+			unwrapItem( ( value ) => new ViewAttributeElement( 'a', { title: value } ) )
 		);
 
 		// NORMAL LINK VIEW TO MODEL CONVERTERS
@@ -538,9 +538,9 @@ describe( 'custom attribute handling for given element', () => {
 		let expected = '<div><blockquote>foo<a href="foo.html" title="Foo source">see source</a></blockquote></div>';
 		expect( viewToString( viewRoot ) ).to.equal( expected );
 
-		modelDispatcher.on( 'addAttribute:bold', wrap( new ViewAttributeElement( 'strong' ) ) );
-		modelDispatcher.on( 'changeAttribute:bold', wrap( new ViewAttributeElement( 'strong' ) ) );
-		modelDispatcher.on( 'removeAttribute:bold', unwrap( new ViewAttributeElement( 'strong' ) ) );
+		modelDispatcher.on( 'addAttribute:bold', wrapItem( new ViewAttributeElement( 'strong' ) ) );
+		modelDispatcher.on( 'changeAttribute:bold', wrapItem( new ViewAttributeElement( 'strong' ) ) );
+		modelDispatcher.on( 'removeAttribute:bold', unwrapItem( new ViewAttributeElement( 'strong' ) ) );
 
 		modelElement.appendChildren( new ModelText( 'bar', { bold: true } ) );
 		modelDispatcher.convertInsertion( ModelRange.createFromParentsAndOffsets( modelElement, 3, modelElement, 6 ) );
@@ -675,9 +675,9 @@ describe( 'universal converter', () => {
 
 		// "Real" converters -- added with higher priority. Should overwrite the "universal" converters.
 		modelDispatcher.on( 'insert:image', insertElement( new ViewContainerElement( 'img' ) ) );
-		modelDispatcher.on( 'addAttribute:bold', wrap( new ViewAttributeElement( 'strong' ) ) );
-		modelDispatcher.on( 'changeAttribute:bold', wrap( new ViewAttributeElement( 'strong' ) ) );
-		modelDispatcher.on( 'removeAttribute:bold', unwrap( new ViewAttributeElement( 'strong' ) ) );
+		modelDispatcher.on( 'addAttribute:bold', wrapItem( new ViewAttributeElement( 'strong' ) ) );
+		modelDispatcher.on( 'changeAttribute:bold', wrapItem( new ViewAttributeElement( 'strong' ) ) );
+		modelDispatcher.on( 'removeAttribute:bold', unwrapItem( new ViewAttributeElement( 'strong' ) ) );
 
 		viewDispatcher.on( 'element:img', ( evt, data, consumable ) => {
 			if ( consumable.consume( data.input, { name: true } ) ) {

--- a/tests/conversion/buildmodelconverter.js
+++ b/tests/conversion/buildmodelconverter.js
@@ -36,6 +36,8 @@ import {
 
 import { createRangeOnElementOnly } from 'tests/engine/model/_utils/utils.js';
 
+import CKEditorError from 'ckeditor5/utils/ckeditorerror.js';
+
 function viewAttributesToString( item ) {
 	let result = '';
 
@@ -422,18 +424,9 @@ describe( 'Model converter builder', () => {
 		} );
 	} );
 
-	it( 'should do nothing on model element to view attribute conversion', () => {
-		buildModelConverter().for( dispatcher ).fromElement( 'div' ).toElement( 'div' );
-		// Should do nothing:
-		buildModelConverter().for( dispatcher ).fromElement( 'paragraph' ).toAttribute( 'paragraph', true );
-		// If above would do something this one would not be fired:
-		buildModelConverter().for( dispatcher ).fromElement( 'paragraph' ).toElement( 'p' );
-
-		let modelElement = new ModelElement( 'div', null, new ModelElement( 'paragraph', null, new ModelText( 'foobar' ) ) );
-		modelRoot.appendChildren( modelElement );
-
-		dispatcher.convertInsertion( ModelRange.createIn( modelRoot ) );
-
-		expect( viewToString( viewRoot ) ).to.equal( '<div><div><p>foobar</p></div></div>' );
+	it( 'should throw when trying to build model element to view attribute converter', () => {
+		expect( () => {
+			buildModelConverter().for( dispatcher ).fromElement( 'paragraph' ).toAttribute( 'paragraph', true );
+		} ).to.throw( CKEditorError, /^build-model-converter-non-attribute-to-attribute/ );
 	} );
 } );

--- a/tests/conversion/model-selection-to-view-converters.js
+++ b/tests/conversion/model-selection-to-view-converters.js
@@ -28,7 +28,7 @@ import {
 import {
 	insertElement,
 	insertText,
-	wrap
+	wrapItem
 } from 'ckeditor5/engine/conversion/model-to-view-converters.js';
 
 import { stringify as stringifyView } from 'ckeditor5/engine/dev-utils/view.js';
@@ -55,7 +55,7 @@ beforeEach( () => {
 	dispatcher = new ModelConversionDispatcher( { mapper, viewSelection } );
 
 	dispatcher.on( 'insert:$text', insertText() );
-	dispatcher.on( 'addAttribute:bold', wrap( new ViewAttributeElement( 'strong' ) ) );
+	dispatcher.on( 'addAttribute:bold', wrapItem( new ViewAttributeElement( 'strong' ) ) );
 
 	// Default selection converters.
 	dispatcher.on( 'selection', clearAttributes(), { priority: 'low' } );
@@ -269,7 +269,7 @@ describe( 'clean-up', () => {
 	describe( 'clearAttributes', () => {
 		it( 'should remove all ranges before adding new range', () => {
 			dispatcher.on( 'selectionAttribute:bold', convertSelectionAttribute( new ViewAttributeElement( 'b' ) ) );
-			dispatcher.on( 'addAttribute:style', wrap( new ViewAttributeElement( 'b' ) ) );
+			dispatcher.on( 'addAttribute:style', wrapItem( new ViewAttributeElement( 'b' ) ) );
 
 			test(
 				[ 3, 3 ],
@@ -291,7 +291,7 @@ describe( 'clean-up', () => {
 
 		it( 'should do nothing if the attribute element had been already removed', () => {
 			dispatcher.on( 'selectionAttribute:bold', convertSelectionAttribute( new ViewAttributeElement( 'b' ) ) );
-			dispatcher.on( 'addAttribute:style', wrap( new ViewAttributeElement( 'b' ) ) );
+			dispatcher.on( 'addAttribute:style', wrapItem( new ViewAttributeElement( 'b' ) ) );
 
 			test(
 				[ 3, 3 ],
@@ -338,7 +338,7 @@ describe( 'using element creator for attributes conversion', () => {
 		}
 
 		dispatcher.on( 'selectionAttribute:theme', convertSelectionAttribute( themeElementCreator ) );
-		dispatcher.on( 'addAttribute:theme', wrap( themeElementCreator ) );
+		dispatcher.on( 'addAttribute:theme', wrapItem( themeElementCreator ) );
 
 		dispatcher.on( 'selectionAttribute:italic', convertSelectionAttribute( new ViewAttributeElement( 'em' ) ) );
 	} );

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -24,10 +24,10 @@ import {
 	insertText,
 	setAttribute,
 	removeAttribute,
-	wrap,
-	unwrap,
-	wrapMarker,
-	unwrapMarker,
+	wrapItem,
+	unwrapItem,
+	wrapRange,
+	unwrapRange,
 	move,
 	remove,
 	rename
@@ -263,8 +263,8 @@ describe( 'wrap/unwrap', () => {
 		modelRoot.appendChildren( modelElement );
 		dispatcher.on( 'insert:paragraph', insertElement( viewP ) );
 		dispatcher.on( 'insert:$text', insertText() );
-		dispatcher.on( 'addAttribute:bold', wrap( viewB ) );
-		dispatcher.on( 'removeAttribute:bold', unwrap( viewB ) );
+		dispatcher.on( 'addAttribute:bold', wrapItem( viewB ) );
+		dispatcher.on( 'removeAttribute:bold', unwrapItem( viewB ) );
 
 		dispatcher.convertInsertion( ModelRange.createIn( modelRoot ) );
 
@@ -290,8 +290,8 @@ describe( 'wrap/unwrap', () => {
 		modelRoot.appendChildren( modelElement );
 		dispatcher.on( 'insert:paragraph', insertElement( viewP ) );
 		dispatcher.on( 'insert:$text', insertText() );
-		dispatcher.on( 'addAttribute:style', wrap( elementGenerator ) );
-		dispatcher.on( 'removeAttribute:style', unwrap( elementGenerator ) );
+		dispatcher.on( 'addAttribute:style', wrapItem( elementGenerator ) );
+		dispatcher.on( 'removeAttribute:style', unwrapItem( elementGenerator ) );
 
 		dispatcher.convertInsertion( ModelRange.createIn( modelRoot ) );
 
@@ -318,8 +318,8 @@ describe( 'wrap/unwrap', () => {
 		modelRoot.appendChildren( modelElement );
 		dispatcher.on( 'insert:paragraph', insertElement( viewP ) );
 		dispatcher.on( 'insert:$text', insertText() );
-		dispatcher.on( 'addAttribute:link', wrap( elementGenerator ) );
-		dispatcher.on( 'changeAttribute:link', wrap( elementGenerator ) );
+		dispatcher.on( 'addAttribute:link', wrapItem( elementGenerator ) );
+		dispatcher.on( 'changeAttribute:link', wrapItem( elementGenerator ) );
 
 		dispatcher.convertInsertion(
 			ModelRange.createIn( modelRoot )
@@ -348,8 +348,8 @@ describe( 'wrap/unwrap', () => {
 		modelRoot.appendChildren( modelElement );
 		dispatcher.on( 'insert:paragraph', insertElement( viewP ) );
 		dispatcher.on( 'insert:$text', insertText() );
-		dispatcher.on( 'addAttribute:bold', wrap( viewB ) );
-		dispatcher.on( 'removeAttribute:bold', unwrap( viewB ) );
+		dispatcher.on( 'addAttribute:bold', wrapItem( viewB ) );
+		dispatcher.on( 'removeAttribute:bold', unwrapItem( viewB ) );
 
 		dispatcher.convertInsertion( ModelRange.createIn( modelRoot ) );
 
@@ -370,7 +370,7 @@ describe( 'wrap/unwrap', () => {
 		modelRoot.appendChildren( modelElement );
 		dispatcher.on( 'insert:paragraph', insertElement( viewP ) );
 		dispatcher.on( 'insert:$text', insertText() );
-		dispatcher.on( 'addAttribute:bold', wrap( viewB ) );
+		dispatcher.on( 'addAttribute:bold', wrapItem( viewB ) );
 		dispatcher.on( 'addAttribute:bold', ( evt, data, consumable ) => {
 			consumable.consume( data.item, 'addAttribute:bold' );
 		}, { priority: 'high' } );
@@ -388,8 +388,8 @@ describe( 'wrap/unwrap', () => {
 		modelRoot.appendChildren( modelElement );
 		dispatcher.on( 'insert:paragraph', insertElement( viewP ) );
 		dispatcher.on( 'insert:$text', insertText() );
-		dispatcher.on( 'addAttribute:bold', wrap( viewB ) );
-		dispatcher.on( 'removeAttribute:bold', unwrap( viewB ) );
+		dispatcher.on( 'addAttribute:bold', wrapItem( viewB ) );
+		dispatcher.on( 'removeAttribute:bold', unwrapItem( viewB ) );
 		dispatcher.on( 'removeAttribute:bold', ( evt, data, consumable ) => {
 			consumable.consume( data.item, 'removeAttribute:bold' );
 		}, { priority: 'high' } );
@@ -407,7 +407,7 @@ describe( 'wrap/unwrap', () => {
 	} );
 } );
 
-describe( 'wrapMarker/unwrapMarker', () => {
+describe( 'wrapRange/unwrapRange', () => {
 	let modelText, rangeJohn, rangeAlice, modelElement;
 
 	beforeEach( () => {
@@ -428,8 +428,8 @@ describe( 'wrapMarker/unwrapMarker', () => {
 	it( 'should convert adding/removing of marker into wrapping element in a view', () => {
 		const viewSpan = new ViewAttributeElement( 'span', { class: 'name' } );
 
-		dispatcher.on( 'addMarker:name', wrapMarker( viewSpan ) );
-		dispatcher.on( 'removeMarker:name', unwrapMarker( viewSpan ) );
+		dispatcher.on( 'addMarker:name', wrapRange( viewSpan ) );
+		dispatcher.on( 'removeMarker:name', unwrapRange( viewSpan ) );
 
 		dispatcher.convertMarker( 'addMarker', 'name', rangeJohn );
 
@@ -443,8 +443,8 @@ describe( 'wrapMarker/unwrapMarker', () => {
 	it( 'should support collapsed markers', () => {
 		const viewSpan = new ViewAttributeElement( 'span' );
 
-		dispatcher.on( 'addMarker:name', wrapMarker( viewSpan ) );
-		dispatcher.on( 'removeMarker:name', unwrapMarker( viewSpan ) );
+		dispatcher.on( 'addMarker:name', wrapRange( viewSpan ) );
+		dispatcher.on( 'removeMarker:name', unwrapRange( viewSpan ) );
 
 		const rangeP = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 0 );
 
@@ -469,8 +469,8 @@ describe( 'wrapMarker/unwrapMarker', () => {
 			return new ViewAttributeElement( 'span', { class: name } );
 		};
 
-		dispatcher.on( 'addMarker:name', wrapMarker( converterCallback ) );
-		dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallback ) );
+		dispatcher.on( 'addMarker:name', wrapRange( converterCallback ) );
+		dispatcher.on( 'removeMarker:name', unwrapRange( converterCallback ) );
 
 		dispatcher.convertMarker( 'addMarker', 'name:john', rangeJohn );
 
@@ -508,8 +508,8 @@ describe( 'wrapMarker/unwrapMarker', () => {
 		const range = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement3, 1 );
 		const viewSpan = new ViewAttributeElement( 'span', { class: 'name' } );
 
-		dispatcher.on( 'addMarker:name', wrapMarker( viewSpan ) );
-		dispatcher.on( 'removeMarker:name', unwrapMarker( viewSpan ) );
+		dispatcher.on( 'addMarker:name', wrapRange( viewSpan ) );
+		dispatcher.on( 'removeMarker:name', unwrapRange( viewSpan ) );
 
 		dispatcher.convertMarker( 'addMarker', 'name', range );
 
@@ -522,16 +522,16 @@ describe( 'wrapMarker/unwrapMarker', () => {
 		expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p><p>22</p><p>333</p></div>' );
 	} );
 
-	it( 'should be possible to override wrapMarker', () => {
+	it( 'should be possible to override wrapRange', () => {
 		const converterCallback = ( data ) => {
 			const name = data.name.split( ':' )[ 1 ];
 
 			return new ViewAttributeElement( 'span', { class: name } );
 		};
 
-		dispatcher.on( 'addMarker:name', wrapMarker( converterCallback ) );
+		dispatcher.on( 'addMarker:name', wrapRange( converterCallback ) );
 		dispatcher.on( 'addMarker:name:alice', ( evt, data, consumable ) => {
-			consumable.consume( data.range, 'range' );
+			consumable.consume( data.range, 'addMarker' );
 		}, { priority: 'high' } );
 
 		dispatcher.convertMarker( 'addMarker', 'name:john', rangeJohn );
@@ -540,17 +540,17 @@ describe( 'wrapMarker/unwrapMarker', () => {
 		expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="john">ob</span>ar</p></div>' );
 	} );
 
-	it( 'should be possible to override unwrapMarker', () => {
+	it( 'should be possible to override unwrapRange', () => {
 		const converterCallback = ( data ) => {
 			const name = data.name.split( ':' )[ 1 ];
 
 			return new ViewAttributeElement( 'span', { class: name } );
 		};
 
-		dispatcher.on( 'addMarker:name', wrapMarker( converterCallback ) );
-		dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallback ) );
+		dispatcher.on( 'addMarker:name', wrapRange( converterCallback ) );
+		dispatcher.on( 'removeMarker:name', unwrapRange( converterCallback ) );
 		dispatcher.on( 'removeMarker:name:john', ( evt, data, consumable ) => {
-			consumable.consume( data.range, 'range' );
+			consumable.consume( data.range, 'removeMarker' );
 		}, { priority: 'high' } );
 
 		dispatcher.convertMarker( 'addMarker', 'name:john', rangeJohn );
@@ -565,10 +565,10 @@ describe( 'wrapMarker/unwrapMarker', () => {
 	it( 'should not convert if view element is not returned by element generating function', () => {
 		const converterCallback = () => null;
 
-		dispatcher.on( 'addMarker:name', wrapMarker( converterCallback ) );
+		dispatcher.on( 'addMarker:name', wrapRange( converterCallback ) );
 		dispatcher.on( 'addMarker:name', ( evt, data, consumable ) => {
 			// Check whether value was not consumed from `consumable`.
-			expect( consumable.test( data.range, 'range' ) ).to.be.true;
+			expect( consumable.test( data.range, 'addMarker' ) ).to.be.true;
 		} );
 
 		dispatcher.convertMarker( 'addMarker', 'name', rangeJohn );
@@ -581,10 +581,10 @@ describe( 'wrapMarker/unwrapMarker', () => {
 			const converterCallbackName = ( data ) => new ViewAttributeElement( 'span', { class: data.name.split( ':' )[ 1 ] } );
 			const converterCallbackSearch = () => new ViewAttributeElement( 'em', { class: 'search' } );
 
-			dispatcher.on( 'addMarker:name', wrapMarker( converterCallbackName ) );
-			dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallbackName ) );
-			dispatcher.on( 'addMarker:search', wrapMarker( converterCallbackSearch ) );
-			dispatcher.on( 'removeMarker:search', unwrapMarker( converterCallbackSearch ) );
+			dispatcher.on( 'addMarker:name', wrapRange( converterCallbackName ) );
+			dispatcher.on( 'removeMarker:name', unwrapRange( converterCallbackName ) );
+			dispatcher.on( 'addMarker:search', wrapRange( converterCallbackSearch ) );
+			dispatcher.on( 'removeMarker:search', unwrapRange( converterCallbackSearch ) );
 
 			const range = rangeAlice;
 
@@ -616,10 +616,10 @@ describe( 'wrapMarker/unwrapMarker', () => {
 			};
 			const converterCallbackSearch = () => new ViewAttributeElement( 'em', { class: 'search' } );
 
-			dispatcher.on( 'addMarker:name', wrapMarker( converterCallbackName ) );
-			dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallbackName ) );
-			dispatcher.on( 'addMarker:search', wrapMarker( converterCallbackSearch ) );
-			dispatcher.on( 'removeMarker:search', unwrapMarker( converterCallbackSearch ) );
+			dispatcher.on( 'addMarker:name', wrapRange( converterCallbackName ) );
+			dispatcher.on( 'removeMarker:name', unwrapRange( converterCallbackName ) );
+			dispatcher.on( 'addMarker:search', wrapRange( converterCallbackSearch ) );
+			dispatcher.on( 'removeMarker:search', unwrapRange( converterCallbackSearch ) );
 
 			const range = rangeJohn;
 
@@ -644,8 +644,8 @@ describe( 'wrapMarker/unwrapMarker', () => {
 		it( 'non-collapsed markers intersecting with same priority', () => {
 			const converterCallbackSearch = () => new ViewAttributeElement( 'em', { class: 'search' } );
 
-			dispatcher.on( 'addMarker:search', wrapMarker( converterCallbackSearch ) );
-			dispatcher.on( 'removeMarker:search', unwrapMarker( converterCallbackSearch ) );
+			dispatcher.on( 'addMarker:search', wrapRange( converterCallbackSearch ) );
+			dispatcher.on( 'removeMarker:search', unwrapRange( converterCallbackSearch ) );
 
 			const range1 = ModelRange.createFromParentsAndOffsets( modelElement, 1, modelElement, 3 );
 			const range2 = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 );
@@ -679,8 +679,8 @@ describe( 'wrapMarker/unwrapMarker', () => {
 				return element;
 			};
 
-			dispatcher.on( 'addMarker:name', wrapMarker( converterCallbackName ) );
-			dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallbackName ) );
+			dispatcher.on( 'addMarker:name', wrapRange( converterCallbackName ) );
+			dispatcher.on( 'removeMarker:name', unwrapRange( converterCallbackName ) );
 
 			const range1 = ModelRange.createFromParentsAndOffsets( modelElement, 1, modelElement, 5 );
 			const range2 = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 2 );

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -26,6 +26,8 @@ import {
 	removeAttribute,
 	wrap,
 	unwrap,
+	wrapMarker,
+	unwrapMarker,
 	move,
 	remove,
 	rename
@@ -402,6 +404,305 @@ describe( 'wrap/unwrap', () => {
 
 		// Nothing changed.
 		expect( viewToString( viewRoot ) ).to.equal( '<div><p><b>foobar</b></p></div>' );
+	} );
+} );
+
+describe( 'wrapMarker/unwrapMarker', () => {
+	let modelText, rangeJohn, rangeAlice, modelElement;
+
+	beforeEach( () => {
+		modelText = new ModelText( 'foobar' );
+		modelElement = new ModelElement( 'paragraph', null, modelText );
+		modelRoot.appendChildren( modelElement );
+
+		const viewText = new ViewText( 'foobar' );
+		const viewElement = new ViewContainerElement( 'p', null, viewText );
+		viewRoot.appendChildren( viewElement );
+
+		mapper.bindElements( modelElement, viewElement );
+
+		rangeJohn = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 );
+		rangeAlice = ModelRange.createFromParentsAndOffsets( modelElement, 1, modelElement, 1 );
+	} );
+
+	it( 'should convert adding/removing of marker into wrapping element in a view', () => {
+		const viewSpan = new ViewAttributeElement( 'span', { class: 'name' } );
+
+		dispatcher.on( 'addMarker:name', wrapMarker( viewSpan ) );
+		dispatcher.on( 'removeMarker:name', unwrapMarker( viewSpan ) );
+
+		dispatcher.convertMarker( 'addMarker', 'name', rangeJohn );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="name">ob</span>ar</p></div>' );
+
+		dispatcher.convertMarker( 'removeMarker', 'name', rangeJohn );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+	} );
+
+	it( 'should support collapsed markers', () => {
+		const viewSpan = new ViewAttributeElement( 'span' );
+
+		dispatcher.on( 'addMarker:name', wrapMarker( viewSpan ) );
+		dispatcher.on( 'removeMarker:name', unwrapMarker( viewSpan ) );
+
+		const rangeP = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 0 );
+
+		dispatcher.convertMarker( 'addMarker', 'name', rangeP );
+		dispatcher.convertMarker( 'addMarker', 'name', rangeAlice );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><span></span><p>f<span></span>oobar</p></div>' );
+
+		dispatcher.convertMarker( 'removeMarker', 'name', rangeP );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<span></span>oobar</p></div>' );
+
+		dispatcher.convertMarker( 'removeMarker', 'name', rangeAlice );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+	} );
+
+	it( 'should convert insert/remove of attribute in model with wrapping element generating function as a parameter', () => {
+		const converterCallback = ( data ) => {
+			const name = data.name.split( ':' )[ 1 ];
+
+			return new ViewAttributeElement( 'span', { class: name } );
+		};
+
+		dispatcher.on( 'addMarker:name', wrapMarker( converterCallback ) );
+		dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallback ) );
+
+		dispatcher.convertMarker( 'addMarker', 'name:john', rangeJohn );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="john">ob</span>ar</p></div>' );
+
+		dispatcher.convertMarker( 'addMarker', 'name:alice', rangeAlice );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<span class="alice"></span>o<span class="john">ob</span>ar</p></div>' );
+
+		dispatcher.convertMarker( 'removeMarker', 'name:john', rangeJohn );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<span class="alice"></span>oobar</p></div>' );
+
+		dispatcher.convertMarker( 'removeMarker', 'name:alice', rangeAlice );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+	} );
+
+	it( 'should support non-flat markers', () => {
+		const modelElement2 = new ModelElement( 'paragraph', null, new ModelText( '22' ) );
+		modelRoot.appendChildren( modelElement2 );
+
+		const modelElement3 = new ModelElement( 'paragraph', null, new ModelText( '333' ) );
+		modelRoot.appendChildren( modelElement3 );
+
+		const viewElement2 = new ViewContainerElement( 'p', null, new ViewText( '22' ) );
+		viewRoot.appendChildren( viewElement2 );
+
+		const viewElement3 = new ViewContainerElement( 'p', null, new ViewText( '333' ) );
+		viewRoot.appendChildren( viewElement3 );
+
+		mapper.bindElements( modelElement2, viewElement2 );
+		mapper.bindElements( modelElement3, viewElement3 );
+
+		const range = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement3, 1 );
+		const viewSpan = new ViewAttributeElement( 'span', { class: 'name' } );
+
+		dispatcher.on( 'addMarker:name', wrapMarker( viewSpan ) );
+		dispatcher.on( 'removeMarker:name', unwrapMarker( viewSpan ) );
+
+		dispatcher.convertMarker( 'addMarker', 'name', range );
+
+		expect( viewToString( viewRoot ) ).to.equal(
+			'<div><p>fo<span class="name">obar</span></p><p><span class="name">22</span></p><p><span class="name">3</span>33</p></div>'
+		);
+
+		dispatcher.convertMarker( 'removeMarker', 'name', range );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p><p>22</p><p>333</p></div>' );
+	} );
+
+	it( 'should be possible to override wrapMarker', () => {
+		const converterCallback = ( data ) => {
+			const name = data.name.split( ':' )[ 1 ];
+
+			return new ViewAttributeElement( 'span', { class: name } );
+		};
+
+		dispatcher.on( 'addMarker:name', wrapMarker( converterCallback ) );
+		dispatcher.on( 'addMarker:name:alice', ( evt, data, consumable ) => {
+			consumable.consume( data.range, 'range' );
+		}, { priority: 'high' } );
+
+		dispatcher.convertMarker( 'addMarker', 'name:john', rangeJohn );
+		dispatcher.convertMarker( 'addMarker', 'name:alice', rangeAlice );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="john">ob</span>ar</p></div>' );
+	} );
+
+	it( 'should be possible to override unwrapMarker', () => {
+		const converterCallback = ( data ) => {
+			const name = data.name.split( ':' )[ 1 ];
+
+			return new ViewAttributeElement( 'span', { class: name } );
+		};
+
+		dispatcher.on( 'addMarker:name', wrapMarker( converterCallback ) );
+		dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallback ) );
+		dispatcher.on( 'removeMarker:name:john', ( evt, data, consumable ) => {
+			consumable.consume( data.range, 'range' );
+		}, { priority: 'high' } );
+
+		dispatcher.convertMarker( 'addMarker', 'name:john', rangeJohn );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="john">ob</span>ar</p></div>' );
+
+		dispatcher.convertMarker( 'removeMarker', 'name:john', rangeJohn );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="john">ob</span>ar</p></div>' );
+	} );
+
+	it( 'should not convert if view element is not returned by element generating function', () => {
+		const converterCallback = () => null;
+
+		dispatcher.on( 'addMarker:name', wrapMarker( converterCallback ) );
+		dispatcher.on( 'addMarker:name', ( evt, data, consumable ) => {
+			// Check whether value was not consumed from `consumable`.
+			expect( consumable.test( data.range, 'range' ) ).to.be.true;
+		} );
+
+		dispatcher.convertMarker( 'addMarker', 'name', rangeJohn );
+
+		expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+	} );
+
+	describe( 'multiple overlapping markers', () => {
+		it( 'collapsed markers', () => {
+			const converterCallbackName = ( data ) => new ViewAttributeElement( 'span', { class: data.name.split( ':' )[ 1 ] } );
+			const converterCallbackSearch = () => new ViewAttributeElement( 'em', { class: 'search' } );
+
+			dispatcher.on( 'addMarker:name', wrapMarker( converterCallbackName ) );
+			dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallbackName ) );
+			dispatcher.on( 'addMarker:search', wrapMarker( converterCallbackSearch ) );
+			dispatcher.on( 'removeMarker:search', unwrapMarker( converterCallbackSearch ) );
+
+			const range = rangeAlice;
+
+			dispatcher.convertMarker( 'addMarker', 'name:a', range );
+			dispatcher.convertMarker( 'addMarker', 'name:b', range );
+			dispatcher.convertMarker( 'addMarker', 'search', range );
+
+			expect( viewToString( viewRoot ) ).to.equal(
+				'<div><p>f<em class="search"></em><span class="b"></span><span class="a"></span>oobar</p></div>'
+			);
+
+			dispatcher.convertMarker( 'removeMarker', 'name:b', range );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<em class="search"></em><span class="a"></span>oobar</p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'search', range );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<span class="a"></span>oobar</p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'name:a', range );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+		} );
+
+		it( 'non-collapsed markers', () => {
+			const converterCallbackName = ( data ) => {
+				const name = data.name.split( ':' )[ 1 ];
+				const element = new ViewAttributeElement( 'span', { class: name } );
+				element.priority = name.charCodeAt( 0 );
+
+				return element;
+			};
+			const converterCallbackSearch = () => new ViewAttributeElement( 'em', { class: 'search' } );
+
+			dispatcher.on( 'addMarker:name', wrapMarker( converterCallbackName ) );
+			dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallbackName ) );
+			dispatcher.on( 'addMarker:search', wrapMarker( converterCallbackSearch ) );
+			dispatcher.on( 'removeMarker:search', unwrapMarker( converterCallbackSearch ) );
+
+			const range = rangeJohn;
+
+			dispatcher.convertMarker( 'addMarker', 'name:a', range );
+			dispatcher.convertMarker( 'addMarker', 'name:b', range );
+			dispatcher.convertMarker( 'addMarker', 'search', range );
+
+			expect( viewToString( viewRoot ) ).to.equal(
+				'<div><p>fo<em class="search"><span class="a"><span class="b">ob</span></span></em>ar</p></div>'
+			);
+
+			dispatcher.convertMarker( 'removeMarker', 'name:b', range );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<em class="search"><span class="a">ob</span></em>ar</p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'search', range );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="a">ob</span>ar</p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'name:a', range );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+		} );
+
+		it( 'non-collapsed markers intersecting with same priority', () => {
+			const converterCallbackSearch = () => new ViewAttributeElement( 'em', { class: 'search' } );
+
+			dispatcher.on( 'addMarker:search', wrapMarker( converterCallbackSearch ) );
+			dispatcher.on( 'removeMarker:search', unwrapMarker( converterCallbackSearch ) );
+
+			const range1 = ModelRange.createFromParentsAndOffsets( modelElement, 1, modelElement, 3 );
+			const range2 = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 );
+			const range3 = ModelRange.createFromParentsAndOffsets( modelElement, 4, modelElement, 6 );
+
+			dispatcher.convertMarker( 'addMarker', 'search', range1 );
+			dispatcher.convertMarker( 'addMarker', 'search', range2 );
+
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<em class="search">oob</em>ar</p></div>' );
+
+			dispatcher.convertMarker( 'addMarker', 'search', range3 );
+
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<em class="search">oobar</em></p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'search', range2 );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<em class="search">o</em>ob<em class="search">ar</em></p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'search', range3 );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<em class="search">o</em>obar</p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'search', range1 );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+		} );
+
+		it( 'collapsed and non-collapsed markers', () => {
+			const converterCallbackName = ( data ) => {
+				const name = data.name.split( ':' )[ 1 ];
+				const element = new ViewAttributeElement( 'span', { class: name } );
+				element.priority = name.charCodeAt( 0 );
+
+				return element;
+			};
+
+			dispatcher.on( 'addMarker:name', wrapMarker( converterCallbackName ) );
+			dispatcher.on( 'removeMarker:name', unwrapMarker( converterCallbackName ) );
+
+			const range1 = ModelRange.createFromParentsAndOffsets( modelElement, 1, modelElement, 5 );
+			const range2 = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 2 );
+			const range3 = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 );
+
+			dispatcher.convertMarker( 'addMarker', 'name:a', range1 );
+			dispatcher.convertMarker( 'addMarker', 'name:b', range2 );
+			dispatcher.convertMarker( 'addMarker', 'name:c', range3 );
+
+			expect( viewToString( viewRoot ) ).to.equal(
+				'<div><p>f<span class="a">o<span class="b"></span><span class="c">ob</span>a</span>r</p></div>'
+			);
+
+			dispatcher.convertMarker( 'removeMarker', 'name:c', range3 );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<span class="a">o<span class="b"></span>oba</span>r</p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'name:b', range2 );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>f<span class="a">ooba</span>r</p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'name:a', range1 );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+		} );
 	} );
 } );
 

--- a/tests/conversion/modelconversiondispatcher.js
+++ b/tests/conversion/modelconversiondispatcher.js
@@ -311,7 +311,7 @@ describe( 'ModelConversionDispatcher', () => {
 	} );
 
 	describe( 'convertMove', () => {
-		it( 'should fire event for moved range', () => {
+		it( 'should fire event for moved range - move before source position', () => {
 			root.appendChildren( new ModelText( 'barfoo' ) );
 
 			const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 3 );
@@ -322,9 +322,25 @@ describe( 'ModelConversionDispatcher', () => {
 				loggedEvents.push( log );
 			} );
 
+			dispatcher.convertMove( ModelPosition.createFromParentAndOffset( root , 3 ), range );
+
+			expect( loggedEvents ).to.deep.equal( [ 'move:3:0:3' ] );
+		} );
+
+		it( 'should fire event for moved range - move after source position', () => {
+			root.appendChildren( new ModelText( 'barfoo' ) );
+
+			const range = ModelRange.createFromParentsAndOffsets( root, 3, root, 6 );
+			const loggedEvents = [];
+
+			dispatcher.on( 'move', ( evt, data ) => {
+				const log = 'move:' + data.sourcePosition.path + ':' + data.targetPosition.path + ':' + data.item.offsetSize;
+				loggedEvents.push( log );
+			} );
+
 			dispatcher.convertMove( ModelPosition.createFromParentAndOffset( root , 0 ), range );
 
-			expect( loggedEvents ).to.deep.equal( [ 'move:0:3:3' ] );
+			expect( loggedEvents ).to.deep.equal( [ 'move:0:6:3' ] );
 		} );
 	} );
 

--- a/tests/conversion/modelconversiondispatcher.js
+++ b/tests/conversion/modelconversiondispatcher.js
@@ -506,4 +506,47 @@ describe( 'ModelConversionDispatcher', () => {
 			expect( dispatcher.fire.calledWith( 'selectionAttribute:bold' ) ).to.be.false;
 		} );
 	} );
+
+	describe( 'convertMarker', () => {
+		let range;
+
+		beforeEach( () => {
+			range = ModelRange.createFromParentsAndOffsets( root, 0, root, 4 );
+		} );
+
+		it( 'should fire event based on passed parameters', () => {
+			sinon.spy( dispatcher, 'fire' );
+
+			const data = {
+				name: 'name',
+				range: range
+			};
+
+			dispatcher.convertMarker( 'addMarker', data );
+
+			expect( dispatcher.fire.calledWith( 'addMarker:name', data ) );
+
+			dispatcher.convertMarker( 'removeMarker', data );
+
+			expect( dispatcher.fire.calledWith( 'removeMarker:name', data ) );
+		} );
+
+		it( 'should prepare consumable values', () => {
+			const data = {
+				name: 'name',
+				range: range
+			};
+
+			dispatcher.on( 'addMarker:name', ( evt, data, consumable ) => {
+				expect( consumable.test( data.range, 'range' ) ).to.be.true;
+			} );
+
+			dispatcher.on( 'removeMarker:name', ( evt, data, consumable ) => {
+				expect( consumable.test( data.range, 'range' ) ).to.be.true;
+			} );
+
+			dispatcher.convertMarker( 'addMarker', data );
+			dispatcher.convertMarker( 'removeMarker', data );
+		} );
+	} );
 } );

--- a/tests/manual/tickets/643/1.html
+++ b/tests/manual/tickets/643/1.html
@@ -1,0 +1,33 @@
+<head>
+	<link rel="stylesheet" href="%APPS_DIR%ckeditor/build/modules/amd/theme/ckeditor.css">
+	<style>
+		.h-red { display: inline-block; background: #FF0000; }
+		.h-yellow { display: inline-block; background: #FFFF00; }
+	</style>
+</head>
+
+<div id="editor">
+	<p>Lorem ipsum dolor sit amet.</p>
+	<p>Foobar.</p>
+</div>
+<br/>
+<div class="buttons">
+	<button id="add-yellow">Add yellow</button>
+	<button id="add-red">Add red</button>
+	<button id="remove-marker">Remove marker</button>
+	<br />
+	<button id="move-to-start">Move selection to start</button>
+	<button id="move-left">Move selection one char left</button>
+	<button id="move-right">Move selection one char right</button>
+</div>
+<br /><br />
+<small>
+	<em>
+		Keep in mind that this is just a simple demo.<br />
+		Highlighted markers do not merge (in model), remove button removes the first marker range which contains selection anchor.<br />
+		Once highlighted, highlight cannot be overwritten.<br />
+		Multi-element ranges are not supported<br />
+		Moving to the start button works only for flat ranges<br />
+		These are all known limitations of the demo.
+	</em>
+</small>

--- a/tests/manual/tickets/643/1.html
+++ b/tests/manual/tickets/643/1.html
@@ -1,5 +1,5 @@
 <head>
-	<link rel="stylesheet" href="%APPS_DIR%ckeditor/build/modules/amd/theme/ckeditor.css">
+	<link rel="stylesheet" href="/theme/ckeditor.css">
 	<style>
 		.h-red { display: inline-block; background: #FF0000; }
 		.h-yellow { display: inline-block; background: #FFFF00; }

--- a/tests/manual/tickets/643/1.js
+++ b/tests/manual/tickets/643/1.js
@@ -5,21 +5,20 @@
 
 /* globals console, window, document */
 
-import ClassicEditor from '/ckeditor5/editor-classic/classic.js';
-import Enter from '/ckeditor5/enter/enter.js';
-import Typing from '/ckeditor5/typing/typing.js';
-import Paragraph from '/ckeditor5/paragraph/paragraph.js';
-import Bold from '/ckeditor5/basic-styles/bold.js';
-import Italic from '/ckeditor5/basic-styles/italic.js';
-import List from '/ckeditor5/list/list.js';
-import Heading from '/ckeditor5/heading/heading.js';
-import Undo from '/ckeditor5/undo/undo.js';
+import ClassicEditor from 'ckeditor5/editor-classic/classic.js';
+import Enter from 'ckeditor5/enter/enter.js';
+import Typing from 'ckeditor5/typing/typing.js';
+import Paragraph from 'ckeditor5/paragraph/paragraph.js';
+import Bold from 'ckeditor5/basic-styles/bold.js';
+import Italic from 'ckeditor5/basic-styles/italic.js';
+import List from 'ckeditor5/list/list.js';
+import Heading from 'ckeditor5/heading/heading.js';
+import Undo from 'ckeditor5/undo/undo.js';
 
-//import { wrapMarker, unwrapMarker } from '/ckeditor5/engine/conversion/model-to-view-converters.js';
-import buildModelConverter from '/ckeditor5/engine/conversion/buildmodelconverter.js';
-import Position from '/ckeditor5/engine/model/position.js';
-import LiveRange from '/ckeditor5/engine/model/liverange.js';
-import ViewAttributeElement from '/ckeditor5/engine/view/attributeelement.js';
+import buildModelConverter from 'ckeditor5/engine/conversion/buildmodelconverter.js';
+import Position from 'ckeditor5/engine/model/position.js';
+import LiveRange from 'ckeditor5/engine/model/liverange.js';
+import ViewAttributeElement from 'ckeditor5/engine/view/attributeelement.js';
 
 let model = null;
 

--- a/tests/manual/tickets/643/1.js
+++ b/tests/manual/tickets/643/1.js
@@ -48,23 +48,30 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 	model.enqueueChanges( () => {
 		const root = model.getRoot();
 		const range = new LiveRange( new Position( root, [ 0, 10 ] ), new Position( root, [ 0, 16 ] ) );
+		const name = 'highlight:yellow:' + uid();
 
-		ranges.push( range );
-		model.markers.addRange( range, 'highlight:yellow' );
+		markerNames.push( name );
+		model.markers.add( name, range );
 	} );
 } )
 .catch( err => {
 	console.error( err.stack );
 } );
 
-const ranges = [];
+const markerNames = [];
+let _uid = 1;
+
+function uid() {
+	return _uid++;
+}
 
 function addHighlight( color ) {
 	model.enqueueChanges( () => {
 		const range = LiveRange.createFromRange( model.selection.getFirstRange() );
+		const name = 'highlight:' + color + ':' + uid();
 
-		ranges.push( range );
-		model.markers.addRange( range, 'highlight:' + color );
+		markerNames.push( name );
+		model.markers.add( name, range );
 	} );
 }
 
@@ -72,12 +79,15 @@ function removeHighlight() {
 	model.enqueueChanges( () => {
 		const pos = model.selection.getFirstPosition();
 
-		for ( let i = 0; i < ranges.length; i++ ) {
-			if ( ranges[ i ].containsPosition( pos ) || ranges[ i ].start.isEqual( pos ) || ranges[ i ].end.isEqual( pos ) ) {
-				model.markers.removeRange( ranges[ i ] );
+		for ( let i = 0; i < markerNames.length; i++ ) {
+			const name = markerNames[ i ];
+			const range = model.markers.get( name );
 
-				ranges[ i ].detach();
-				ranges.splice( i, 1 );
+			if ( range.containsPosition( pos ) || range.start.isEqual( pos ) || range.end.isEqual( pos ) ) {
+				model.markers.remove( name );
+				range.detach();
+
+				markerNames.splice( i, 1 );
 				break;
 			}
 		}

--- a/tests/manual/tickets/643/1.js
+++ b/tests/manual/tickets/643/1.js
@@ -1,0 +1,107 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '/ckeditor5/editor-classic/classic.js';
+import Enter from '/ckeditor5/enter/enter.js';
+import Typing from '/ckeditor5/typing/typing.js';
+import Paragraph from '/ckeditor5/paragraph/paragraph.js';
+import Bold from '/ckeditor5/basic-styles/bold.js';
+import Italic from '/ckeditor5/basic-styles/italic.js';
+import List from '/ckeditor5/list/list.js';
+import Heading from '/ckeditor5/heading/heading.js';
+import Undo from '/ckeditor5/undo/undo.js';
+
+//import { wrapMarker, unwrapMarker } from '/ckeditor5/engine/conversion/model-to-view-converters.js';
+import buildModelConverter from '/ckeditor5/engine/conversion/buildmodelconverter.js';
+import Position from '/ckeditor5/engine/model/position.js';
+import LiveRange from '/ckeditor5/engine/model/liverange.js';
+import ViewAttributeElement from '/ckeditor5/engine/view/attributeelement.js';
+
+let model = null;
+
+ClassicEditor.create( document.querySelector( '#editor' ), {
+	plugins: [ Enter, Typing, Paragraph, Bold, Italic, List, Heading, Undo ],
+	toolbar: [ 'headings', 'bold', 'italic', 'bulletedList', 'numberedList', 'undo', 'redo' ]
+} )
+.then( editor => {
+	window.editor = editor;
+	model = window.editor.editing.model;
+
+	buildModelConverter().for( editor.editing.modelToView ).
+		fromMarker( 'highlight' ).
+		toElement( ( data ) => {
+			const color = data.name.split( ':' )[ 1 ];
+
+			return new ViewAttributeElement( 'span', { class: 'h-' + color } );
+		} );
+
+	window.document.getElementById( 'add-yellow' ).addEventListener( 'click', () => addHighlight( 'yellow' ) );
+	window.document.getElementById( 'add-red' ).addEventListener( 'click', () => addHighlight( 'red' ) );
+	window.document.getElementById( 'remove-marker' ).addEventListener( 'click', () => removeHighlight() );
+	window.document.getElementById( 'move-to-start' ).addEventListener( 'click', () => moveSelectionToStart() );
+	window.document.getElementById( 'move-left' ).addEventListener( 'click', () => moveSelectionByOffset( -1 ) );
+	window.document.getElementById( 'move-right' ).addEventListener( 'click', () => moveSelectionByOffset( 1 ) );
+
+	model.enqueueChanges( () => {
+		const root = model.getRoot();
+		const range = new LiveRange( new Position( root, [ 0, 10 ] ), new Position( root, [ 0, 16 ] ) );
+
+		ranges.push( range );
+		model.markers.addRange( range, 'highlight:yellow' );
+	} );
+} )
+.catch( err => {
+	console.error( err.stack );
+} );
+
+const ranges = [];
+
+function addHighlight( color ) {
+	model.enqueueChanges( () => {
+		const range = LiveRange.createFromRange( model.selection.getFirstRange() );
+
+		ranges.push( range );
+		model.markers.addRange( range, 'highlight:' + color );
+	} );
+}
+
+function removeHighlight() {
+	model.enqueueChanges( () => {
+		const pos = model.selection.getFirstPosition();
+
+		for ( let i = 0; i < ranges.length; i++ ) {
+			if ( ranges[ i ].containsPosition( pos ) || ranges[ i ].start.isEqual( pos ) || ranges[ i ].end.isEqual( pos ) ) {
+				model.markers.removeRange( ranges[ i ] );
+
+				ranges[ i ].detach();
+				ranges.splice( i, 1 );
+				break;
+			}
+		}
+	} );
+}
+
+function moveSelectionToStart() {
+	const range = model.selection.getFirstRange();
+
+	if ( range.isFlat ) {
+		model.enqueueChanges( () => {
+			model.batch().move( range, new Position( model.getRoot(), [ 0, 0 ] ) );
+		} );
+	}
+}
+
+function moveSelectionByOffset( offset ) {
+	const range = model.selection.getFirstRange();
+	const pos = offset < 0 ? range.start : range.end;
+
+	if ( range.isFlat ) {
+		model.enqueueChanges( () => {
+			model.batch().move( range, pos.getShiftedBy( offset ) );
+		} );
+	}
+}

--- a/tests/manual/tickets/643/1.md
+++ b/tests/manual/tickets/643/1.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: ticket, 643, iteration5
+
+### Markers integration [#643](https://github.com/ckeditor/ckeditor5-engine/issues/643)
+
+1. Write before, after and inside marked text.
+2. Remove before, after and inside marked text.
+3. Make selection intersecting with marked text and remove it.
+4. Make selection intersecting with marked text and start typing.
+5. Style text and see if marked selection brakes in some way.
+6. Click enter inside marked text.
+7. Change a paragraph with marked text to a list item or header.
+8. Remove all marked text and see if there are no artifacts.
+9. Use undo.
+10. Use buttons to create and remove markers.
+11. Make different selections and play with "move to start" button.

--- a/tests/model/delta/transform/_utils/utils.js
+++ b/tests/model/delta/transform/_utils/utils.js
@@ -15,6 +15,7 @@ import Range from 'ckeditor5/engine/model/range.js';
 import AttributeDelta from 'ckeditor5/engine/model/delta/attributedelta.js';
 import InsertDelta from 'ckeditor5/engine/model/delta/insertdelta.js';
 import WeakInsertDelta from 'ckeditor5/engine/model/delta/weakinsertdelta.js';
+import RenameDelta from 'ckeditor5/engine/model/delta/renamedelta.js';
 import RemoveDelta from 'ckeditor5/engine/model/delta/removedelta.js';
 import MoveDelta from 'ckeditor5/engine/model/delta/movedelta.js';
 import MergeDelta from 'ckeditor5/engine/model/delta/mergedelta.js';
@@ -26,6 +27,7 @@ import AttributeOperation from 'ckeditor5/engine/model/operation/attributeoperat
 import InsertOperation from 'ckeditor5/engine/model/operation/insertoperation.js';
 import MoveOperation from 'ckeditor5/engine/model/operation/moveoperation.js';
 import RemoveOperation from 'ckeditor5/engine/model/operation/removeoperation.js';
+import RenameOperation from 'ckeditor5/engine/model/operation/renameoperation.js';
 
 export function getAttributeDelta( range, key, oldValue, newValue, version ) {
 	let delta = new AttributeDelta();
@@ -81,6 +83,15 @@ export function getRemoveDelta( sourcePosition, howMany, baseVersion ) {
 
 	let remove = new RemoveOperation( sourcePosition, howMany, baseVersion );
 	delta.addOperation( remove );
+
+	return delta;
+}
+
+export function getRenameDelta( position, oldName, newName, baseVersion ) {
+	let delta = new RenameDelta();
+
+	let rename = new RenameOperation( position, oldName, newName, baseVersion );
+	delta.addOperation( rename );
 
 	return delta;
 }

--- a/tests/model/liverange.js
+++ b/tests/model/liverange.js
@@ -367,7 +367,7 @@ describe( 'LiveRange', () => {
 				live.end.path = [ 0, 1, 12 ];
 
 				let moveSource = new Position( root, [ 0, 1, 2 ] );
-				let moveRange = new Range( new Position( root, [ 0, 1, 5 ] ), new Position( root, [ 0, 1, 9 ] ) );
+				let moveRange = new Range( new Position( root, [ 0, 1, 7 ] ), new Position( root, [ 0, 1, 10 ] ) );
 
 				let changes = {
 					range: moveRange,

--- a/tests/model/markerscollection.js
+++ b/tests/model/markerscollection.js
@@ -75,7 +75,7 @@ describe( 'MarkersCollection', () => {
 	} );
 
 	describe( 'remove', () => {
-		it( 'should return true and fire remove event if range is removed - passed name', () => {
+		it( 'should return true and fire remove event if range is removed', () => {
 			markers.add( 'name', live );
 
 			sinon.spy( markers, 'fire' );
@@ -87,41 +87,15 @@ describe( 'MarkersCollection', () => {
 			} );
 
 			const result = markers.remove( 'name' );
-
-			expect( result ).to.be.true;
-			expect( markers.fire.calledWith( 'remove' ) ).to.be.true;
-		} );
-
-		it( 'should return true and fire remove event if range is removed - passed range', () => {
-			markers.add( 'name', live );
-
-			sinon.spy( markers, 'fire' );
-
-			markers.on( 'remove', ( evt, name, range ) => {
-				expect( name ).to.equal( 'name' );
-				expect( range.isEqual( live ) ).to.be.true;
-				expect( range ).not.to.equal( live );
-			} );
-
-			const result = markers.remove( live );
 
 			expect( result ).to.be.true;
 			expect( markers.fire.calledWith( 'remove' ) ).to.be.true;
 		} );
 
 		it( 'should return false if name has not been found in collection', () => {
-			const result = markers.remove( 'name' );
-
-			expect( result ).to.be.false;
-		} );
-
-		it( 'should return false if range has not been found in collection', () => {
 			markers.add( 'name', live );
 
-			const other = LiveRange.createFromParentsAndOffsets( root, 0, root, 4 );
-			const result = markers.remove( other );
-
-			other.detach();
+			const result = markers.remove( 'other' );
 
 			expect( result ).to.be.false;
 		} );
@@ -138,7 +112,7 @@ describe( 'MarkersCollection', () => {
 			newLive.detach();
 		} );
 
-		it( 'should return true and use remove and add methods if range was found in collection - passed name', () => {
+		it( 'should return true and use remove and add methods if range was found in collection', () => {
 			const newLive = LiveRange.createFromParentsAndOffsets( root, 1, root, 5 );
 			markers.add( 'name', live );
 
@@ -146,22 +120,6 @@ describe( 'MarkersCollection', () => {
 			sinon.spy( markers, 'add' );
 
 			const result = markers.update( 'name', newLive );
-
-			expect( markers.remove.calledWith( 'name' ) ).to.be.true;
-			expect( markers.add.calledWith( 'name', newLive ) ).to.be.true;
-			expect( result ).to.be.true;
-
-			newLive.detach();
-		} );
-
-		it( 'should return true and use remove and add methods if range was found in collection - passed range', () => {
-			const newLive = LiveRange.createFromParentsAndOffsets( root, 1, root, 5 );
-			markers.add( 'name', live );
-
-			sinon.spy( markers, 'remove' );
-			sinon.spy( markers, 'add' );
-
-			const result = markers.update( live, newLive );
 
 			expect( markers.remove.calledWith( 'name' ) ).to.be.true;
 			expect( markers.add.calledWith( 'name', newLive ) ).to.be.true;
@@ -172,12 +130,6 @@ describe( 'MarkersCollection', () => {
 
 		it( 'should return false if given name was not found in collection', () => {
 			const result = markers.update( 'name', newLive );
-
-			expect( result ).to.be.false;
-		} );
-
-		it( 'should return false if given range was not found in collection', () => {
-			const result = markers.update( live, newLive );
 
 			expect( result ).to.be.false;
 		} );

--- a/tests/model/markerscollection.js
+++ b/tests/model/markerscollection.js
@@ -1,0 +1,142 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* bender-tags: model */
+
+import MarkersCollection from 'ckeditor5/engine/model/markerscollection.js';
+import Range from 'ckeditor5/engine/model/range.js';
+import LiveRange from 'ckeditor5/engine/model/liverange.js';
+import Document from 'ckeditor5/engine/model/document.js';
+import CKEditorError from 'ckeditor5/utils/ckeditorerror.js';
+
+let markers, live, doc, root;
+
+beforeEach( () => {
+	doc = new Document();
+	markers = new MarkersCollection();
+
+	root = doc.createRoot();
+	live = LiveRange.createFromParentsAndOffsets( root, 0, root, 4 );
+} );
+
+afterEach( () => {
+	markers.destroy();
+	live.detach();
+} );
+
+describe( 'MarkersCollection', () => {
+	describe( 'addRange', () => {
+		it( 'should throw if passed parameter is not a LiveRange', () => {
+			const range = Range.createFromParentsAndOffsets( root, 1, root, 3 );
+
+			expect( () => {
+				markers.addRange( range, 'name' );
+			} ).to.throw( CKEditorError, /^markers-collection-add-range-not-live-range/ );
+		} );
+
+		it( 'should fire addMarker event when range is added', () => {
+			sinon.spy( markers, 'fire' );
+
+			markers.on( 'addMarker', ( evt, name, range ) => {
+				expect( name ).to.equal( 'name' );
+				expect( range.isEqual( live ) ).to.be.true;
+				expect( range ).not.to.equal( live );
+			} );
+
+			markers.addRange( live, 'name' );
+
+			expect( markers.fire.calledWith( 'addMarker' ) ).to.be.true;
+		} );
+
+		it( 'should throw if given range was already added', () => {
+			markers.addRange( live, 'name' );
+
+			expect( () => {
+				markers.addRange( live, 'otherName' );
+			} ).to.throw( CKEditorError, /^markers-collection-add-range-already-added/ );
+		} );
+	} );
+
+	describe( 'removeRange', () => {
+		it( 'should return false if range has not been found in collection', () => {
+			const result = markers.removeRange( live );
+
+			expect( result ).to.be.false;
+		} );
+
+		it( 'should return true and fire removeMarker event if range is removed', () => {
+			markers.addRange( live, 'name' );
+
+			sinon.spy( markers, 'fire' );
+
+			markers.on( 'removeMarker', ( evt, name, range ) => {
+				expect( name ).to.equal( 'name' );
+				expect( range.isEqual( live ) ).to.be.true;
+				expect( range ).not.to.equal( live );
+			} );
+
+			const result = markers.removeRange( live );
+
+			expect( result ).to.be.true;
+			expect( markers.fire.calledWith( 'removeMarker' ) ).to.be.true;
+		} );
+
+		it( 'should make MarkersCollection stop listening to range change event', () => {
+			markers.addRange( live, 'name' );
+			markers.removeRange( live );
+
+			sinon.spy( markers, 'fire' );
+
+			// Simulate LiveRange change.
+			const oldRange = Range.createFromRange( live );
+			live.end.path[ 0 ]++;
+			live.fire( 'change', oldRange );
+
+			expect( markers.fire.called ).to.be.false;
+		} );
+	} );
+
+	describe( 'updateRange', () => {
+		let newLive;
+
+		beforeEach( () => {
+			newLive = LiveRange.createFromParentsAndOffsets( root, 1, root, 5 );
+		} );
+
+		afterEach( () => {
+			newLive.detach();
+		} );
+
+		it( 'should return false if given range was not found in collection', () => {
+			const result = markers.updateRange( live, newLive );
+
+			expect( result ).to.be.false;
+		} );
+
+		it( 'should return true and use removeRange and addRange methods if range was found in collection', () => {
+			const newLive = LiveRange.createFromParentsAndOffsets( root, 1, root, 5 );
+			markers.addRange( live, 'name' );
+
+			sinon.spy( markers, 'removeRange' );
+			sinon.spy( markers, 'addRange' );
+
+			const result = markers.updateRange( live, newLive );
+
+			expect( markers.removeRange.calledWith( live ) ).to.be.true;
+			expect( markers.addRange.calledWith( newLive, 'name' ) ).to.be.true;
+			expect( result ).to.be.true;
+		} );
+	} );
+
+	describe( 'destroy', () => {
+		it( 'should make MarkersCollection stop listening to all events', () => {
+			sinon.spy( markers, 'stopListening' );
+
+			markers.destroy();
+
+			expect( markers.stopListening.calledWithExactly() ).to.be.true;
+		} );
+	} );
+} );

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -487,14 +487,6 @@ describe( 'Range', () => {
 			expect( transformed[ 0 ].end.path ).to.deep.equal( [ 4, 4 ] );
 		} );
 
-		it( 'should not change if the range is collapsed and isSticky is false', () => {
-			const range = new Range( new Position( root, [ 3, 2 ] ), new Position( root, [ 3, 2 ] ) );
-			const transformed = range._getTransformedByInsertion( new Position( root, [ 3, 2 ] ), 3, false, false );
-
-			expect( transformed[ 0 ].start.path ).to.deep.equal( [ 3, 2 ] );
-			expect( transformed[ 0 ].end.path ).to.deep.equal( [ 3, 2 ] );
-		} );
-
 		it( 'should move after inserted nodes if the range is collapsed and isSticky is true', () => {
 			const range = new Range( new Position( root, [ 3, 2 ] ), new Position( root, [ 3, 2 ] ) );
 			const transformed = range._getTransformedByInsertion( new Position( root, [ 3, 2 ] ), 3, false, true );

--- a/tests/view/writer/move.js
+++ b/tests/view/writer/move.js
@@ -119,6 +119,17 @@ describe( 'writer', () => {
 			expect( stringify( view, newRange, { showType: true } ) ).to.equal( expectedView );
 		} );
 
+		it( 'should correctly move text nodes inside same container', () => {
+			let { view, selection } = parse( '<container:p><attribute:b>a{b</attribute:b>xx<attribute:b>c}d</attribute:b>yy</container:p>' );
+
+			const viewText = view.getChild( 3 );
+			const newRange = move( selection.getFirstRange(), ViewPosition.createAt( viewText, 1 ) );
+
+			expect( stringify( view, newRange, { showType: true } ) ).to.equal(
+				'<container:p><attribute:b>ad</attribute:b>y[<attribute:b>b</attribute:b>xx<attribute:b>c</attribute:b>]y</container:p>'
+			);
+		} );
+
 		it( 'should move EmptyElement', () => {
 			test(
 				'<container:p>foo[<empty:img></empty:img>]bar</container:p>',


### PR DESCRIPTION
This PR introduces markers implementation in CKEditor5 engine. Fixes #643.

Other than that some changes and fixes has been done:
* `Mapper` position mapping events have changed, now callbacks receive position mapped by default algorithm (previously default mapping was a lowest priority callback). This way default mapping can be used in custom callbacks.
* `LiveRange` transformation has been changed. `LiveRange` is not sticky anymore (which was weird from UX perspective).
* `Range.createFromRanges` was introduced, it glues multiple ranges into one. Useful after a range is transformed.
* `view.Writer.move` and `ModelConversionDispatcher#convertMove` were fixed.
* other slight fixes.

Related PRs and follow-up issues will be linked in comments below.