### PR TITLE
t/789: View range enlarge method

### DIFF
--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -7,12 +7,8 @@ import ModelRange from '../model/range';
 import ModelPosition from '../model/position';
 import ModelElement from '../model/element';
 
-import ViewRange from '../view/range';
 import ViewElement from '../view/element';
-import ViewAttributeElement from '../view/element';
-import ViewUIElement from '../view/element';
 import ViewText from '../view/text';
-import ViewTreeWalker from '../view/treewalker';
 import viewWriter from '../view/writer';
 
 /**
@@ -414,27 +410,6 @@ export function unwrapRange( elementCreator ) {
 	};
 }
 
-// Takes given `viewPosition` and returns a widest possible range that contains this position and all view elements
-// before that position and after that position which has zero length in model (empty `ViewAttributeElement`s and `ViewUIElement`s).
-// @param {module:engine/view/position~Position} viewPosition Position to start from when looking for furthest zero length position.
-// @returns {module:engine/view/range~Range}
-function enlargeViewPosition( viewPosition ) {
-	const start = viewPosition;
-	let end = viewPosition;
-
-	const walker = new ViewTreeWalker( { startPosition: start } );
-
-	for ( let step of walker ) {
-		if ( step.item instanceof ViewAttributeElement || step.item instanceof ViewUIElement ) {
-			end = walker.position;
-		} else {
-			break;
-		}
-	}
-
-	return new ViewRange( start, end );
-}
-
 /**
  * Function factory, creates a default model-to-view converter for nodes move changes.
  *
@@ -500,10 +475,10 @@ export function removeUIElement( elementCreator ) {
 			return;
 		}
 
-		const viewPosition = conversionApi.mapper.toViewPosition( data.range.start );
-		const viewRange = enlargeViewPosition( viewPosition );
+		const viewRange = conversionApi.mapper.toViewRange( data.range );
+		const enlargedViewRange = viewRange.getEnlarged();
 
-		viewWriter.clear( viewRange, viewElement );
+		viewWriter.clear( enlargedViewRange, viewElement );
 	};
 }
 

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -270,7 +270,7 @@ export default class Position {
 	 *
 	 * For example:
 	 *
-	 * 		getPriorPosition( value => value.type == 'text' ); // <paragraph>[]foo</paragraph> -> <paragraph>foo[]</paragraph>
+	 * 		getPriorPosition( value => value.type == 'text' ); // <paragraph>foo[]</paragraph> -> <paragraph>[]foo</paragraph>
 	 * 		getPriorPosition( value => false ); // Do not move the position.
 	 *
 	 * @param {Function} skip Callback function. Gets {@link module:engine/model/treewalker~TreeWalkerValue} and should

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -9,6 +9,7 @@
 
 import DocumentFragment from './documentfragment';
 import Element from './element';
+import TreeWalker from './treewalker';
 import last from '@ckeditor/ckeditor5-utils/src/lib/lodash/last';
 import compareArrays from '@ckeditor/ckeditor5-utils/src/comparearrays';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
@@ -242,6 +243,44 @@ export default class Position {
 					return 'after';
 				}
 		}
+	}
+
+	/**
+	 * Use forward {@link module:engine/model/treewalker~TreeWalker TreeWalker} to get the farthest position which
+	 * matches the callback.
+	 *
+	 * For example:
+	 *
+	 * 		getFurtherPosition( value => value.type == 'text' ); // <paragraph>[]foo</paragraph> -> <paragraph>foo[]</paragraph>
+	 * 		getFurtherPosition( value => false ); // Do not move the position.
+	 *
+	 * @param {Function} skip Callback function. Gets {@link module:engine/model/treewalker~TreeWalkerValue} and should
+	 * return `true` if the value should be skipped or `false` if not.
+	 */
+	getFurtherPosition( skip ) {
+		const treeWalker = new TreeWalker( { startPosition: this } );
+		treeWalker.skip( skip );
+
+		return treeWalker.position;
+	}
+
+	/**
+	 * Use backward {@link module:engine/model/treewalker~TreeWalker TreeWalker} to get the farthest position which
+	 * matches the callback.
+	 *
+	 * For example:
+	 *
+	 * 		getPriorPosition( value => value.type == 'text' ); // <paragraph>[]foo</paragraph> -> <paragraph>foo[]</paragraph>
+	 * 		getPriorPosition( value => false ); // Do not move the position.
+	 *
+	 * @param {Function} skip Callback function. Gets {@link module:engine/model/treewalker~TreeWalkerValue} and should
+	 * return `true` if the value should be skipped or `false` if not.
+	 */
+	getPriorPosition( skip ) {
+		const treeWalker = new TreeWalker( { startPosition: this, direction: 'backward' } );
+		treeWalker.skip( skip );
+
+		return treeWalker.position;
 	}
 
 	/**

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -246,38 +246,30 @@ export default class Position {
 	}
 
 	/**
-	 * Use forward {@link module:engine/model/treewalker~TreeWalker TreeWalker} to get the farthest position which
-	 * matches the callback.
+	 * Gets the farthest position which matches the callback using
+	 * {@link module:engine/model/treewalker~TreeWalker TreeWalker}.
 	 *
 	 * For example:
 	 *
-	 * 		getFurtherPosition( value => value.type == 'text' ); // <paragraph>[]foo</paragraph> -> <paragraph>foo[]</paragraph>
-	 * 		getFurtherPosition( value => false ); // Do not move the position.
+	 * 		getLastMatchingPosition( value => value.type == 'text' );
+	 * 		// <paragraph>[]foo</paragraph> -> <paragraph>foo[]</paragraph>
+	 *
+	 * 		getLastMatchingPosition( value => value.type == 'text', { direction: 'backward' } );
+	 * 		// <paragraph>foo[]</paragraph> -> <paragraph>[]foo</paragraph>
+	 *
+	 * 		getLastMatchingPosition( value => false );
+	 * 		// Do not move the position.
 	 *
 	 * @param {Function} skip Callback function. Gets {@link module:engine/model/treewalker~TreeWalkerValue} and should
 	 * return `true` if the value should be skipped or `false` if not.
+	 * @param {Object} options Object with configuration options. See {@link module:engine/model/treewalker~TreeWalker}.
+	 *
+	 * @returns {module:engine/model/position~Position} The position after the last item which matches the `skip` callback test.
 	 */
