### PR TITLE
Changed: MarkerOperation should be passed MarkerCollection instance.

### DIFF
--- a/src/model/markercollection.js
+++ b/src/model/markercollection.js
@@ -79,8 +79,15 @@ export default class MarkerCollection {
 	 */
 	set( markerOrName, range ) {
 		const markerName = markerOrName instanceof Marker ? markerOrName.name : markerOrName;
+		const oldMarker = this._markers.get( markerName );
 
-		if ( this._markers.has( markerName ) ) {
+		if ( oldMarker ) {
+			const oldRange = oldMarker.getRange();
+
+			if ( oldRange.isEqual( range ) ) {
+				return oldMarker;
+			}
+
 			this.remove( markerName );
 		}
 
@@ -101,13 +108,13 @@ export default class MarkerCollection {
 	 */
 	remove( markerOrName ) {
 		const markerName = markerOrName instanceof Marker ? markerOrName.name : markerOrName;
-		const marker = this._markers.get( markerName );
+		const oldMarker = this._markers.get( markerName );
 
-		if ( marker ) {
+		if ( oldMarker ) {
 			this._markers.delete( markerName );
-			this.fire( 'remove', marker );
+			this.fire( 'remove', oldMarker );
 
-			this._destroyMarker( marker );
+			this._destroyMarker( oldMarker );
 
 			return true;
 		}

--- a/src/model/operation/markeroperation.js
+++ b/src/model/operation/markeroperation.js
@@ -86,17 +86,7 @@ export default class MarkerOperation extends Operation {
 	_execute() {
 		const type = this.newRange ? 'set' : 'remove';
 
-		if ( type == 'remove' && this._markers.has( this.name ) ) {
-			// Remove marker only if the marker exists.
-			this._markers.remove( this.name );
-		} else if ( type == 'set' ) {
-			const oldMarker = this._markers.get( this.name );
-
-			if ( oldMarker === null || !oldMarker.getRange().isEqual( this.newRange ) ) {
-				// Set marker only if it does not exist or it has different range.
-				this._markers.set( this.name, this.newRange );
-			}
-		}
+		this._markers[ type ]( this.name, this.newRange );
 
 		return { name: this.name, type: type };
 	}

--- a/tests/model/delta/markerdelta.js
+++ b/tests/model/delta/markerdelta.js
@@ -42,14 +42,16 @@ describe( 'Batch', () => {
 			const marker = doc.markers.get( 'name' );
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
 
-			doc.batch().setMarker( marker, range2 );
+			const batch = doc.batch().setMarker( marker, range2 );
+			const op = batch.deltas[ 0 ].operations[ 0 ];
 
 			expect( doc.markers.get( 'name' ).getRange().isEqual( range2 ) ).to.be.true;
+			expect( op.oldRange.isEqual( range ) ).to.be.true;
+			expect( op.newRange.isEqual( range2 ) ).to.be.true;
 		} );
 
 		it( 'should accept empty range parameter if marker instance is passed', () => {
-			doc.markers.set( 'name', range );
-			const marker = doc.markers.get( 'name' );
+			const marker = doc.markers.set( 'name', range );
 
 			sinon.spy( doc, 'fire' );
 
@@ -60,9 +62,12 @@ describe( 'Batch', () => {
 				}
 			} );
 
-			doc.batch().setMarker( marker );
+			const batch = doc.batch().setMarker( marker );
+			const op = batch.deltas[ 0 ].operations[ 0 ];
 
 			expect( doc.fire.calledWith( 'change', 'marker' ) ).to.be.true;
+			expect( op.oldRange ).to.be.null;
+			expect( op.newRange.isEqual( range ) ).to.be.true;
 		} );
 
 		it( 'should throw if marker with given name does not exist and range is not passed', () => {

--- a/tests/model/markercollection.js
+++ b/tests/model/markercollection.js
@@ -52,15 +52,12 @@ describe( 'MarkerCollection', () => {
 		} );
 
 		it( 'should fire remove event, and create a new marker if marker with given name was in the collection', () => {
-			markers.set( 'name', range );
-			const marker1 = markers.get( 'name' );
+			const marker1 = markers.set( 'name', range );
 
 			sinon.spy( markers, 'fire' );
 
-			const result = markers.set( 'name', range2 );
-			const marker2 = markers.get( 'name' );
+			const marker2 = markers.set( 'name', range2 );
 
-			expect( result ).to.equal( marker2 );
 			expect( markers.fire.calledWithExactly( 'remove', marker1 ) ).to.be.true;
 			expect( markers.fire.calledWithExactly( 'add', marker2 ) ).to.be.true;
 
@@ -68,6 +65,17 @@ describe( 'MarkerCollection', () => {
 			expect( marker2.getRange().isEqual( range2 ) ).to.be.true;
 
 			expect( marker1 ).not.to.equal( marker2 );
+		} );
+
+		it( 'should not fire event and return the same marker if given marker has a range equal to given range', () => {
+			const marker1 = markers.set( 'name', range );
+
+			sinon.spy( markers, 'fire' );
+
+			const marker2 = markers.set( 'name', range );
+
+			expect( marker1 ).to.equal( marker2 );
+			expect( markers.fire.notCalled ).to.be.true;
 		} );
 
 		it( 'should accept marker instance instead of name', () => {

--- a/tests/model/operation/transform.js
+++ b/tests/model/operation/transform.js
@@ -418,7 +418,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no position update', () => {
 				const newRange = new Range( new Position( root, [ 0, 2, 0 ] ), new Position( root, [ 0, 2, 4 ] ) );
-				let transformBy = new MarkerOperation( 'name', null, newRange, baseVersion );
+				let transformBy = new MarkerOperation( 'name', null, newRange, doc.markers, baseVersion );
 
 				let transOp = transform( op, transformBy );
 
@@ -1142,7 +1142,7 @@ describe( 'transform', () => {
 			describe( 'by MarkerOperation', () => {
 				it( 'no operation update', () => {
 					const newRange = new Range( new Position( root, [ 0, 2, 0 ] ), new Position( root, [ 0, 2, 8 ] ) );
-					let transformBy = new MarkerOperation( 'name', null, newRange, baseVersion );
+					let transformBy = new MarkerOperation( 'name', null, newRange, doc.markers, baseVersion );
 
 					let transOp = transform( op, transformBy );
 
@@ -1620,7 +1620,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no position update', () => {
 				const newRange = new Range( new Position( root, [ 0, 2, 0 ] ), new Position( root, [ 0, 2, 8 ] ) );
-				let transformBy = new MarkerOperation( 'name', null, newRange, baseVersion );
+				let transformBy = new MarkerOperation( 'name', null, newRange, doc.markers, baseVersion );
 
 				let transOp = transform( op, transformBy );
 
@@ -2746,7 +2746,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no position update', () => {
 				const newRange = new Range( new Position( root, [ 2, 2, 3 ] ), new Position( root, [ 2, 2, 8 ] ) );
-				let transformBy = new MarkerOperation( 'name', null, newRange, baseVersion );
+				let transformBy = new MarkerOperation( 'name', null, newRange, doc.markers, baseVersion );
 
 				let transOp = transform( op, transformBy );
 
@@ -2897,7 +2897,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no position update', () => {
 				const newRange = new Range( new Position( root, [ 0, 2, 0 ] ), new Position( root, [ 0, 2, 8 ] ) );
-				let transformBy = new MarkerOperation( 'name', null, newRange, baseVersion );
+				let transformBy = new MarkerOperation( 'name', null, newRange, doc.markers, baseVersion );
 
 				let transOp = transform( op, transformBy );
 
@@ -3021,7 +3021,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no operation update', () => {
 				const newRange = new Range( new Position( root, [ 0, 2, 0 ] ), new Position( root, [ 0, 2, 8 ] ) );
-				let transformBy = new MarkerOperation( 'name', null, newRange, baseVersion );
+				let transformBy = new MarkerOperation( 'name', null, newRange, doc.markers, baseVersion );
 
 				let transOp = transform( op, transformBy );
 
@@ -3190,7 +3190,7 @@ describe( 'transform', () => {
 		beforeEach( () => {
 			oldRange = Range.createFromParentsAndOffsets( root, 1, root, 4 );
 			newRange = Range.createFromParentsAndOffsets( root, 10, root, 12 );
-			op = new MarkerOperation( 'name', oldRange, newRange, baseVersion );
+			op = new MarkerOperation( 'name', oldRange, newRange, doc.markers, baseVersion );
 
 			expected = {
 				name: 'name',
@@ -3340,7 +3340,7 @@ describe( 'transform', () => {
 
 		describe( 'by MarkerOperation', () => {
 			it( 'different marker name: no operation update', () => {
-				let transformBy = new MarkerOperation( 'otherName', oldRange, newRange, baseVersion );
+				let transformBy = new MarkerOperation( 'otherName', oldRange, newRange, doc.markers, baseVersion );
 
 				let transOp = transform( op, transformBy );
 
@@ -3350,7 +3350,7 @@ describe( 'transform', () => {
 
 			it( 'same marker name and is important: convert to NoOperation', () => {
 				const anotherRange = Range.createFromParentsAndOffsets( root, 2, root, 2 );
-				let transformBy = new MarkerOperation( 'name', oldRange, anotherRange, baseVersion );
+				let transformBy = new MarkerOperation( 'name', oldRange, anotherRange, doc.markers, baseVersion );
 
 				let transOp = transform( op, transformBy );
 
@@ -3363,7 +3363,7 @@ describe( 'transform', () => {
 
 			it( 'same marker name and is less important: update oldRange parameter', () => {
 				const anotherRange = Range.createFromParentsAndOffsets( root, 2, root, 2 );
-				let transformBy = new MarkerOperation( 'name', oldRange, anotherRange, baseVersion );
+				let transformBy = new MarkerOperation( 'name', oldRange, anotherRange, doc.markers, baseVersion );
 
 				let transOp = transform( op, transformBy, true );
 


### PR DESCRIPTION
Fixes #783 

Also fixes wrong behavior that `MarkerDelta` set `oldRange` equal to `newRange` for markers that are synchronized (when marker is created by `MarkerCollection` first). It was wrong because then reverse operation (for example in undo) would not remove the marker. In this case `oldRange` has to be `null`.