### PR TITLE
t/833: Nothing should happen if creator return null in convertSelectionMarker

### DIFF
--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -149,6 +149,10 @@ export function convertSelectionAttribute( elementCreator ) {
 			elementCreator.clone( true ) :
 			elementCreator( data.value, data, data.selection, consumable, conversionApi );
 
+		if ( !viewElement ) {
+			return;
+		}
+
 		const consumableName = 'selectionAttribute:' + data.key;
 
 		wrapCollapsedSelectionPosition( data.selection, conversionApi.viewSelection, viewElement, consumable, consumableName );
@@ -174,6 +178,10 @@ export function convertSelectionMarker( elementCreator ) {
 		const viewElement = elementCreator instanceof ViewElement ?
 			elementCreator.clone( true ) :
 			elementCreator( data, consumable, conversionApi );
+
+		if ( !viewElement ) {
+			return;
+		}
 
 		const consumableName = 'selectionMarker:' + data.name;
 

--- a/tests/conversion/model-selection-to-view-converters.js
+++ b/tests/conversion/model-selection-to-view-converters.js
@@ -291,6 +291,31 @@ describe( 'model-selection-to-view-converters', () => {
 					.to.equal( '<div>foo<span class="marker2">[]</span>bar</div>' );
 			} );
 
+			it( 'should do nothing if creator return null', () => {
+				dispatcher.on( 'selectionMarker:marker3', convertSelectionMarker( () => {
+					return;
+				} ) );
+
+				setModelData( modelDoc, 'foobar' );
+				const marker = modelDoc.markers.set( 'marker3', ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 ) );
+
+				modelSelection.setRanges( [ new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) ] );
+
+				// Remove view children manually (without firing additional conversion).
+				viewRoot.removeChildren( 0, viewRoot.childCount );
+
+				// Convert model to view.
+				dispatcher.convertInsertion( ModelRange.createIn( modelRoot ) );
+				dispatcher.convertMarker( 'addMarker', marker.name, marker.getRange() );
+
+				const markers = Array.from( modelDoc.markers.getMarkersAtPosition( modelSelection.getFirstPosition() ) );
+				dispatcher.convertSelection( modelSelection, markers );
+
+				// Stringify view and check if it is same as expected.
+				expect( stringifyView( viewRoot, viewSelection, { showType: false } ) )
+					.to.equal( '<div>foo{}bar</div>' );
+			} );
+
 			it( 'consumes consumable values properly', () => {
 				// Add callbacks that will fire before default ones.
 				// This should prevent default callbacks doing anything.
@@ -501,6 +526,19 @@ describe( 'model-selection-to-view-converters', () => {
 					'<strong style="text-transform:uppercase;">[]</strong>' +
 					'<span style="color:yellow;">ba</span>r',
 					{ theme: 'important' }
+				);
+			} );
+
+			it( 'convertSelectionAttribute should do nothing if creator return null', () => {
+				dispatcher.on( 'selectionAttribute:bold', convertSelectionAttribute( () => {
+					return;
+				} ) );
+
+				test(
+					[ 3, 3 ],
+					'foobar',
+					'foo{}bar',
+					{ bold: 'true' }
 				);
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: You can now return `null` from the element creators in converters for selection attributes and markers. It does not crash the conversion anymore. Closes #833.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
