### PR TITLE
T/830 view.Range.enlarge is not compatible with view.Writer.wrap

### DIFF
--- a/src/view/range.js
+++ b/src/view/range.js
@@ -98,8 +98,8 @@ export default class Range {
 	 * @returns {module:engine/view/range~Range} Enlarged range.
 	 */
 	getEnlarged() {
-		const start = this.start.getLastMatchingPosition( enlargeShrinkStartSkip, { direction: 'backward' } );
-		const end = this.end.getLastMatchingPosition( enlargeShrinkEndSkip );
+		const start = this.start.getLastMatchingPosition( enlargeShrinkSkip, { direction: 'backward' } );
+		const end = this.end.getLastMatchingPosition( enlargeShrinkSkip );
 
 		return new Range( start, end );
 	}
@@ -121,8 +121,8 @@ export default class Range {
 	 * @returns {module:engine/view/range~Range} Shrink range.
 	 */
 	getTrimmed() {
-		let start = this.start.getLastMatchingPosition( enlargeShrinkStartSkip );
-		let end = this.end.getLastMatchingPosition( enlargeShrinkEndSkip, { direction: 'backward' } );
+		let start = this.start.getLastMatchingPosition( enlargeShrinkSkip );
+		let end = this.end.getLastMatchingPosition( enlargeShrinkSkip, { direction: 'backward' } );
 		let nodeAfterStart = start.nodeAfter;
 		let nodeBeforeEnd = end.nodeBefore;
 
@@ -408,25 +408,8 @@ export default class Range {
 }
 
 // Function used by getEnlagred and getShrinked methods.
-function enlargeShrinkStartSkip( value ) {
+function enlargeShrinkSkip( value ) {
 	if ( value.item.is( 'attributeElement' ) || value.item.is( 'uiElement' ) ) {
-		return true;
-	}
-
-	if ( value.item.is( 'containerElement' ) && value.type == 'elementStart' ) {
-		return true;
-	}
-
-	return false;
-}
-
-// Function used by getEnlagred and getShrinked methods.
-function enlargeShrinkEndSkip( value ) {
-	if ( value.item.is( 'attributeElement' ) || value.item.is( 'uiElement' ) ) {
-		return true;
-	}
-
-	if ( value.item.is( 'containerElement' ) && value.type == 'elementEnd' ) {
 		return true;
 	}
 

--- a/tests/view/range.js
+++ b/tests/view/range.js
@@ -89,7 +89,7 @@ describe( 'Range', () => {
 	describe( 'getEnlarged', () => {
 		it( 'case 1', () => {
 			expect( enlarge( '<p>f<b>{oo}</b></p><p>bar</p>' ) )
-				.to.equal( '<p>f[<b>oo</b></p>]<p>bar</p>' );
+				.to.equal( '<p>f[<b>oo</b>]</p><p>bar</p>' );
 		} );
 
 		it( 'case 2', () => {
@@ -114,7 +114,7 @@ describe( 'Range', () => {
 
 		it( 'case6', () => {
 			expect( enlarge( '<p>foo</p><p>[bar]</p><p>bom</p>' ) )
-				.to.equal( '<p>foo</p>[<p>bar</p>]<p>bom</p>' );
+				.to.equal( '<p>foo</p><p>[bar]</p><p>bom</p>' );
 		} );
 
 		function enlarge( data ) {
@@ -138,7 +138,7 @@ describe( 'Range', () => {
 
 	describe( 'getTrimmed', () => {
 		it( 'case 1', () => {
-			expect( trim( '<p>f[<b>oo</b></p>]<p>bar</p>' ) )
+			expect( trim( '<p>f[<b>oo</b>]</p><p>bar</p>' ) )
 				.to.equal( '<p>f<b>{oo}</b></p><p>bar</p>' );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `view.Range.enlarge()` and `view.Range.shrink()` should not pass the container limit because the `view.Writer` expects that the whole range is in the same container. Closes #830.