-	getFurtherPosition( skip ) {
-		const treeWalker = new TreeWalker( { startPosition: this } );
-		treeWalker.skip( skip );
+	getLastMatchingPosition( skip, options = {} ) {
+		options.startPosition = this;
 
-		return treeWalker.position;
-	}
-
-	/**
-	 * Use backward {@link module:engine/model/treewalker~TreeWalker TreeWalker} to get the farthest position which
-	 * matches the callback.
-	 *
-	 * For example:
-	 *
-	 * 		getPriorPosition( value => value.type == 'text' ); // <paragraph>foo[]</paragraph> -> <paragraph>[]foo</paragraph>
-	 * 		getPriorPosition( value => false ); // Do not move the position.
-	 *
-	 * @param {Function} skip Callback function. Gets {@link module:engine/model/treewalker~TreeWalkerValue} and should
-	 * return `true` if the value should be skipped or `false` if not.
-	 */
-	getPriorPosition( skip ) {
-		const treeWalker = new TreeWalker( { startPosition: this, direction: 'backward' } );
+		const treeWalker = new TreeWalker( options );
 		treeWalker.skip( skip );
 
 		return treeWalker.position;

--- a/src/model/treewalker.js
+++ b/src/model/treewalker.js
@@ -153,6 +153,34 @@ export default class TreeWalker {
 	}
 
 	/**
+	 * Move {@link #position} in the {@link #direction} skipping values as long as the callback function returns `true`.
+	 *
+	 * For example:
+	 *
+	 * 		walker.skip( value => value.type == 'text' ); // <paragraph>[]foo</paragraph> -> <paragraph>foo[]</paragraph>
+	 * 		walker.skip( value => true ); // Move the position to the end: <paragraph>[]foo</paragraph> -> <paragraph>foo</paragraph>[]
+	 * 		walker.skip( value => false ); // Do not move the position.
+	 *
+	 * @param {Function} skip Callback function. Gets {@link module:engine/model/treewalker~TreeWalkerValue} and should
+	 * return `true` if the value should be skipped or `false` if not.
+	 */
+	skip( skip ) {
+		let done, value, prevPosition, prevVisitedParent;
+
+		do {
+			prevPosition = this.position;
+			prevVisitedParent = this._visitedParent;
+
+			( { done, value } = this.next() );
+		} while ( !done && skip( value ) );
+
+		if ( !done ) {
+			this.position = prevPosition;
+			this._visitedParent = prevVisitedParent;
+		}
+	}
+
+	/**
 	 * Iterator interface method.
 	 * Detects walking direction and makes step forward or backward.
 	 *

--- a/src/model/treewalker.js
+++ b/src/model/treewalker.js
@@ -153,7 +153,7 @@ export default class TreeWalker {
 	}
 
 	/**
-	 * Move {@link #position} in the {@link #direction} skipping values as long as the callback function returns `true`.
+	 * Moves {@link #position} in the {@link #direction} skipping values as long as the callback function returns `true`.
 	 *
 	 * For example:
 	 *

--- a/src/view/position.js
+++ b/src/view/position.js
@@ -166,7 +166,7 @@ export default class Position {
 	 *
 	 * For example:
 	 *
-	 * 		getPriorPosition( value => value.type == 'text' ); // <p>[]foo</p> -> <p>foo{}</p>
+	 * 		getPriorPosition( value => value.type == 'text' ); // <p>foo[]</p> -> <p>{}foo</p>
 	 * 		getPriorPosition( value => false ); // Do not move the position.
 	 *
 	 * @param {Function} skip Callback function. Gets {@link module:engine/view/treewalker~TreeWalkerValue} and should

--- a/src/view/position.js
+++ b/src/view/position.js
@@ -11,6 +11,8 @@ import Text from './text';
 import TextProxy from './textproxy';
 import DocumentFragment from './documentfragment';
 
+import TreeWalker from './treewalker';
+
 import compareArrays from '@ckeditor/ckeditor5-utils/src/comparearrays';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import EditableElement from './editableelement';
@@ -137,6 +139,44 @@ export default class Position {
 		shifted.offset = offset < 0 ? 0 : offset;
 
 		return shifted;
+	}
+
+	/**
+	 * Use forward {@link module:engine/view/treewalker~TreeWalker TreeWalker} to get the farthest position which
+	 * matches the callback.
+	 *
+	 * For example:
+	 *
+	 * 		getFurtherPosition( value => value.type == 'text' ); // <p>{}foo</p> -> <p>foo[]</p>
+	 * 		getFurtherPosition( value => false ); // Do not move the position.
+	 *
+	 * @param {Function} skip Callback function. Gets {@link module:engine/view/treewalker~TreeWalkerValue} and should
+	 * return `true` if the value should be skipped or `false` if not.
+	 */
+	getFurtherPosition( skip ) {
+		const treeWalker = new TreeWalker( { startPosition: this } );
+		treeWalker.skip( skip );
+
+		return treeWalker.position;
+	}
+
+	/**
+	 * Use backward {@link module:engine/view/treewalker~TreeWalker TreeWalker} to get the farthest position which
+	 * matches the callback.
+	 *
+	 * For example:
+	 *
+	 * 		getPriorPosition( value => value.type == 'text' ); // <p>[]foo</p> -> <p>foo{}</p>
+	 * 		getPriorPosition( value => false ); // Do not move the position.
+	 *
+	 * @param {Function} skip Callback function. Gets {@link module:engine/view/treewalker~TreeWalkerValue} and should
+	 * return `true` if the value should be skipped or `false` if not.
+	 */
+	getPriorPosition( skip ) {
+		const treeWalker = new TreeWalker( { startPosition: this, direction: 'backward' } );
+		treeWalker.skip( skip );
+
+		return treeWalker.position;
 	}
 
 	/**

--- a/src/view/position.js
+++ b/src/view/position.js
@@ -142,38 +142,25 @@ export default class Position {
 	}
 
 	/**
-	 * Use forward {@link module:engine/view/treewalker~TreeWalker TreeWalker} to get the farthest position which
-	 * matches the callback.
+	 * Gets the farthest position which matches the callback using
+	 * {@link module:engine/view/treewalker~TreeWalker TreeWalker}.
 	 *
 	 * For example:
 	 *
-	 * 		getFurtherPosition( value => value.type == 'text' ); // <p>{}foo</p> -> <p>foo[]</p>
-	 * 		getFurtherPosition( value => false ); // Do not move the position.
+	 * 		getLastMatchingPosition( value => value.type == 'text' ); // <p>{}foo</p> -> <p>foo[]</p>
+	 * 		getLastMatchingPosition( value => value.type == 'text', { direction: 'backward' } ); // <p>foo[]</p> -> <p>{}foo</p>
+	 * 		getLastMatchingPosition( value => false ); // Do not move the position.
 	 *
 	 * @param {Function} skip Callback function. Gets {@link module:engine/view/treewalker~TreeWalkerValue} and should
 	 * return `true` if the value should be skipped or `false` if not.
+	 * @param {Object} options Object with configuration options. See {@link module:engine/view/treewalker~TreeWalker}.
+	 *
+	 * @returns {module:engine/view/position~Position} The position after the last item which matches the `skip` callback test.
 	 */
-	getFurtherPosition( skip ) {
-		const treeWalker = new TreeWalker( { startPosition: this } );
-		treeWalker.skip( skip );
+	getLastMatchingPosition( skip, options = {} ) {
+		options.startPosition = this;
 
-		return treeWalker.position;
-	}
-
-	/**
-	 * Use backward {@link module:engine/view/treewalker~TreeWalker TreeWalker} to get the farthest position which
-	 * matches the callback.
-	 *
-	 * For example:
-	 *
-	 * 		getPriorPosition( value => value.type == 'text' ); // <p>foo[]</p> -> <p>{}foo</p>
-	 * 		getPriorPosition( value => false ); // Do not move the position.
-	 *
-	 * @param {Function} skip Callback function. Gets {@link module:engine/view/treewalker~TreeWalkerValue} and should
-	 * return `true` if the value should be skipped or `false` if not.
-	 */
-	getPriorPosition( skip ) {
-		const treeWalker = new TreeWalker( { startPosition: this, direction: 'backward' } );
+		const treeWalker = new TreeWalker( options );
 		treeWalker.skip( skip );
 
 		return treeWalker.position;

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -87,45 +87,47 @@ export default class Range {
 	}
 
 	/**
-	 * Creates a new range with the same content, but containing all surrendering tags with no semantic meaning.
+	 * Creates a maximal range that has the same content as this range but is expanded in both ways (at the beginning
+	 * and at the end).
 	 *
 	 * For example:
 	 *
 	 * 		<p>Foo</p><p><b>{Bar}</b></p> -> <p>Foo</p>[<p><b>Bar</b></p>]
 	 * 		<p><b>foo</b>{bar}<span></span></p> -> <p><b>foo[</b>bar<span></span>]</p>
 	 *
-	 * Note that in the sample above all:
+	 * Note that in the sample above:
 	 *  - `<p>` have type of {@link module:engine/view/containerelement~ContainerElement},
 	 *  - `<b>` have type of {@link module:engine/view/attributeelement~AttributeElement},
-	 *  - `<span>` have type of {@link module:engine/view/uielement~UiElement}.
+	 *  - `<span>` have type of {@link module:engine/view/uielement~UIElement}.
 	 *
 	 * @returns {module:engine/view/range~Range} Enlarged range.
 	 */
 	getEnlarged() {
-		const start = this.start.getPriorPosition( enlagreShrinkStartSkip );
-		const end = this.end.getFurtherPosition( enlagreShrinkEndSkip );
+		const start = this.start.getLastMatchingPosition( enlargeShrinkStartSkip, { direction: 'backward' } );
+		const end = this.end.getLastMatchingPosition( enlargeShrinkEndSkip );
 
 		return new Range( start, end );
 	}
 
 	/**
-	 * Creates a new range with the same content, but without all surrendering tags with no semantic meaning.
+	 * Creates a minimum range that has the same content as this range but is trimmed in both ways (at the beginning
+	 * and at the end).
 	 *
 	 * For example:
 	 *
 	 * 		<p>Foo</p>[<p><b>Bar</b></p>] -> <p>Foo</p><p><b>{Bar}</b></p>
 	 * 		<p><b>foo[</b>bar<span></span>]</p> -> <p><b>foo</b>{bar}<span></span></p>
 	 *
-	 * Note that in the sample above all:
+	 * Note that in the sample above:
 	 *  - `<p>` have type of {@link module:engine/view/containerelement~ContainerElement},
 	 *  - `<b>` have type of {@link module:engine/view/attributeelement~AttributeElement},
-	 *  - `<span>` have type of {@link module:engine/view/uielement~UiElement}.
+	 *  - `<span>` have type of {@link module:engine/view/uielement~UIElement}.
 	 *
 	 * @returns {module:engine/view/range~Range} Shrink range.
 	 */
-	getShrinked() {
-		let start = this.start.getFurtherPosition( enlagreShrinkStartSkip );
-		let end = this.end.getPriorPosition( enlagreShrinkEndSkip );
+	getTrimmed() {
+		let start = this.start.getLastMatchingPosition( enlargeShrinkStartSkip );
+		let end = this.end.getLastMatchingPosition( enlargeShrinkEndSkip, { direction: 'backward' } );
 		let nodeAfterStart = start.nodeAfter;
 		let nodeBeforeEnd = end.nodeBefore;
 
@@ -410,7 +412,7 @@ export default class Range {
 }
 
 // Function used by getEnlagred and getShrinked methods.
-function enlagreShrinkStartSkip( value ) {
+function enlargeShrinkStartSkip( value ) {
 	if ( value.item instanceof AttributeElement || value.item instanceof UIElement ) {
 		return true;
 	}
@@ -423,7 +425,7 @@ function enlagreShrinkStartSkip( value ) {
 }
 
 // Function used by getEnlagred and getShrinked methods.
-function enlagreShrinkEndSkip( value ) {
+function enlargeShrinkEndSkip( value ) {
 	if ( value.item instanceof AttributeElement || value.item instanceof UIElement ) {
 		return true;
 	}

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -131,6 +131,7 @@ export default class Range {
 		let nodeAfterStart = start.nodeAfter;
 		let nodeBeforeEnd = end.nodeBefore;
 
+		// Because TreeWalker prefers positions next to text node, we need to move them manually into these text nodes.
 		if ( nodeAfterStart instanceof Text ) {
 			start = new Position( nodeAfterStart, 0 );
 		}

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -87,7 +87,7 @@ export default class Range {
 	}
 
 	/**
-	 * Create a new range with the same content, but containing all surrendering tags with no semantic meaning.
+	 * Creates a new range with the same content, but containing all surrendering tags with no semantic meaning.
 	 *
 	 * For example:
 	 *
@@ -95,9 +95,9 @@ export default class Range {
 	 * 		<p><b>foo</b>{bar}<span></span></p> -> <p><b>foo[</b>bar<span></span>]</p>
 	 *
 	 * Note that in the sample above all:
-	 *  - `<p>` have type of {@link module:engine/view/containerelement~ContainerElement}
-	 *  - `<b>` have type of {@link module:engine/view/attributeelement~AttributeElement}
-	 *  - `<span>` have type of {@link module:engine/view/uielement~UiElement}
+	 *  - `<p>` have type of {@link module:engine/view/containerelement~ContainerElement},
+	 *  - `<b>` have type of {@link module:engine/view/attributeelement~AttributeElement},
+	 *  - `<span>` have type of {@link module:engine/view/uielement~UiElement}.
 	 *
 	 * @returns {module:engine/view/range~Range} Enlarged range.
 	 */
@@ -109,7 +109,7 @@ export default class Range {
 	}
 
 	/**
-	 * Create a new range with the same content, but without all surrendering tags with no semantic meaning.
+	 * Creates a new range with the same content, but without all surrendering tags with no semantic meaning.
 	 *
 	 * For example:
 	 *
@@ -117,9 +117,9 @@ export default class Range {
 	 * 		<p><b>foo[</b>bar<span></span>]</p> -> <p><b>foo</b>{bar}<span></span></p>
 	 *
 	 * Note that in the sample above all:
-	 *  - `<p>` have type of {@link module:engine/view/containerelement~ContainerElement}
-	 *  - `<b>` have type of {@link module:engine/view/attributeelement~AttributeElement}
-	 *  - `<span>` have type of {@link module:engine/view/uielement~UiElement}
+	 *  - `<p>` have type of {@link module:engine/view/containerelement~ContainerElement},
+	 *  - `<b>` have type of {@link module:engine/view/attributeelement~AttributeElement},
+	 *  - `<span>` have type of {@link module:engine/view/uielement~UiElement}.
 	 *
 	 * @returns {module:engine/view/range~Range} Shrink range.
 	 */

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -12,7 +12,7 @@ import Position from './position';
 import TreeWalker from './treewalker';
 
 import AttributeElement from './attributeelement';
-import ContainerElement from './AttributeElement';
+import ContainerElement from './containerelement';
 import UIElement from './uielement';
 
 /**

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -101,7 +101,7 @@ export default class Range {
 	 *
 	 * @returns {module:engine/view/range~Range} Enlarged range.
 	 */
-	getEnlagred() {
+	getEnlarged() {
 		const start = this.start.getPriorPosition( enlagreShrinkStartSkip );
 		const end = this.end.getFurtherPosition( enlagreShrinkEndSkip );
 

--- a/src/view/treewalker.js
+++ b/src/view/treewalker.js
@@ -141,6 +141,32 @@ export default class TreeWalker {
 	}
 
 	/**
+	 * Move {@link #position} in the {@link #direction} skipping values as long as the callback function returns `true`.
+	 *
+	 * For example:
+	 *
+	 * 		walker.skip( value => value.type == 'text' ); // <p>{}foo</p> -> <p>foo[]</p>
+	 * 		walker.skip( value => true ); // Move the position to the end: <p>{}foo</p> -> <p>foo</p>[]
+	 * 		walker.skip( value => false ); // Do not move the position.
+	 *
+	 * @param {Function} skip Callback function. Gets {@link module:engine/view/treewalker~TreeWalkerValue} and should
+	 * return `true` if the value should be skipped or `false` if not.
+	 */
+	skip( skip ) {
+		let done, value, prevPosition;
+
+		do {
+			prevPosition = this.position;
+
+			( { done, value } = this.next() );
+		} while ( !done && skip( value ) );
+
+		if ( !done ) {
+			this.position = prevPosition;
+		}
+	}
+
+	/**
 	 * Iterator interface method.
 	 * Detects walking direction and makes step forward or backward.
 	 *

--- a/src/view/treewalker.js
+++ b/src/view/treewalker.js
@@ -141,7 +141,7 @@ export default class TreeWalker {
 	}
 
 	/**
-	 * Move {@link #position} in the {@link #direction} skipping values as long as the callback function returns `true`.
+	 * Moves {@link #position} in the {@link #direction} skipping values as long as the callback function returns `true`.
 	 *
 	 * For example:
 	 *

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -578,21 +578,19 @@ describe( 'position', () => {
 		} );
 	} );
 
-	describe( 'getFurtherPosition', () => {
-		it( 'should return skip', () => {
+	describe( 'getLastMatchingPosition', () => {
+		it( 'should skip forward', () => {
 			let position = new Position( root, [ 1, 0, 0 ] );
 
-			position = position.getFurtherPosition( ( value ) => value.type == 'text' );
+			position = position.getLastMatchingPosition( ( value ) => value.type == 'text' );
 
 			expect( position.path ).to.deep.equal( [ 1, 0, 3 ] );
 		} );
-	} );
 
-	describe( 'getPriorPosition', () => {
-		it( 'should return skip', () => {
+		it( 'should skip backward', () => {
 			let position = new Position( root, [ 1, 0, 2 ] );
 
-			position = position.getPriorPosition( ( value ) => value.type == 'text' );
+			position = position.getLastMatchingPosition( ( value ) => value.type == 'text', { direction: 'backward' } );
 
 			expect( position.path ).to.deep.equal( [ 1, 0, 0 ] );
 		} );

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -578,6 +578,26 @@ describe( 'position', () => {
 		} );
 	} );
 
+	describe( 'getFurtherPosition', () => {
+		it( 'should return skip', () => {
+			let position = new Position( root, [ 1, 0, 0 ] );
+
+			position = position.getFurtherPosition( ( value ) => value.type == 'text' );
+
+			expect( position.path ).to.deep.equal( [ 1, 0, 3 ] );
+		} );
+	} );
+
+	describe( 'getPriorPosition', () => {
+		it( 'should return skip', () => {
+			let position = new Position( root, [ 1, 0, 2 ] );
+
+			position = position.getPriorPosition( ( value ) => value.type == 'text' );
+
+			expect( position.path ).to.deep.equal( [ 1, 0, 0 ] );
+		} );
+	} );
+
 	describe( '_getTransformedByInsertion', () => {
 		it( 'should return a new Position instance', () => {
 			const position = new Position( root, [ 0 ] );

--- a/tests/model/treewalker.js
+++ b/tests/model/treewalker.js
@@ -562,6 +562,81 @@ describe( 'TreeWalker', () => {
 			expectValue( value, expected[ i++ ], { ignoreElementEnd: true } );
 		}
 	} );
+
+	describe( 'skip', () => {
+		describe( 'forward treewalker', () => {
+			it( 'should jump over all text nodes', () => {
+				const walker = new TreeWalker( {
+					startPosition: Position.createFromParentAndOffset( paragraph, 0 )
+				} );
+
+				walker.skip( value => value.type == 'text' );
+
+				expect( walker.position.parent ).to.equal( paragraph );
+				expect( walker.position.offset ).to.equal( 3 );
+			} );
+
+			it( 'should do not move if the condition is false', () => {
+				const walker = new TreeWalker( {
+					startPosition: Position.createFromParentAndOffset( paragraph, 1 )
+				} );
+
+				walker.skip( () => false );
+
+				expect( walker.position.parent ).to.equal( paragraph );
+				expect( walker.position.offset ).to.equal( 1 );
+			} );
+
+			it( 'should move to the end if the condition is true', () => {
+				const walker = new TreeWalker( {
+					startPosition: Position.createFromParentAndOffset( paragraph, 1 )
+				} );
+
+				walker.skip( () => true );
+
+				expect( walker.position.parent ).to.equal( rootEnding.parent );
+				expect( walker.position.offset ).to.equal( rootEnding.offset );
+			} );
+		} );
+
+		describe( 'backward treewalker', () => {
+			it( 'should jump over all text nodes', () => {
+				const walker = new TreeWalker( {
+					startPosition: Position.createFromParentAndOffset( paragraph, 3 ),
+					direction: 'backward'
+				} );
+
+				walker.skip( value => value.type == 'text' );
+
+				expect( walker.position.parent ).to.equal( paragraph );
+				expect( walker.position.offset ).to.equal( 0 );
+			} );
+
+			it( 'should do not move if the condition is false', () => {
+				const walker = new TreeWalker( {
+					startPosition: Position.createFromParentAndOffset( paragraph, 1 ),
+					direction: 'backward'
+				} );
+
+				walker.skip( () => false );
+
+				expect( walker.position.parent ).to.equal( paragraph );
+				expect( walker.position.offset ).to.equal( 1 );
+			} );
+
+			it( 'should move to the end if the condition is true', () => {
+				const walker = new TreeWalker( {
+					startPosition: Position.createFromParentAndOffset( paragraph, 1 ),
+					direction: 'backward'
+				} );
+
+				walker.skip( () => true );
+
+				expect( walker.position.parent ).to.equal( rootBeginning.parent );
+				expect( walker.position.offset ).to.equal( rootBeginning.offset );
+			} );
+		} );
+	} );
 } );
 
 function expectValue( value, expected, options ) {

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -99,23 +99,21 @@ describe( 'Position', () => {
 		} );
 	} );
 
-	describe( 'getFurtherPosition', () => {
-		it( 'should return skip', () => {
+	describe( 'getLastMatchingPosition', () => {
+		it( 'should skip forward', () => {
 			const { view, selection } = parse( '<p><b>{}foo</b></p>' );
 			let position = selection.getFirstPosition();
 
-			position = position.getFurtherPosition( ( value ) => value.type == 'text' );
+			position = position.getLastMatchingPosition( ( value ) => value.type == 'text' );
 
 			expect( stringify( view, position ) ).to.equal( '<p><b>foo[]</b></p>' );
 		} );
-	} );
 
-	describe( 'getPriorPosition', () => {
-		it( 'should return skip', () => {
+		it( 'should skip backward', () => {
 			const { view, selection } = parse( '<p><b>foo{}</b></p>' );
 			let position = selection.getFirstPosition();
 
-			position = position.getPriorPosition( ( value ) => value.type == 'text' );
+			position = position.getLastMatchingPosition( ( value ) => value.type == 'text', { direction: 'backward' } );
 
 			expect( stringify( view, position ) ).to.equal( '<p><b>[]foo</b></p>' );
 		} );

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -14,7 +14,7 @@ import TextProxy from '../../src/view/textproxy';
 
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
-import { parse } from '../../src/dev-utils/view';
+import { parse, stringify } from '../../src/dev-utils/view';
 
 describe( 'Position', () => {
 	const parentMock = {};
@@ -96,6 +96,28 @@ describe( 'Position', () => {
 			const shifted = position.getShiftedBy( -20 );
 
 			expect( shifted.offset ).to.equal( 0 );
+		} );
+	} );
+
+	describe( 'getFurtherPosition', () => {
+		it( 'should return skip', () => {
+			const { view, selection } = parse( '<p><b>{}foo</b></p>' );
+			let position = selection.getFirstPosition();
+
+			position = position.getFurtherPosition( ( value ) => value.type == 'text' );
+
+			expect( stringify( view, position ) ).to.equal( '<p><b>foo[]</b></p>' );
+		} );
+	} );
+
+	describe( 'getPriorPosition', () => {
+		it( 'should return skip', () => {
+			const { view, selection } = parse( '<p><b>foo{}</b></p>' );
+			let position = selection.getFirstPosition();
+
+			position = position.getPriorPosition( ( value ) => value.type == 'text' );
+
+			expect( stringify( view, position ) ).to.equal( '<p><b>[]foo</b></p>' );
 		} );
 	} );
 

--- a/tests/view/range.js
+++ b/tests/view/range.js
@@ -86,7 +86,7 @@ describe( 'Range', () => {
 		} );
 	} );
 
-	describe( 'getEnlagred', () => {
+	describe( 'getEnlarged', () => {
 		it( 'case 1', () => {
 			expect( enlarge( '<p>f<b>{oo}</b></p><p>bar</p>' ) )
 				.to.equal( '<p>f[<b>oo</b></p>]<p>bar</p>' );
@@ -130,7 +130,7 @@ describe( 'Range', () => {
 			const { view, selection } = parse( data, { rootElement: viewFrag } );
 			const range = selection.getFirstRange();
 
-			const enlargedRange = range.getEnlagred();
+			const enlargedRange = range.getEnlarged();
 
 			return stringify( view, enlargedRange );
 		}

--- a/tests/view/range.js
+++ b/tests/view/range.js
@@ -136,43 +136,43 @@ describe( 'Range', () => {
 		}
 	} );
 
-	describe( 'getShrinked', () => {
+	describe( 'getTrimmed', () => {
 		it( 'case 1', () => {
-			expect( shrink( '<p>f[<b>oo</b></p>]<p>bar</p>' ) )
+			expect( trim( '<p>f[<b>oo</b></p>]<p>bar</p>' ) )
 				.to.equal( '<p>f<b>{oo}</b></p><p>bar</p>' );
 		} );
 
 		it( 'case 2', () => {
-			expect( shrink( '<p>f{oo}bar</p>' ) )
+			expect( trim( '<p>f{oo}bar</p>' ) )
 				.to.equal( '<p>f{oo}bar</p>' );
 		} );
 
 		it( 'case 3', () => {
-			expect( shrink( '<p>f[<span></span>oo<span></span>]bar</p>' ) )
+			expect( trim( '<p>f[<span></span>oo<span></span>]bar</p>' ) )
 				.to.equal( '<p>f<span></span>{oo}<span></span>bar</p>' );
 		} );
 
 		it( 'case 4', () => {
-			expect( shrink( '<p>f<img></img>[oo]<img></img>bar</p>' ) )
+			expect( trim( '<p>f<img></img>[oo]<img></img>bar</p>' ) )
 				.to.equal( '<p>f<img></img>{oo}<img></img>bar</p>' );
 		} );
 
 		it( 'case 5', () => {
-			expect( shrink( '<p><b>f[</b>oo<b><span></span>]bar</b></p>' ) )
+			expect( trim( '<p><b>f[</b>oo<b><span></span>]bar</b></p>' ) )
 				.to.equal( '<p><b>f</b>{oo}<b><span></span>bar</b></p>' );
 		} );
 
 		it( 'case6', () => {
-			expect( shrink( '<p>foo[</p><p>bar</p><p>]bom</p>' ) )
+			expect( trim( '<p>foo[</p><p>bar</p><p>]bom</p>' ) )
 				.to.equal( '<p>foo[</p><p>bar</p><p>]bom</p>' );
 		} );
 
 		it( 'case7', () => {
-			expect( shrink( '<p>foo[<b><img></img></b>]bom</p>' ) )
+			expect( trim( '<p>foo[<b><img></img></b>]bom</p>' ) )
 				.to.equal( '<p>foo<b>[<img></img>]</b>bom</p>' );
 		} );
 
-		function shrink( data ) {
+		function trim( data ) {
 			data = data
 				.replace( /<p>/g, '<container:p>' )
 				.replace( /<\/p>/g, '</container:p>' )
@@ -185,9 +185,9 @@ describe( 'Range', () => {
 			const { view, selection } = parse( data, { rootElement: viewFrag } );
 			const range = selection.getFirstRange();
 
-			const shrinkedRange = range.getShrinked();
+			const trimmedRange = range.getTrimmed();
 
-			return stringify( view, shrinkedRange );
+			return stringify( view, trimmedRange );
 		}
 	} );
 

--- a/tests/view/treewalker.js
+++ b/tests/view/treewalker.js
@@ -27,10 +27,7 @@ describe( 'TreeWalker', () => {
 		//  |- img1
 		//  |- p
 		//     |- b
-		//     |  |- A
-		//     |  |- B
-		//     |  |- C
-		//     |  |- D
+		//     |  |- abcd
 		//     |
 		//     |- Y
 		//     |
@@ -1005,6 +1002,92 @@ describe( 'TreeWalker', () => {
 		const nodes = Array.from( iterator ).map( ( step ) => step.item );
 
 		expect( nodes ).to.deep.equal( [ p, foo, b, bar ] );
+	} );
+
+	describe( 'skip', () => {
+		describe( 'forward treewalker', () => {
+			it( 'should jump over all text nodes', () => {
+				const walker = new TreeWalker( {
+					startPosition: new Position( paragraph, 0 )
+				} );
+
+				walker.skip( value => value.type == 'text' || value.item.name == 'b' );
+
+				expect( walker.position.parent ).to.equal( paragraph );
+				expect( walker.position.offset ).to.equal( 2 );
+			} );
+
+			it( 'should do not move if the condition is false', () => {
+				const walker = new TreeWalker( {
+					startPosition: new Position( bold, 0 )
+				} );
+
+				walker.skip( () => false );
+
+				expect( walker.position.parent ).to.equal( bold );
+				expect( walker.position.offset ).to.equal( 0 );
+			} );
+
+			it( 'should do not move if the condition is false and the position is in text node', () => {
+				const walker = new TreeWalker( {
+					startPosition: new Position( bold.getChild( 0 ), 2 )
+				} );
+
+				walker.skip( () => false );
+
+				expect( walker.position.parent ).to.equal( bold.getChild( 0 ) );
+				expect( walker.position.offset ).to.equal( 2 );
+			} );
+
+			it( 'should move to the end if the condition is true', () => {
+				const walker = new TreeWalker( {
+					startPosition: new Position( bold, 0 )
+				} );
+
+				walker.skip( () => true );
+
+				expect( walker.position.parent ).to.equal( rootEnding.parent );
+				expect( walker.position.offset ).to.equal( rootEnding.offset );
+			} );
+		} );
+
+		describe( 'backward treewalker', () => {
+			it( 'should jump over all text nodes', () => {
+				const walker = new TreeWalker( {
+					startPosition: new Position( bold.getChild( 0 ), 2 ),
+					direction: 'backward'
+				} );
+
+				walker.skip( value => value.type == 'text' || value.item.name == 'b' );
+
+				expect( walker.position.parent ).to.equal( paragraph );
+				expect( walker.position.offset ).to.equal( 0 );
+			} );
+
+			it( 'should do not move if the condition is false', () => {
+				const walker = new TreeWalker( {
+					startPosition: new Position( bold, 0 ),
+					direction: 'backward'
+				} );
+
+				walker.skip( () => false );
+
+				expect( walker.position.parent ).to.equal( bold );
+				expect( walker.position.offset ).to.equal( 0 );
+			} );
+
+			it( 'should move to the end if the condition is true', () => {
+				const walker = new TreeWalker( {
+					startPosition: new Position( bold, 0 ),
+					direction: 'backward'
+				} );
+
+				walker.skip( () => true );
+
+				expect( walker.position.parent ).to.equal( rootBeginning.parent );
+				expect( walker.position.offset ).to.equal( rootBeginning.offset );
+			} );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
## Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `view.Range#getEnlarged()`, `view.Range#getTrimmed()`, `view.Position#getLastMatchingPosition()`, `model.Position#getLastMatchingPosition()`, `view.TreeWalker#skip()`, `model.TreeWalker#skip()`. Closes #789.