### PR TITLE
Changed: Range#_getTransformedByMove better UX for transforming collapsed range.

### DIFF
--- a/src/model/range.js
+++ b/src/model/range.js
@@ -442,6 +442,12 @@ export default class Range {
 	 * @returns {Array.<module:engine/model/range~Range>} Result of the transformation.
 	 */
 	_getTransformedByMove( sourcePosition, targetPosition, howMany, spread, isSticky = false ) {
+		if ( this.isCollapsed ) {
+			const newPos = this.start._getTransformedByMove( sourcePosition, targetPosition, howMany, true, true );
+
+			return [ new Range( newPos ) ];
+		}
+
 		let result;
 
 		const moveRange = new Range( sourcePosition, sourcePosition.getShiftedBy( howMany ) );

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -555,6 +555,22 @@ describe( 'Range', () => {
 			expect( transformed[ 0 ].start.path ).to.deep.equal( [ 4, 2 ] );
 			expect( transformed[ 0 ].end.path ).to.deep.equal( [ 4, 7 ] );
 		} );
+
+		it( 'should stick to moved range, if the transformed range is collapsed #1', () => {
+			const range = new Range( new Position( root, [ 3, 2 ] ), new Position( root, [ 3, 2 ] ) );
+			const transformed = range._getTransformedByMove( new Position( root, [ 3, 0 ] ), new Position( root, [ 6 ] ), 2 );
+
+			expect( transformed[ 0 ].start.path ).to.deep.equal( [ 8 ] );
+			expect( transformed[ 0 ].end.path ).to.deep.equal( [ 8 ] );
+		} );
+
+		it( 'should stick to moved range, if the transformed range is collapsed #2', () => {
+			const range = new Range( new Position( root, [ 3, 2 ] ), new Position( root, [ 3, 2 ] ) );
+			const transformed = range._getTransformedByMove( new Position( root, [ 3, 2 ] ), new Position( root, [ 6 ] ), 2 );
+
+			expect( transformed[ 0 ].start.path ).to.deep.equal( [ 6 ] );
+			expect( transformed[ 0 ].end.path ).to.deep.equal( [ 6 ] );
+		} );
 	} );
 
 	describe( 'getDifference', () => {


### PR DESCRIPTION
Fixes #723.