### PR TITLE
Conversion - get rid of `move` and `rename` events. 

### DIFF
--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -86,7 +86,7 @@ export default class DataController {
 		 * @readonly
 		 * @member {module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher}
 		 */
-		this.modelToView = new ModelConversionDispatcher( {
+		this.modelToView = new ModelConversionDispatcher( this.model, {
 			mapper: this.mapper
 		} );
 		this.modelToView.on( 'insert:$text', insertText(), { priority: 'lowest' } );

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -12,12 +12,7 @@ import Mapper from '../conversion/mapper';
 import ModelConversionDispatcher from '../conversion/modelconversiondispatcher';
 import {
 	insertText,
-	remove,
-	move,
-	rename,
-	insertRangeIntoMarker,
-	insertRangeWithMarker,
-	moveInOutOfMarker
+	remove
 } from '../conversion/model-to-view-converters';
 import { convertSelectionChange } from '../conversion/view-selection-to-model-converters';
 import {
@@ -80,7 +75,7 @@ export default class EditingController {
 		 * @readonly
 		 * @member {module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher} #modelToView
 		 */
-		this.modelToView = new ModelConversionDispatcher( {
+		this.modelToView = new ModelConversionDispatcher( this.model, {
 			mapper: this.mapper,
 			viewSelection: this.view.selection
 		} );
@@ -101,10 +96,9 @@ export default class EditingController {
 
 		// Convert model selection to view.
 		this._listener.listenTo( this.model, 'changesDone', () => {
-			const selection = model.selection;
-			const markers = Array.from( model.markers.getMarkersAtPosition( selection.getFirstPosition() ) );
+			const selection = this.model.selection;
 
-			this.modelToView.convertSelection( selection, markers );
+			this.modelToView.convertSelection( selection );
 			this.view.render();
 		}, { priority: 'low' } );
 
@@ -118,18 +112,11 @@ export default class EditingController {
 		} );
 
 		// Convert view selection to model.
-		this._listener.listenTo( this.view, 'selectionChange', convertSelectionChange( model, this.mapper ) );
+		this._listener.listenTo( this.view, 'selectionChange', convertSelectionChange( this.model, this.mapper ) );
 
 		// Attach default content converters.
 		this.modelToView.on( 'insert:$text', insertText(), { priority: 'lowest' } );
 		this.modelToView.on( 'remove', remove(), { priority: 'low' } );
-		this.modelToView.on( 'move', move(), { priority: 'low' } );
-		this.modelToView.on( 'rename', rename(), { priority: 'low' } );
-
-		// Attach default markers converters.
-		this.modelToView.on( 'insert', insertRangeIntoMarker( this.model.markers ), { priority: 'lowest' } );
-		this.modelToView.on( 'insert', insertRangeWithMarker( this.model.markers ), { priority: 'lowest' } );
-		this.modelToView.on( 'move', moveInOutOfMarker( this.model.markers ), { priority: 'lowest' } );
 
 		// Attach default selection converters.
 		this.modelToView.on( 'selection', clearAttributes(), { priority: 'low' } );

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -157,7 +157,7 @@ class ModelConverterBuilder {
 	 *
 	 * @chainable
 	 * @param {String} markerName Name of marker to convert.
-	 * @returns {module:engine/conversion/modelconverterbuilder~ModelConverterBuilder}
+	 * @returns {module:engine/conversion/buildmodelconverter~ModelConverterBuilder}
 	 */
 	fromMarker( markerName ) {
 		this._from = {
@@ -176,7 +176,7 @@ class ModelConverterBuilder {
 	 *
 	 * @chainable
 	 * @param {String} markerName Name of marker to convert.
-	 * @returns {module:engine/conversion/modelconverterbuilder~ModelConverterBuilder}
+	 * @returns {module:engine/conversion/buildmodelconverter~ModelConverterBuilder}
 	 */
 	fromCollapsedMarker( markerName ) {
 		this._from = {

--- a/src/conversion/mapper.js
+++ b/src/conversion/mapper.js
@@ -314,7 +314,7 @@ export default class Mapper {
 	 * Gets the length of the view element in the model.
 	 *
 	 * The length is calculated as follows:
-	 * * if {@link ~registerViewToModelLength length mapping callback} is provided for given `viewNode` it is used to
+	 * * if {@link #registerViewToModelLength length mapping callback} is provided for given `viewNode` it is used to
 	 * evaluate model length (`viewNode` is used as first and only parameter passed to the callback),
 	 * * length of a {@link module:engine/view/text~Text text node} is equal to the length of it's
 	 * {@link module:engine/view/text~Text#data data},

--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -114,7 +114,7 @@ export function convertCollapsedSelection() {
  *		modelDispatcher.on( 'selectionAttribute:style', convertSelectionAttribute( styleCreator ) );
  *
  * **Note:** You can use the same `elementCreator` function for this converter factory
- * and {@link module:engine/conversion/model-to-view-converters~wrap}
+ * and {@link module:engine/conversion/model-to-view-converters~wrapRange}
  * model to view converter, as long as the `elementCreator` function uses only the first parameter (attribute value).
  *
  *		modelDispatcher.on( 'selection', convertCollapsedSelection() );

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -5,7 +5,6 @@
 
 import ModelRange from '../model/range';
 
-import ViewRange from '../view/range';
 import ViewElement from '../view/element';
 import ViewText from '../view/text';
 import viewWriter from '../view/writer';
@@ -422,15 +421,8 @@ export function remove() {
 			return;
 		}
 
-		let viewRange;
-
-		if ( data.item.is( 'element' ) ) {
-			const viewElement = conversionApi.mapper.toViewElement( data.item );
-			viewRange = ViewRange.createOn( viewElement );
-		} else {
-			const modelRange = ModelRange.createFromPositionAndShift( data.sourcePosition, data.item.offsetSize );
-			viewRange = conversionApi.mapper.toViewRange( modelRange );
-		}
+		const modelRange = ModelRange.createFromPositionAndShift( data.sourcePosition, data.item.offsetSize );
+		const viewRange = conversionApi.mapper.toViewRange( modelRange );
 
 		viewWriter.remove( viewRange );
 		conversionApi.mapper.unbindModelElement( data.item );

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -4,8 +4,6 @@
  */
 
 import ModelRange from '../model/range';
-import ModelPosition from '../model/position';
-import ModelElement from '../model/element';
 
 import ViewElement from '../view/element';
 import ViewText from '../view/text';
@@ -411,28 +409,6 @@ export function unwrapRange( elementCreator ) {
 }
 
 /**
- * Function factory, creates a default model-to-view converter for nodes move changes.
- *
- *		modelDispatcher.on( 'move', move() );
- *
- * @returns {Function} Move event converter.
- */
-export function move() {
-	return ( evt, data, consumable, conversionApi ) => {
-		if ( !consumable.consume( data.item, 'move' ) ) {
-			return;
-		}
-
-		const modelRange = ModelRange.createFromPositionAndShift( data.sourcePosition, data.item.offsetSize );
-		const sourceViewRange = conversionApi.mapper.toViewRange( modelRange );
-
-		const targetViewPosition = conversionApi.mapper.toViewPosition( data.targetPosition );
-
-		viewWriter.move( sourceViewRange, targetViewPosition );
-	};
-}
-
-/**
  * Function factory, creates a default model-to-view converter for node remove changes.
  *
  *		modelDispatcher.on( 'remove', remove() );
@@ -479,132 +455,6 @@ export function removeUIElement( elementCreator ) {
 		const enlargedViewRange = viewRange.getEnlarged();
 
 		viewWriter.clear( enlargedViewRange, viewElement );
-	};
-}
-
-/**
- * Function factory, creates default model-to-view converter for elements which name has changed.
- *
- *		modelDispatcher.on( 'rename', rename() );
- *
- * This converter re-uses converters added for `insert`, `move` and `remove` change types.
- *
- * @fires module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:insert
- * @fires module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:move
- * @fires module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:remove
- * @returns {Function}
- */
-export function rename() {
-	return ( evt, data, consumable, conversionApi ) => {
-		if ( !consumable.consume( data.element, 'rename' ) ) {
-			return;
-		}
-
-		// Create fake model element that will represent "old version" of renamed element.
-		const fakeElement = new ModelElement( data.oldName, data.element.getAttributes() );
-		// Append the fake element to model document to enable making range on it.
-		data.element.parent.insertChildren( data.element.index, fakeElement );
-
-		// Check what was bound to renamed element.
-		const oldViewElement = conversionApi.mapper.toViewElement( data.element );
-		// Unbind renamed element.
-		conversionApi.mapper.unbindModelElement( data.element );
-		// Bind view element to the fake element.
-		conversionApi.mapper.bindElements( fakeElement, oldViewElement );
-
-		// The range that includes only the renamed element. Will be used to insert an empty element in the view.
-		const insertRange = ModelRange.createFromParentsAndOffsets( data.element.parent, data.element.startOffset, data.element, 0 );
-
-		// Move source position and range of moved nodes. Will be used to move nodes from original view element to renamed one.
-		const moveSourcePosition = ModelPosition.createAt( fakeElement, 0 );
-		const moveRange = ModelRange.createIn( data.element );
-
-		// Remove range containing the fake element. Will be used to remove original view element from the view.
-		const removeRange = ModelRange.createOn( fakeElement );
-
-		// Start the conversion. Use already defined converters by firing insertion, move and remove conversion
-		// on correct ranges / positions.
-		conversionApi.dispatcher.convertInsertion( insertRange );
-		conversionApi.dispatcher.convertMove( moveSourcePosition, moveRange );
-		conversionApi.dispatcher.convertRemove( removeRange.start, removeRange );
-
-		// Cleanup.
-		fakeElement.remove();
-	};
-}
-
-/**
- * Function factory, creates a default converter for inserting {@link module:engine/model/item~Item model item}
- * into a marker range.
- *
- *		modelDispatcher.on( 'insert', insertRangeIntoMarker( modelDocument.markers ) );
- *
- * @param {module:engine/model/markercollection~MarkerCollection} markerCollection Markers collection to check when
- * inserting.
- * @returns {Function}
- */
-export function insertRangeIntoMarker( markerCollection ) {
-	return ( evt, data, consumable, conversionApi ) => {
-		for ( let marker of markerCollection ) {
-			const range = marker.getRange();
-
-			if ( range.containsPosition( data.range.start ) ) {
-				conversionApi.dispatcher.convertMarker( 'addMarker', marker.name, data.range );
-			}
-		}
-	};
-}
-
-/**
- * Function factory, creates a default converter for inserting a {@link module:engine/model/range~Range model range}
- * that contains a marker. This happens when marker was in a graveyard (so it was removed from the view) or was
- * created in a {@link module:engine/model/documentfragment~DocumentFragment DocumentFragment} (so it was not in the view before).
- *
- *		modelDispatcher.on( 'insert', insertRangeWithMarker( modelDocument.markers ) );
- *
- * @param {module:engine/model/markercollection~MarkerCollection} markerCollection Markers collection to check when
- * inserting.
- * @returns {Function}
- */
-export function insertRangeWithMarker( markerCollection ) {
-	return ( evt, data, consumable, conversionApi ) => {
-		for ( let marker of markerCollection ) {
-			const range = marker.getRange();
-
-			if ( data.range.containsRange( range ) || data.range.isEqual( range ) ) {
-				conversionApi.dispatcher.convertMarker( 'addMarker', marker.name, range );
-			}
-		}
-	};
-}
-
-/**
- * Function factory, creates a default converter for move changes that move {@link module:engine/model/item~Item model items}
- * into or outside of a marker range.
- *
- *		modelDispatcher.on( 'move', moveInOutOfMarker( modelDocument.markers ) );
- *
- * @param {module:engine/model/markercollection~MarkerCollection} markerCollection Markers collection to check when
- * moving.
- * @returns {Function}
- */
-export function moveInOutOfMarker( markerCollection ) {
-	return ( evt, data, consumable, conversionApi ) => {
-		const sourcePos = data.sourcePosition._getTransformedByInsertion( data.targetPosition, data.item.offsetSize );
-		const movedRange = ModelRange.createOn( data.item );
-
-		for ( let marker of markerCollection ) {
-			const range = marker.getRange();
-
-			const wasInMarker = range.containsPosition( sourcePos ) || range.start.isEqual( sourcePos ) || range.end.isEqual( sourcePos );
-			const common = movedRange.getIntersection( range );
-
-			if ( wasInMarker && common === null ) {
-				conversionApi.dispatcher.convertMarker( 'removeMarker', marker.name, movedRange );
-			} else if ( common !== null ) {
-				conversionApi.dispatcher.convertMarker( 'addMarker', marker.name, common );
-			}
-		}
 	};
 }
 

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -372,7 +372,7 @@ export function wrapRange( elementCreator ) {
  * was passed, it will be used to look for similar element in the view for unwrapping. If `Function` is provided, it is passed all
  * the parameters of the
  * {@link module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:removeMarker removeMarker event}.
- * It's expected that the function returns a {@link module:/engine/view/attributeelement~AttributeElement}. The result of
+ * It's expected that the function returns a {@link module:engine/view/attributeelement~AttributeElement}. The result of
  * the function will be used to look for similar element in the view for unwrapping.
  *
  * The converter automatically consumes corresponding value from consumables list, stops the event (see

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -5,6 +5,7 @@
 
 import ModelRange from '../model/range';
 
+import ViewRange from '../view/range';
 import ViewElement from '../view/element';
 import ViewText from '../view/text';
 import viewWriter from '../view/writer';
@@ -421,8 +422,15 @@ export function remove() {
 			return;
 		}
 
-		const modelRange = ModelRange.createFromPositionAndShift( data.sourcePosition, data.item.offsetSize );
-		const viewRange = conversionApi.mapper.toViewRange( modelRange );
+		let viewRange;
+
+		if ( data.item.is( 'element' ) ) {
+			const viewElement = conversionApi.mapper.toViewElement( data.item );
+			viewRange = ViewRange.createOn( viewElement );
+		} else {
+			const modelRange = ModelRange.createFromPositionAndShift( data.sourcePosition, data.item.offsetSize );
+			viewRange = conversionApi.mapper.toViewRange( modelRange );
+		}
 
 		viewWriter.remove( viewRange );
 		conversionApi.mapper.unbindModelElement( data.item );

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -240,7 +240,6 @@ export default class ModelConversionDispatcher {
 	 * @param {module:engine/model/position~Position} sourcePosition Position from where the range has been removed.
 	 * @param {module:engine/model/range~Range} range Removed range (after remove, in
 	 * {@link module:engine/model/document~Document#graveyard graveyard root}).
-	 * @param {String} removeAs If passed, removed item is treated like it was an element of given name.
 	 */
 	convertMove( sourcePosition, range ) {
 		this.convertRemove( sourcePosition, range );

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -175,6 +175,8 @@ export default class ModelConversionDispatcher {
 	}
 
 	/**
+	 * Starts conversion of insertion-change on given `range`.
+	 *
 	 * Analyzes given range and fires insertion-connected events with data based on that range.
 	 *
 	 * **Note**: This method will fire separate events for node insertion and attributes insertion. All
@@ -229,13 +231,27 @@ export default class ModelConversionDispatcher {
 		}
 	}
 
+	/**
+	 * Starts conversion of move-change of given `range`, that was moved from given `sourcePosition`.
+	 *
+	 * Fires {@link ~#event:remove remove event} and {@link ~#event:insert insert event} based on passed parameters.
+	 *
+	 * @fires remove
+	 * @fires insert
+	 * @param {module:engine/model/position~Position} sourcePosition Position from where the range has been removed.
+	 * @param {module:engine/model/range~Range} range Removed range (after remove, in
+	 * {@link module:engine/model/document~Document#graveyard graveyard root}).
+	 * @param {String} removeAs If passed, removed item is treated like it was an element of given name.
+	 */
 	convertMove( sourcePosition, range ) {
 		this.convertRemove( sourcePosition, range );
 		this.convertInsertion( range );
 	}
 
 	/**
-	 * Fires remove event with data based on passed values.
+	 * Starts conversion of remove-change of given `range`, that was removed from given `sourcePosition`.
+	 *
+	 * Fires {@link ~#event:remove remove event} with data based on passed values.
 	 *
 	 * @fires remove
 	 * @param {module:engine/model/position~Position} sourcePosition Position from where the range has been removed.
@@ -259,6 +275,8 @@ export default class ModelConversionDispatcher {
 	}
 
 	/**
+	 * Starts conversion of attribute-change on given `range`.
+	 *
 	 * Analyzes given attribute change and fires attributes-connected events with data based on passed values.
 	 *
 	 * @fires addAttribute
@@ -293,9 +311,12 @@ export default class ModelConversionDispatcher {
 	}
 
 	/**
-	 * Fires rename event with data based on passed values.
+	 * Starts conversion of rename-change of given `element` that had given `oldName`.
 	 *
-	 * @fires rename
+	 * Fires {@link ~#event:remove remove event} and {@link ~#event:insert insert event} based on passed values.
+	 *
+	 * @fires remove
+	 * @fires insert
 	 * @param {module:engine/model/element~Element} element Renamed element.
 	 * @param {String} oldName Name of the renamed element before it was renamed.
 	 */
@@ -308,6 +329,8 @@ export default class ModelConversionDispatcher {
 	}
 
 	/**
+	 * Starts selection conversion.
+	 *
 	 * Fires events for given {@link module:engine/model/selection~Selection selection} to start selection conversion.
 	 *
 	 * @fires selection
@@ -346,11 +369,14 @@ export default class ModelConversionDispatcher {
 	}
 
 	/**
-	 * Fires event for given marker change.
+	 * Starts marker-conversion.
+	 *
+	 * Fires {@link ~#event:addMarker addMarker event} or {@link ~#event:removeMarker removeMarker event} based on
+	 * given `type` with data based on passed parameters.
 	 *
 	 * @fires addMarker
 	 * @fires removeMarker
-	 * @param {String} type Change type.
+	 * @param {'addMarker'|'removeMarker'} type Change type.
 	 * @param {String} name Marker name.
 	 * @param {module:engine/model/range~Range} range Marker range.
 	 */

--- a/src/dev-utils/model.js
+++ b/src/dev-utils/model.js
@@ -25,7 +25,7 @@ import modelWriter from '../model/writer';
 import ViewConversionDispatcher from '../conversion/viewconversiondispatcher';
 import ViewSelection from '../view/selection';
 import ViewDocumentFragment from '../view/documentfragment';
-import ViewElement from '../view/containerelement';
+import ViewContainerElement from '../view/containerelement';
 import ViewAttributeElement from '../view/attributeelement';
 
 import Mapper from '../conversion/mapper';
@@ -167,14 +167,15 @@ setData._parse = parse;
  *
  * @param {module:engine/model/rootelement~RootElement|module:engine/model/element~Element|module:engine/model/text~Text|
  * module:engine/model/documentfragment~DocumentFragment} node Node to stringify.
- * @param {module:engine/model/selection~Selection|module:engine/model/position~Position|module:engine/model/range~Range}
- * [selectionOrPositionOrRange=null]
+ * @param {module:engine/model/selection~Selection|module:engine/model/position~Position|
+ * module:engine/model/range~Range} [selectionOrPositionOrRange=null]
  * Selection instance which ranges will be included in returned string data. If Range instance is provided - it will be
  * converted to selection containing this range. If Position instance is provided - it will be converted to selection
  * containing one range collapsed at this position.
  * @returns {String} HTML-like string representing the model.
  */
 export function stringify( node, selectionOrPositionOrRange = null ) {
+	const modelDoc = new ModelDocument();
 	const mapper = new Mapper();
 	let selection, range;
 
@@ -208,7 +209,7 @@ export function stringify( node, selectionOrPositionOrRange = null ) {
 	// Setup model to view converter.
 	const viewDocumentFragment = new ViewDocumentFragment();
 	const viewSelection = new ViewSelection();
-	const modelToView = new ModelConversionDispatcher( { mapper, viewSelection } );
+	const modelToView = new ModelConversionDispatcher( modelDoc, { mapper, viewSelection } );
 
 	// Bind root elements.
 	mapper.bindElements( node.root, viewDocumentFragment );
@@ -223,7 +224,7 @@ export function stringify( node, selectionOrPositionOrRange = null ) {
 		// Stringify object types values for properly display as an output string.
 		const attributes = convertAttributes( data.item.getAttributes(), stringifyAttributeValue );
 
-		return new ViewElement( data.item.name, attributes );
+		return new ViewContainerElement( data.item.name, attributes );
 	} ) );
 	modelToView.on( 'selection', convertRangeSelection() );
 	modelToView.on( 'selection', convertCollapsedSelection() );

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -277,43 +277,14 @@ describe( 'EditingController', () => {
 		it( 'should forward add marker event if content is inserted into a marker range', () => {
 			const markerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
 			const innerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
-			const consumableMock = {
-				consume: () => true,
-				test: () => true
-			};
 
 			model.markers.set( 'name', markerRange );
 
 			sinon.spy( editing.modelToView, 'convertMarker' );
 
-			editing.modelToView.fire( 'insert', {
-				range: innerRange
-			}, consumableMock, { dispatcher: editing.modelToView } );
+			editing.modelToView.convertInsertion( innerRange );
 
 			expect( editing.modelToView.convertMarker.calledWithExactly( 'addMarker', 'name', innerRange ) ).to.be.true;
-
-			editing.modelToView.convertMarker.restore();
-		} );
-
-		it( 'should forward add marker event if inserted content has a marker (reinsert from graveyard)', () => {
-			const gyHolder = new ModelElement( '$graveyardHolder', [], new ModelText( 'foo' ) );
-			model.graveyard.appendChildren( gyHolder );
-
-			const markerRange = ModelRange.createIn( gyHolder );
-			const consumableMock = {
-				consume: () => true,
-				test: () => true
-			};
-
-			model.markers.set( 'name', markerRange );
-
-			sinon.spy( editing.modelToView, 'convertMarker' );
-
-			editing.modelToView.fire( 'insert', {
-				range: markerRange
-			}, consumableMock, { dispatcher: editing.modelToView } );
-
-			expect( editing.modelToView.convertMarker.calledWithExactly( 'addMarker', 'name', markerRange ) ).to.be.true;
 
 			editing.modelToView.convertMarker.restore();
 		} );
@@ -325,18 +296,11 @@ describe( 'EditingController', () => {
 			const markerRange = ModelRange.createFromParentsAndOffsets( element, 1, element, 2 );
 			const outerRange = ModelRange.createOn( element );
 
-			const consumableMock = {
-				consume: () => true,
-				test: () => true
-			};
-
 			model.markers.set( 'name', markerRange );
 
 			sinon.spy( editing.modelToView, 'convertMarker' );
 
-			editing.modelToView.fire( 'insert', {
-				range: outerRange
-			}, consumableMock, { dispatcher: editing.modelToView } );
+			editing.modelToView.convertInsertion( outerRange );
 
 			expect( editing.modelToView.convertMarker.calledWithExactly( 'addMarker', 'name', markerRange ) ).to.be.true;
 
@@ -364,98 +328,23 @@ describe( 'EditingController', () => {
 			editing.modelToView.convertMarker.restore();
 		} );
 
-		it( 'should forward remove marker event if part of marker range is moved - intersecting', () => {
-			const markerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 1 );
-			const consumableMock = {
-				consume: () => true,
-				test: () => true
-			};
-
-			model.markers.set( 'name', markerRange );
-
-			sinon.spy( editing.modelToView, 'convertMarker' );
-
-			editing.modelToView.fire( 'move', {
-				sourcePosition: ModelPosition.createAt( modelRoot, 1 ),
-				targetPosition: ModelPosition.createAt( modelRoot, 2 ),
-				item: modelRoot.getChild( 2 )
-			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
-
-			expect( editing.modelToView.convertMarker.calledWith( 'removeMarker', 'name' ) ).to.be.true;
-
-			editing.modelToView.convertMarker.restore();
-		} );
-
-		it( 'should forward remove marker event if part of marker range is moved - inside', () => {
-			model.enqueueChanges( () => {
-				model.batch().insert( ModelPosition.createAt( model.getRoot(), 'end' ), new ModelElement( 'paragraph' ) );
-			} );
-
-			const markerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 2 );
-			const consumableMock = {
-				consume: () => true,
-				test: () => true
-			};
-
-			model.markers.set( 'name', markerRange );
-
-			sinon.spy( editing.modelToView, 'convertMarker' );
-
-			editing.modelToView.fire( 'move', {
-				sourcePosition: ModelPosition.createAt( modelRoot, 1 ),
-				targetPosition: ModelPosition.createAt( modelRoot, 3 ),
-				item: modelRoot.getChild( 3 )
-			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
-
-			expect( editing.modelToView.convertMarker.calledWith( 'removeMarker', 'name' ) ).to.be.true;
-
-			editing.modelToView.convertMarker.restore();
-		} );
-
 		it( 'should forward add marker event if content is moved into a marker range', () => {
 			model.enqueueChanges( () => {
 				model.batch().insert( ModelPosition.createAt( model.getRoot(), 'end' ), new ModelElement( 'paragraph' ) );
 			} );
 
 			const markerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
-			const consumableMock = {
-				consume: () => true,
-				test: () => true
-			};
 
 			model.markers.set( 'name', markerRange );
 
 			sinon.spy( editing.modelToView, 'convertMarker' );
 
-			editing.modelToView.fire( 'move', {
-				sourcePosition: ModelPosition.createAt( modelRoot, 3 ),
-				targetPosition: ModelPosition.createAt( modelRoot, 1 ),
-				item: modelRoot.getChild( 1 )
-			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
+			editing.modelToView.convertMove(
+				ModelPosition.createAt( modelRoot, 3 ),
+				ModelRange.createOn( modelRoot.getChild( 1 ) )
+			);
 
 			expect( editing.modelToView.convertMarker.calledWith( 'addMarker', 'name' ) ).to.be.true;
-
-			editing.modelToView.convertMarker.restore();
-		} );
-
-		it( 'should not start marker conversion if moved content does not affect the marker', () => {
-			const markerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 1 );
-			const consumableMock = {
-				consume: () => true,
-				test: () => true
-			};
-
-			model.markers.set( 'name', markerRange );
-
-			sinon.spy( editing.modelToView, 'convertMarker' );
-
-			editing.modelToView.fire( 'move', {
-				sourcePosition: ModelPosition.createAt( modelRoot, 2 ),
-				targetPosition: ModelPosition.createAt( modelRoot, 0 ),
-				item: modelRoot.getChild( 2 )
-			}, consumableMock, { dispatcher: editing.modelToView, mapper: editing.mapper } );
-
-			expect( editing.modelToView.convertMarker.called ).to.be.false;
 
 			editing.modelToView.convertMarker.restore();
 		} );

--- a/tests/conversion/advanced-converters.js
+++ b/tests/conversion/advanced-converters.js
@@ -32,7 +32,6 @@ import {
 	removeAttribute,
 	wrapItem,
 	unwrapItem,
-	move,
 	remove,
 	eventNameToConsumableType
 } from '../../src/conversion/model-to-view-converters';
@@ -51,12 +50,11 @@ describe( 'advanced-converters', () => {
 		mapper = new Mapper();
 		mapper.bindElements( modelRoot, viewRoot );
 
-		modelDispatcher = new ModelConversionDispatcher( { mapper } );
+		modelDispatcher = new ModelConversionDispatcher( modelDoc, { mapper } );
 		// Schema is mocked up because we don't care about it in those tests.
 		viewDispatcher = new ViewConversionDispatcher( { schema: { check: () => true } } );
 
 		modelDispatcher.on( 'insert:$text', insertText() );
-		modelDispatcher.on( 'move', move() );
 		modelDispatcher.on( 'remove', remove() );
 		viewDispatcher.on( 'text', convertText() );
 		viewDispatcher.on( 'documentFragment', convertToModelFragment() );

--- a/tests/conversion/buildmodelconverter.js
+++ b/tests/conversion/buildmodelconverter.js
@@ -24,7 +24,6 @@ import ModelConversionDispatcher from '../../src/conversion/modelconversiondispa
 
 import {
 	insertText,
-	move,
 	remove
 } from '../../src/conversion/model-to-view-converters';
 
@@ -86,10 +85,9 @@ describe( 'Model converter builder', () => {
 		mapper = new Mapper();
 		mapper.bindElements( modelRoot, viewRoot );
 
-		dispatcher = new ModelConversionDispatcher( { mapper, viewSelection } );
+		dispatcher = new ModelConversionDispatcher( modelDoc, { mapper, viewSelection } );
 
 		dispatcher.on( 'insert:$text', insertText() );
-		dispatcher.on( 'move', move() );
 		dispatcher.on( 'remove', remove() );
 	} );
 

--- a/tests/conversion/model-selection-to-view-converters.js
+++ b/tests/conversion/model-selection-to-view-converters.js
@@ -57,7 +57,7 @@ describe( 'model-selection-to-view-converters', () => {
 		mapper = new Mapper();
 		mapper.bindElements( modelRoot, viewRoot );
 
-		dispatcher = new ModelConversionDispatcher( { mapper, viewSelection } );
+		dispatcher = new ModelConversionDispatcher( modelDoc, { mapper, viewSelection } );
 
 		dispatcher.on( 'insert:$text', insertText() );
 		dispatcher.on( 'addAttribute:bold', wrapItem( new ViewAttributeElement( 'strong' ) ) );

--- a/tests/conversion/modelconversiondispatcher.js
+++ b/tests/conversion/modelconversiondispatcher.js
@@ -16,15 +16,15 @@ describe( 'ModelConversionDispatcher', () => {
 	let dispatcher, doc, root;
 
 	beforeEach( () => {
-		dispatcher = new ModelConversionDispatcher();
 		doc = new ModelDocument();
+		dispatcher = new ModelConversionDispatcher( doc );
 		root = doc.createRoot();
 	} );
 
 	describe( 'constructor()', () => {
 		it( 'should create ModelConversionDispatcher with given api', () => {
 			const apiObj = {};
-			const dispatcher = new ModelConversionDispatcher( { apiObj } );
+			const dispatcher = new ModelConversionDispatcher( doc, { apiObj } );
 
 			expect( dispatcher.conversionApi.apiObj ).to.equal( apiObj );
 		} );
@@ -89,16 +89,6 @@ describe( 'ModelConversionDispatcher', () => {
 			expect( cbInsertText.called ).to.be.false;
 		} );
 
-		it( 'should fire move callback for move changes', () => {
-			const cbMove = sinon.spy();
-
-			dispatcher.on( 'move', cbMove );
-
-			doc.batch().move( image, imagePos.getShiftedBy( 3 ) );
-
-			expect( cbMove.called );
-		} );
-
 		it( 'should fire remove callback for remove changes', () => {
 			const cbRemove = sinon.spy();
 
@@ -106,17 +96,7 @@ describe( 'ModelConversionDispatcher', () => {
 
 			doc.batch().remove( image );
 
-			expect( cbRemove.called );
-		} );
-
-		it( 'should fire rename callback for rename changes', () => {
-			const cbRename = sinon.spy();
-
-			dispatcher.on( 'rename', cbRename );
-
-			doc.batch().rename( image, 'figure' );
-
-			expect( cbRename.called );
+			expect( cbRemove.called ).to.be.true;
 		} );
 
 		it( 'should fire addAttribute callbacks for add attribute change', () => {
@@ -309,37 +289,6 @@ describe( 'ModelConversionDispatcher', () => {
 	} );
 
 	describe( 'convertMove', () => {
-		it( 'should fire event for moved range - move before source position', () => {
-			root.appendChildren( new ModelText( 'barfoo' ) );
-
-			const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 3 );
-			const loggedEvents = [];
-
-			dispatcher.on( 'move', ( evt, data ) => {
-				const log = 'move:' + data.sourcePosition.path + ':' + data.targetPosition.path + ':' + data.item.offsetSize;
-				loggedEvents.push( log );
-			} );
-
-			dispatcher.convertMove( ModelPosition.createFromParentAndOffset( root , 3 ), range );
-
-			expect( loggedEvents ).to.deep.equal( [ 'move:3:0:3' ] );
-		} );
-
-		it( 'should fire event for moved range - move after source position', () => {
-			root.appendChildren( new ModelText( 'barfoo' ) );
-
-			const range = ModelRange.createFromParentsAndOffsets( root, 3, root, 6 );
-			const loggedEvents = [];
-
-			dispatcher.on( 'move', ( evt, data ) => {
-				const log = 'move:' + data.sourcePosition.path + ':' + data.targetPosition.path + ':' + data.item.offsetSize;
-				loggedEvents.push( log );
-			} );
-
-			dispatcher.convertMove( ModelPosition.createFromParentAndOffset( root , 0 ), range );
-
-			expect( loggedEvents ).to.deep.equal( [ 'move:0:6:3' ] );
-		} );
 	} );
 
 	describe( 'convertRemove', () => {
@@ -362,22 +311,6 @@ describe( 'ModelConversionDispatcher', () => {
 	} );
 
 	describe( 'convertRename', () => {
-		it( 'should fire rename event with correct name, consumable, and renamed element and it\'s old name in data', ( done ) => {
-			const oldName = 'oldName';
-			const element = new ModelElement( oldName );
-			element.name = 'newName';
-
-			dispatcher.on( 'rename', ( evt, data, consumable ) => {
-				expect( evt.name ).to.equal( 'rename:newName:oldName' );
-				expect( data.element ).to.equal( element );
-				expect( data.oldName ).to.equal( oldName );
-				expect( consumable.test( data.element, 'rename' ) ).to.be.true;
-
-				done();
-			} );
-
-			dispatcher.convertRename( element, oldName );
-		} );
 	} );
 
 	describe( 'convertAttribute', () => {
@@ -545,11 +478,11 @@ describe( 'ModelConversionDispatcher', () => {
 
 			dispatcher.convertMarker( 'addMarker', 'name', range );
 
-			expect( dispatcher.fire.calledWith( 'addMarker:name', 'name', range ) );
+			expect( dispatcher.fire.calledWith( 'addMarker:name' ) ).to.be.true;
 
 			dispatcher.convertMarker( 'removeMarker', 'name', range );
 
-			expect( dispatcher.fire.calledWith( 'removeMarker:name', 'name', range ) );
+			expect( dispatcher.fire.calledWith( 'removeMarker:name' ) ).to.be.true;
 		} );
 
 		it( 'should not convert marker if it is added in graveyard', () => {

--- a/tests/manual/markers.js
+++ b/tests/manual/markers.js
@@ -81,11 +81,11 @@ function removeHighlight() {
 
 		for ( let i = 0; i < markerNames.length; i++ ) {
 			const name = markerNames[ i ];
-			const range = model.markers.get( name );
+			const marker = model.markers.get( name );
+			const range = marker.getRange();
 
 			if ( range.containsPosition( pos ) || range.start.isEqual( pos ) || range.end.isEqual( pos ) ) {
 				model.markers.remove( name );
-				range.detach();
 
 				markerNames.splice( i, 1 );
 				break;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `ModelConversionDispatcher` now uses `remove` + `insert` events to convert `move` and `rename` changes, instead of dedicated `move` and `rename` events. Closes #837.

BREAKING CHANGES: `ModelConversionDispatcher` no longer fires `move` and `rename` events. This means that feature converters added as callbacks to those should be replaced by `remove` and `insert` converters.