### PR TITLE
Fixed view Matcher.getElementName to not return function name.

### DIFF
--- a/src/view/matcher.js
+++ b/src/view/matcher.js
@@ -203,9 +203,14 @@ export default class Matcher {
 	 * @returns {String|null} Element name trying to match.
 	 */
 	getElementName() {
-		return this._patterns.length == 1 && this._patterns[ 0 ].name && !( this._patterns[ 0 ].name instanceof RegExp ) ?
-			this._patterns[ 0 ].name :
-			null;
+		if ( this._patterns.length !== 1 ) {
+			return null;
+		}
+
+		const pattern = this._patterns[ 0 ];
+		const name = pattern.name;
+
+		return ( typeof pattern != 'function' && name && !( name instanceof RegExp ) ) ? name : null;
 	}
 
 }

--- a/tests/view/matcher.js
+++ b/tests/view/matcher.js
@@ -401,5 +401,17 @@ describe( 'Matcher', () => {
 
 			expect( matcher.getElementName() ).to.be.null;
 		} );
+
+		it( 'should return null for matching function', () => {
+			const matcher = new Matcher( () => {} );
+
+			expect( matcher.getElementName() ).to.be.null;
+		} );
+
+		it( 'should return null for matching named function', () => {
+			const matcher = new Matcher( function matchFunction() {} );
+
+			expect( matcher.getElementName() ).to.be.null;
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `view.Matcher#getElementName()` now returns proper value when named function is used as a pattern. Closes #850.


