### PR TITLE
T/792

### DIFF
--- a/src/view/treewalker.js
+++ b/src/view/treewalker.js
@@ -129,6 +129,8 @@ export default class TreeWalker {
 		 * @member {module:engine/view/node~Node} module:engine/view/treewalker~TreeWalker#_boundaryEndParent
 		 */
 		this._boundaryEndParent = this.boundaries ? this.boundaries.end.parent : null;
+
+		this._fixStartPositionInText();
 	}
 
 	/**
@@ -365,7 +367,7 @@ export default class TreeWalker {
 	 * @returns {module:engine/view/treewalker~TreeWalkerValue}
 	 */
 	_formatReturnValue( type, item, previousPosition, nextPosition, length ) {
-		// Text is a specific parent, because contains string instead of childs.
+		// Text is a specific parent, because contains string instead of children.
 		// Walker doesn't enter to the Text except situations when walker is iterating over every single character,
 		// or the bound starts/ends inside the Text. So when the position is at the beginning or at the end of the Text
 		// we move it just before or just after Text.
@@ -403,6 +405,24 @@ export default class TreeWalker {
 				length: length
 			}
 		};
+	}
+
+	/**
+	 * Fixes tree walker start position if it is at the beginning or at the end of a {@link module:engine/view/text~Text text node}.
+	 *
+	 * Without the fix, the first returned value by tree walker would have type `elementEnd` or `elementStart` but the
+	 * item would be a {@link module:engine/view/text~Text text node}.
+	 *
+	 * @private
+	 */
+	_fixStartPositionInText() {
+		const parent = this.position.parent;
+
+		if ( parent instanceof Text && this.position.isAtStart ) {
+			this.position = Position.createBefore( parent );
+		} else if ( parent instanceof Text && this.position.isAtEnd ) {
+			this.position = Position.createAfter( parent );
+		}
 	}
 }
 

--- a/tests/conversion/mapper.js
+++ b/tests/conversion/mapper.js
@@ -12,6 +12,7 @@ import ModelPosition from '../../src/model/position';
 import ModelRange from '../../src/model/range';
 
 import ViewElement from '../../src/view/element';
+import ViewUIElement from '../../src/view/uielement';
 import ViewText from '../../src/view/text';
 import ViewPosition from '../../src/view/position';
 import ViewRange from '../../src/view/range';
@@ -469,7 +470,7 @@ describe( 'Mapper', () => {
 		} );
 	} );
 
-	describe( 'List mapping (test registerViewToModelLengthCallback)', () => {
+	describe( 'List mapping (test registerViewToModelLength)', () => {
 		function createToModelTest( viewElement, viewOffset, modelElement, modelOffset ) {
 			const viewPosition = new ViewPosition( viewElement, viewOffset );
 			const modelPosition = mapper.toModelPosition( viewPosition );
@@ -536,6 +537,56 @@ describe( 'Mapper', () => {
 			it( 'should transform viewList 0', () => createToModelTest( viewList, 0, modelRoot, 0 ) );
 			it( 'should transform viewList 1', () => createToModelTest( viewList, 1, modelRoot, 3 ) );
 			it( 'should transform viewList 2', () => createToModelTest( viewList, 2, modelRoot, 4 ) );
+		} );
+	} );
+
+	describe( 'getModelLength', () => {
+		let mapper;
+
+		beforeEach( () => {
+			mapper = new Mapper();
+		} );
+
+		it( 'should return length according to callback added by registerViewToModelLength', () => {
+			const viewElement = new ViewElement( 'span' );
+
+			mapper.registerViewToModelLength( 'span', () => 4 );
+
+			expect( mapper.getModelLength( viewElement ) ).to.equal( 4 );
+		} );
+
+		it( 'should return 1 for mapped elements', () => {
+			const viewElement = new ViewElement( 'span' );
+			const modelElement = new ModelElement( 'span' );
+			mapper.bindElements( modelElement, viewElement );
+
+			expect( mapper.getModelLength( viewElement ) ).to.equal( 1 );
+		} );
+
+		it( 'should return 0 for ui elements', () => {
+			const viewUiElement = new ViewUIElement( 'span' );
+
+			expect( mapper.getModelLength( viewUiElement ) ).to.equal( 0 );
+		} );
+
+		it( 'should return length of data for text nodes', () => {
+			const viewText = new ViewText( 'foo' );
+
+			expect( mapper.getModelLength( viewText ) ).to.equal( 3 );
+		} );
+
+		it( 'should return sum of length of children for unmapped element', () => {
+			const modelP = new ModelElement( 'p' );
+			const viewP = new ViewElement( 'p' );
+			const viewUi = new ViewUIElement( 'span' );
+			const viewFoo = new ViewText( 'foo' );
+			const viewCallback = new ViewElement( 'xxx' );
+			const viewDiv = new ViewElement( 'div', null, [ viewP, viewUi, viewFoo, viewCallback ] );
+
+			mapper.bindElements( modelP, viewP );
+			mapper.registerViewToModelLength( 'xxx', () => 2 );
+
+			expect( mapper.getModelLength( viewDiv ) ).to.equal( 6 );
 		} );
 	} );
 } );

--- a/tests/view/treewalker.js
+++ b/tests/view/treewalker.js
@@ -979,6 +979,17 @@ describe( 'TreeWalker', () => {
 		} );
 	} );
 
+	it( 'should not return elementEnd for a text node when iteration begins at the start or the end of that text node', () => {
+		let iterator = new TreeWalker( {
+			startPosition: Position.createAt( textAbcd, 'end' )
+		} );
+
+		const step = iterator.next();
+
+		expect( step.value.type ).to.equal( 'elementEnd' );
+		expect( step.value.item ).to.equal( bold );
+	} );
+
 	it( 'should iterate over document fragment', () => {
 		const foo = new Text( 'foo' );
 		const bar = new Text( 'bar' );


### PR DESCRIPTION
### Suggested merge commit message

Feature: Model converters from markers to `view.UIElement`. Closes #792.

---

### Additional information

`wrapRange` and `unwrapRange` converters does not properly convert collapsed markers anymore. Use introduced `insertUIElement` and `removeUIElement` instead. In most cases, given marker type will be either collapsed or non-collapsed, markers that have sense collapsed and non-collapsed will be rarity. Developer introducing functionality using such markers will have to bring it's own converter (probably will be able to use existing converters, though).