### PR TITLE
Fix: view.DocumentFragmen.getAncestors returns array with itself when requested. Closes: #803.

### DIFF
--- a/src/view/documentfragment.js
+++ b/src/view/documentfragment.js
@@ -86,10 +86,12 @@ export default class DocumentFragment {
 	/**
 	 * Returns ancestor elements of `DocumentFragment`, which is an empty array. Added for compatibility reasons.
 	 *
-	 * @returns {Array}
+	 * @param {Object} options Options object.
+	 * @param {Boolean} [options.includeNode=false] When set to `true` this node will be also included in parent's array.
+	 * @returns {Array} Empty Array or Array with itself.
 	 */
-	getAncestors() {
-		return [];
+	getAncestors( options = { includeNode: false } ) {
+		return options.includeNode ? [ this ] : [];
 	}
 
 	/**

--- a/tests/view/documentfragment.js
+++ b/tests/view/documentfragment.js
@@ -61,6 +61,12 @@ describe( 'DocumentFragment', () => {
 
 			expect( fragment.getAncestors() ).to.deep.equal( [] );
 		} );
+
+		it( 'should return array with itself when `includeNode` option is set as true', () => {
+			const fragment = new DocumentFragment();
+
+			expect( fragment.getAncestors( { includeNode: true } ) ).to.deep.equal( [ fragment ] );
+		} );
 	} );
 
 	describe( 'isEmpty', () => {


### PR DESCRIPTION
### Commit message:

Fix: `view.DocumentFragmen.getAncestors` should return an array with itself when requested. Closes: #803.
