### PR TITLE
Fixed issue when setData() didn't work with custom roots.

### DIFF
--- a/src/dev-utils/model.js
+++ b/src/dev-utils/model.js
@@ -100,7 +100,8 @@ export function setData( document, data, options = {} ) {
 	// Parse data string to model.
 	const parsedResult = setData._parse( data, document.schema, {
 		lastRangeBackward: options.lastRangeBackward,
-		selectionAttributes: options.selectionAttributes
+		selectionAttributes: options.selectionAttributes,
+		context: [ modelRoot.name ]
 	} );
 
 	// Retrieve DocumentFragment and Selection from parsed model.

--- a/tests/controller/deletecontent.js
+++ b/tests/controller/deletecontent.js
@@ -311,14 +311,14 @@ describe( 'DataController', () => {
 			it( 'deletes two inline elements', () => {
 				setData(
 					doc,
-					'<paragraph>x[<image></image><image></image>]z</paragraph>',
+					'x[<image></image><image></image>]z',
 					{ rootName: 'paragraphRoot' }
 				);
 
 				deleteContent( doc.selection, doc.batch() );
 
 				expect( getData( doc, { rootName: 'paragraphRoot' } ) )
-					.to.equal( '<paragraph>x[]z</paragraph>' );
+					.to.equal( 'x[]z' );
 			} );
 
 			it( 'creates a paragraph when text is not allowed (paragraph selected)', () => {

--- a/tests/dev-utils/model.js
+++ b/tests/dev-utils/model.js
@@ -157,6 +157,18 @@ describe( 'model test utils', () => {
 			expect( document.selection.getAttribute( 'foo' ) ).to.equal( 'bar' );
 		} );
 
+		// #815.
+		it( 'should work in a special root', () => {
+			const document = new Document();
+
+			document.schema.registerItem( 'textOnly' );
+			document.schema.allow( { name: '$text', inside: 'textOnly' } );
+			document.createRoot( 'textOnly', 'textOnly' );
+
+			setData( document, 'a[b]c', { rootName: 'textOnly' } );
+			expect( getData( document, { rootName: 'textOnly' } ) ).to.equal( 'a[b]c' );
+		} );
+
 		function test( data, expected ) {
 			expected = expected || data;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `dev-utils/model#setData()` should work with custom roots. Closes #815.

---

### Additional information

I'll run all editors tests because this issue meant that some issues in tests might be unnoticed.