### PR TITLE
Fixed: Wrong usage of `is()` method.

### DIFF
--- a/src/view/attributeelement.js
+++ b/src/view/attributeelement.js
@@ -110,7 +110,7 @@ function getFillerOffset() {
 	let element = this.parent;
 
 	// <p><b></b></p> needs filler -> <p><b><br></b></p>
-	while ( element.is( 'attributeElement' ) ) {
+	while ( element && element.is( 'attributeElement' ) ) {
 		if ( element.childCount > 1 ) {
 			return null;
 		}

--- a/tests/view/attributeelement.js
+++ b/tests/view/attributeelement.js
@@ -131,5 +131,11 @@ describe( 'AttributeElement', () => {
 
 			expect( attribute.getFillerOffset() ).to.be.null;
 		} );
+
+		it( 'should return null if there is no parent', () => {
+			const attribute = new AttributeElement( 'b' );
+
+			expect( attribute.getFillerOffset() ).to.be.null;
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Used `element instanceof` instead of `element.is()` in `AttributeElement#getFillerOffset` because it is expected that `element` is `null`. Closes #835.

---

### Additional information

Internal because it reverts a change done in one of earlier PRs.
