### PR TITLE
Fixed: wrapRange model-to-view converter should not convert if range is collapsed.

### DIFF
--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -351,11 +351,16 @@ export function wrapRange( elementCreator ) {
 			return;
 		}
 
+		const viewRange = conversionApi.mapper.toViewRange( data.range );
+
+		if ( viewRange.isCollapsed ) {
+			return;
+		}
+
 		if ( !consumable.consume( data.range, 'addMarker' ) ) {
 			return;
 		}
 
-		const viewRange = conversionApi.mapper.toViewRange( data.range );
 		const flatViewRanges = viewWriter.breakViewRangePerContainer( viewRange );
 
 		for ( let range of flatViewRanges ) {
@@ -395,11 +400,16 @@ export function unwrapRange( elementCreator ) {
 			return;
 		}
 
+		const viewRange = conversionApi.mapper.toViewRange( data.range );
+
+		if ( viewRange.isCollapsed ) {
+			return;
+		}
+
 		if ( !consumable.consume( data.range, 'removeMarker' ) ) {
 			return;
 		}
 
-		const viewRange = conversionApi.mapper.toViewRange( data.range );
 		const flatViewRanges = viewWriter.breakViewRangePerContainer( viewRange );
 
 		for ( let range of flatViewRanges ) {

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -608,6 +608,36 @@ describe( 'model-to-view-converters', () => {
 			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
 		} );
 
+		it( 'should not convert or consume if range is collapsed', () => {
+			const viewElement = new ViewAttributeElement( 'b' );
+
+			sinon.spy( dispatcher, 'fire' );
+
+			dispatcher.on( 'addMarker:name', wrapRange( viewElement ) );
+			dispatcher.on( 'addMarker:name', ( evt, data, consumable ) => {
+				// Check whether value was not consumed from `consumable`.
+				expect( consumable.test( data.range, 'addMarker' ) ).to.be.true;
+			} );
+
+			dispatcher.on( 'removeMarker:name', unwrapRange( viewElement ) );
+			dispatcher.on( 'removeMarker:name', ( evt, data, consumable ) => {
+				// Check whether value was not consumed from `consumable`.
+				expect( consumable.test( data.range, 'removeMarker' ) ).to.be.true;
+			} );
+
+			const collapsedRange = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 2 );
+
+			dispatcher.convertMarker( 'addMarker', 'name', collapsedRange );
+
+			expect( dispatcher.fire.calledWith( 'addMarker:name' ) ).to.be.true;
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+
+			dispatcher.convertMarker( 'removeMarker', 'name', collapsedRange );
+
+			expect( dispatcher.fire.calledWith( 'removeMarker:name' ) ).to.be.true;
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+		} );
+
 		it( 'multiple overlapping non-collapsed markers', () => {
 			const converterCallbackName = ( data ) => {
 				const name = data.name.split( ':' )[ 1 ];


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `wrapRange()` and `unwrapRange()` default model-to-view converters will not consume nor convert changes if the range to convert is collapsed. Closes #832.