### PR TITLE
T/460 Selection rendering breaks composition

### DIFF
--- a/src/view/document.js
+++ b/src/view/document.js
@@ -18,6 +18,7 @@ import SelectionObserver from './observer/selectionobserver';
 import FocusObserver from './observer/focusobserver';
 import KeyObserver from './observer/keyobserver';
 import FakeSelectionObserver from './observer/fakeselectionobserver';
+import CompositionObserver from './observer/compositionobserver';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 
@@ -91,6 +92,18 @@ export default class Document {
 		this.set( 'isFocused', false );
 
 		/**
+		 * True if composition is in progress inside the document.
+		 *
+		 * This property is updated by the {@link module:engine/view/observer/compositionobserver~CompositionObserver}.
+		 * If the {@link module:engine/view/observer/compositionobserver~CompositionObserver} is disabled this property will not change.
+		 *
+		 * @readonly
+		 * @observable
+		 * @member {Boolean} module:engine/view/document~Document#isComposing
+		 */
+		this.set( 'isComposing', false );
+
+		/**
 		 * Instance of the {@link module:engine/view/document~Document#renderer renderer}.
 		 *
 		 * @readonly
@@ -98,6 +111,7 @@ export default class Document {
 		 */
 		this.renderer = new Renderer( this.domConverter, this.selection );
 		this.renderer.bind( 'isFocused' ).to( this, 'isFocused' );
+		this.renderer.bind( 'isComposing' ).to( this, 'isComposing' );
 
 		/**
 		 * Map of registered {@link module:engine/view/observer/observer~Observer observers}.
@@ -113,6 +127,7 @@ export default class Document {
 		this.addObserver( FocusObserver );
 		this.addObserver( KeyObserver );
 		this.addObserver( FakeSelectionObserver );
+		this.addObserver( CompositionObserver );
 
 		injectQuirksHandling( this );
 

--- a/src/view/observer/compositionobserver.js
+++ b/src/view/observer/compositionobserver.js
@@ -30,9 +30,6 @@ export default class CompositionObserver extends DomEventObserver {
 
 		document.on( 'compositionend', () => {
 			document.isComposing = false;
-
-			// Re-render the document to update view elements.
-			document.render();
 		} );
 	}
 

--- a/src/view/observer/compositionobserver.js
+++ b/src/view/observer/compositionobserver.js
@@ -1,0 +1,84 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module engine/view/observer/compositionobserver
+ */
+
+import DomEventObserver from './domeventobserver';
+
+/**
+ * {@link module:engine/view/document~Document#event:compositionstart Compositionstart},
+ * {@link module:engine/view/document~Document#event:compositionupdate compositionupdate} and
+ * {@link module:engine/view/document~Document#event:compositionend compositionend} events observer.
+ *
+ * Note that this observer is attached by the {@link module:engine/view/document~Document} and is available by default.
+ *
+ * @extends module:engine/view/observer/domeventobserver~DomEventObserver
+ */
+export default class CompositionObserver extends DomEventObserver {
+	constructor( document ) {
+		super( document );
+
+		this.domEventType = [ 'compositionstart', 'compositionupdate', 'compositionend' ];
+
+		document.on( 'compositionstart', () => {
+			document.isComposing = true;
+		} );
+
+		document.on( 'compositionend', () => {
+			document.isComposing = false;
+
+			// Re-render the document to update view elements.
+			document.render();
+		} );
+	}
+
+	onDomEvent( domEvent ) {
+		this.fire( domEvent.type, domEvent );
+	}
+}
+
+/**
+ * Fired when composition starts inside one of the editables.
+ *
+ * Introduced by {@link module:engine/view/observer/compositionobserver~CompositionObserver}.
+ *
+ * Note that because {@link module:engine/view/observer/compositionobserver~CompositionObserver} is attached by the
+ * {@link module:engine/view/document~Document}
+ * this event is available by default.
+ *
+ * @see module:engine/view/observer/compositionobserver~CompositionObserver
+ * @event module:engine/view/document~Document#event:compositionstart
+ * @param {module:engine/view/observer/domeventdata~DomEventData} data Event data.
+ */
+
+/**
+ * Fired when composition is updated inside one of the editables.
+ *
+ * Introduced by {@link module:engine/view/observer/compositionobserver~CompositionObserver}.
+ *
+ * Note that because {@link module:engine/view/observer/compositionobserver~CompositionObserver} is attached by the
+ * {@link module:engine/view/document~Document}
+ * this event is available by default.
+ *
+ * @see module:engine/view/observer/compositionobserver~CompositionObserver
+ * @event module:engine/view/document~Document#event:compositionupdate
+ * @param {module:engine/view/observer/domeventdata~DomEventData} data Event data.
+ */
+
+/**
+ * Fired when composition ends inside one of the editables.
+ *
+ * Introduced by {@link module:engine/view/observer/compositionobserver~CompositionObserver}.
+ *
+ * Note that because {@link module:engine/view/observer/compositionobserver~CompositionObserver} is attached by the
+ * {@link module:engine/view/document~Document}
+ * this event is available by default.
+ *
+ * @see module:engine/view/observer/compositionobserver~CompositionObserver
+ * @event module:engine/view/document~Document#event:compositionend
+ * @param {module:engine/view/observer/domeventdata~DomEventData} data Event data.
+ */

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -105,7 +105,7 @@ export default class Renderer {
 		this.isFocused = false;
 
 		/**
-		 * Indicates if composition takes places inside view document. View will not be rendered durning composition.
+		 * Indicates if composition takes places inside view document. View will not be rerendered during composition.
 		 *
 		 * @member {Boolean}
 		 */
@@ -166,8 +166,8 @@ export default class Renderer {
 	 * if needed updates the selection.
 	 *
 	 * Renderer tries not to break text composition (e.g. IME) and x-index of the selection,
-	 * so it does as little as it is needed to update the DOM. During the composition all rendering is blocked
-	 * in order not to break the composition. Render is called after composition ends.
+	 * so it does as little as it is needed to update the DOM. During the composition all rendering is suspended
+	 * in order not to break the composition.
 	 *
 	 * For attributes it adds new attributes to DOM elements, updates values and removes
 	 * attributes which do not exist in the view element.

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -105,6 +105,13 @@ export default class Renderer {
 		this.isFocused = false;
 
 		/**
+		 * Indicates if composition takes places inside view document. View will not be rendered durning composition.
+		 *
+		 * @member {Boolean}
+		 */
+		this.isComposing = false;
+
+		/**
 		 * DOM element containing fake selection.
 		 *
 		 * @private
@@ -159,7 +166,8 @@ export default class Renderer {
 	 * if needed updates the selection.
 	 *
 	 * Renderer tries not to break text composition (e.g. IME) and x-index of the selection,
-	 * so it does as little as it is needed to update the DOM.
+	 * so it does as little as it is needed to update the DOM. During the composition all rendering is blocked
+	 * in order not to break the composition. Render is called after composition ends.
 	 *
 	 * For attributes it adds new attributes to DOM elements, updates values and removes
 	 * attributes which do not exist in the view element.
@@ -177,6 +185,10 @@ export default class Renderer {
 	 * removed as long selection is in the text node which needed it at first.
 	 */
 	render() {
+		if ( this.isComposing ) {
+			return;
+		}
+
 		let inlineFillerPosition;
 
 		// There was inline filler rendered in the DOM but it's not

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -13,6 +13,7 @@ import SelectionObserver from '../../../src/view/observer/selectionobserver';
 import FocusObserver from '../../../src/view/observer/focusobserver';
 import KeyObserver from '../../../src/view/observer/keyobserver';
 import FakeSelectionObserver from '../../../src/view/observer/fakeselectionobserver';
+import CompositionObserver from '../../../src/view/observer/compositionobserver';
 import Renderer from '../../../src/view/renderer';
 import ViewRange from '../../../src/view/range';
 import DomConverter from '../../../src/view/domconverter';
@@ -23,7 +24,7 @@ import log from '@ckeditor/ckeditor5-utils/src/log';
 testUtils.createSinonSandbox();
 
 describe( 'Document', () => {
-	const DEFAULT_OBSERVERS_COUNT = 5;
+	const DEFAULT_OBSERVERS_COUNT = 6;
 	let ObserverMock, ObserverMockGlobalCount, instantiated, enabled, domRoot, viewDocument;
 
 	before( () => {
@@ -88,6 +89,7 @@ describe( 'Document', () => {
 			expect( viewDocument.getObserver( FocusObserver ) ).to.be.instanceof( FocusObserver );
 			expect( viewDocument.getObserver( KeyObserver ) ).to.be.instanceof( KeyObserver );
 			expect( viewDocument.getObserver( FakeSelectionObserver ) ).to.be.instanceof( FakeSelectionObserver );
+			expect( viewDocument.getObserver( CompositionObserver ) ).to.be.instanceof( CompositionObserver );
 		} );
 	} );
 
@@ -419,6 +421,18 @@ describe( 'Document', () => {
 			viewDocument.focus();
 			expect( logSpy.calledOnce ).to.be.true;
 			expect( logSpy.args[ 0 ][ 0 ] ).to.match( /^view-focus-no-selection/ );
+		} );
+	} );
+
+	describe( 'isComposing', () => {
+		it( 'should change renderer.isComposing too', () => {
+			expect( viewDocument.isComposing ).to.equal( false );
+			expect( viewDocument.renderer.isComposing ).to.equal( false );
+
+			viewDocument.isComposing = true;
+
+			expect( viewDocument.isComposing ).to.equal( true );
+			expect( viewDocument.renderer.isComposing ).to.equal( true );
 		} );
 	} );
 } );

--- a/tests/view/manual/compositionobserver.html
+++ b/tests/view/manual/compositionobserver.html
@@ -1,0 +1,3 @@
+<div id="editor">
+	<p>foo bar</p>
+</div>

--- a/tests/view/manual/compositionobserver.js
+++ b/tests/view/manual/compositionobserver.js
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classic';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+
+ClassicEditor.create( document.querySelector( '#editor' ), {
+	plugins: [ Typing, Paragraph ]
+} )
+.then( editor => {
+	window.editor = editor;
+
+	const viewDocument = editor.editing.view;
+
+	viewDocument.on( 'compositionstart', ( evt, data ) => console.log( 'compositionstart', data ) );
+	viewDocument.on( 'compositionupdate', ( evt, data ) => console.log( 'compositionupdate', data ) );
+	viewDocument.on( 'compositionend', ( evt, data ) => console.log( 'compositionend', data ) );
+	viewDocument.focus();
+} )
+.catch( err => {
+	console.error( err.stack );
+} );

--- a/tests/view/manual/compositionobserver.md
+++ b/tests/view/manual/compositionobserver.md
@@ -1,0 +1,10 @@
+* Expected initialization: `{}foo bar`.
+* Check whether composition events are logged to the console with proper data:
+  * `compositionstart`,
+  * `compositionupdate`,
+  * `compositionend`
+  
+**Composition events are fired while typing:**
+* Hiragana,
+* Spanish-ISO: accent "' + a",
+* MacOS: long "a" press (accent balloon)

--- a/tests/view/observer/compositionobserver.js
+++ b/tests/view/observer/compositionobserver.js
@@ -63,14 +63,6 @@ describe( 'CompositionObserver', () => {
 			const data = spy.args[ 0 ][ 1 ];
 			expect( data.domTarget ).to.equal( document.body );
 		} );
-
-		it( 'should render document after compositionend', () => {
-			const renderSpy = sinon.spy( viewDocument, 'render' );
-
-			observer.onDomEvent( { type: 'compositionend', target: document.body } );
-
-			sinon.assert.calledOnce( renderSpy );
-		} );
 	} );
 
 	describe( 'handle isComposing property of the document', () => {

--- a/tests/view/observer/compositionobserver.js
+++ b/tests/view/observer/compositionobserver.js
@@ -1,0 +1,122 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals document */
+
+import CompositionObserver from '../../../src/view/observer/compositionobserver';
+import ViewDocument from '../../../src/view/document';
+import ViewRange from '../../../src/view/range';
+
+describe( 'CompositionObserver', () => {
+	let viewDocument, observer;
+
+	beforeEach( () => {
+		viewDocument = new ViewDocument();
+		observer = viewDocument.getObserver( CompositionObserver );
+	} );
+
+	afterEach( () => {
+		viewDocument.destroy();
+	} );
+
+	it( 'should define domEventType', () => {
+		expect( observer.domEventType ).to.deep.equal( [ 'compositionstart', 'compositionupdate', 'compositionend' ] );
+	} );
+
+	describe( 'onDomEvent', () => {
+		it( 'should fire compositionstart with the right event data', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'compositionstart', spy );
+
+			observer.onDomEvent( { type: 'compositionstart', target: document.body } );
+
+			expect( spy.calledOnce ).to.be.true;
+
+			const data = spy.args[ 0 ][ 1 ];
+			expect( data.domTarget ).to.equal( document.body );
+		} );
+
+		it( 'should fire compositionupdate with the right event data', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'compositionupdate', spy );
+
+			observer.onDomEvent( { type: 'compositionupdate', target: document.body } );
+
+			expect( spy.calledOnce ).to.be.true;
+
+			const data = spy.args[ 0 ][ 1 ];
+			expect( data.domTarget ).to.equal( document.body );
+		} );
+
+		it( 'should fire compositionend with the right event data', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'compositionend', spy );
+
+			observer.onDomEvent( { type: 'compositionend', target: document.body } );
+
+			expect( spy.calledOnce ).to.be.true;
+
+			const data = spy.args[ 0 ][ 1 ];
+			expect( data.domTarget ).to.equal( document.body );
+		} );
+
+		it( 'should render document after compositionend', () => {
+			const renderSpy = sinon.spy( viewDocument, 'render' );
+
+			observer.onDomEvent( { type: 'compositionend', target: document.body } );
+
+			sinon.assert.calledOnce( renderSpy );
+		} );
+	} );
+
+	describe( 'handle isComposing property of the document', () => {
+		let domMain, domHeader, viewMain, viewHeader;
+
+		beforeEach( () => {
+			domMain = document.createElement( 'div' );
+			domHeader = document.createElement( 'h1' );
+
+			viewMain = viewDocument.createRoot( domMain );
+			viewHeader = viewDocument.createRoot( domHeader, 'header' );
+		} );
+
+		it( 'should set isComposing to true on compositionstart', () => {
+			observer.onDomEvent( { type: 'compositionstart', target: domMain } );
+
+			expect( viewDocument.isComposing ).to.equal( true );
+		} );
+
+		it( 'should set isComposing to false on compositionend', () => {
+			observer.onDomEvent( { type: 'compositionstart', target: domMain } );
+
+			expect( viewDocument.isComposing ).to.equal( true );
+
+			observer.onDomEvent( { type: 'compositionend', target: domMain } );
+
+			expect( viewDocument.isComposing ).to.equal( false );
+		} );
+
+		it( 'should not change isComposing on compositionupdate during composition', () => {
+			observer.onDomEvent( { type: 'compositionstart', target: domMain } );
+
+			expect( viewDocument.isComposing ).to.equal( true );
+
+			observer.onDomEvent( { type: 'compositionupdate', target: domMain } );
+
+			expect( viewDocument.isComposing ).to.equal( true );
+		} );
+
+		it( 'should not change isComposing on compositionupdate outside composition', () => {
+			expect( viewDocument.isComposing ).to.equal( false );
+
+			observer.onDomEvent( { type: 'compositionupdate', target: domMain } );
+
+			expect( viewDocument.isComposing ).to.equal( false );
+		} );
+	} );
+} );

--- a/tests/view/observer/compositionobserver.js
+++ b/tests/view/observer/compositionobserver.js
@@ -7,7 +7,6 @@
 
 import CompositionObserver from '../../../src/view/observer/compositionobserver';
 import ViewDocument from '../../../src/view/document';
-import ViewRange from '../../../src/view/range';
 
 describe( 'CompositionObserver', () => {
 	let viewDocument, observer;
@@ -75,14 +74,10 @@ describe( 'CompositionObserver', () => {
 	} );
 
 	describe( 'handle isComposing property of the document', () => {
-		let domMain, domHeader, viewMain, viewHeader;
+		let domMain;
 
 		beforeEach( () => {
 			domMain = document.createElement( 'div' );
-			domHeader = document.createElement( 'h1' );
-
-			viewMain = viewDocument.createRoot( domMain );
-			viewHeader = viewDocument.createRoot( domHeader, 'header' );
 		} );
 
 		it( 'should set isComposing to true on compositionstart', () => {

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1142,6 +1142,113 @@ describe( 'Renderer', () => {
 			expect( domFocusSpy.called ).to.be.false;
 		} );
 
+		it( 'should block rendering during composition', () => {
+			renderer.isComposing = true;
+
+			const removeInlineFillerSpy = testUtils.sinon.spy( renderer, '_removeInlineFiller' );
+			const updateTextSpy = testUtils.sinon.spy( renderer, '_updateText' );
+			const updateAttrsSpy = testUtils.sinon.spy( renderer, '_updateAttrs' );
+			const updateChildrenSpy = testUtils.sinon.spy( renderer, '_updateChildren' );
+			const updateSelectionSpy = testUtils.sinon.spy( renderer, '_updateSelection' );
+			const updateFocusSpy = testUtils.sinon.spy( renderer, '_updateFocus' );
+
+			renderer.render();
+
+			expect( removeInlineFillerSpy.called ).to.be.false;
+			expect( updateTextSpy.called ).to.be.false;
+			expect( updateAttrsSpy.called ).to.be.false;
+			expect( updateChildrenSpy.called ).to.be.false;
+			expect( updateSelectionSpy.called ).to.be.false;
+			expect( updateFocusSpy.called ).to.be.false;
+		} );
+
+		it( 'should block rendering during composition (update attributes)', () => {
+			renderer.isComposing = true;
+
+			viewRoot.setAttribute( 'class', 'foo' );
+
+			renderer.markToSync( 'attributes', viewRoot );
+			renderer.render();
+
+			expect( domRoot.getAttribute( 'class' ) ).to.equal( null );
+
+			expect( renderer.markedAttributes.size ).to.equal( 1 );
+		} );
+
+		it( 'should block rendering during composition (remove attributes)', () => {
+			renderer.isComposing = true;
+
+			viewRoot.setAttribute( 'class', 'foo' );
+			domRoot.setAttribute( 'id', 'bar' );
+			domRoot.setAttribute( 'class', 'bar' );
+
+			renderer.markToSync( 'attributes', viewRoot );
+			renderer.render();
+
+			expect( domRoot.getAttribute( 'class' ) ).to.equal( 'bar' );
+			expect( domRoot.getAttribute( 'id' ) ).to.equal( 'bar' );
+
+			expect( renderer.markedAttributes.size ).to.equal( 1 );
+		} );
+
+		it( 'should block rendering during composition (add children)', () => {
+			renderer.isComposing = true;
+
+			viewRoot.appendChildren( new ViewText( 'foo' ) );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			expect( domRoot.childNodes.length ).to.equal( 0 );
+
+			expect( renderer.markedChildren.size ).to.equal( 1 );
+		} );
+
+		it( 'should block rendering during composition (remove children)', () => {
+			viewRoot.appendChildren( new ViewText( 'foo' ) );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			expect( domRoot.childNodes.length ).to.equal( 1 );
+			expect( domRoot.childNodes[ 0 ].data ).to.equal( 'foo' );
+
+			renderer.isComposing = true;
+
+			viewRoot.removeChildren( 0, 1 );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			expect( domRoot.childNodes.length ).to.equal( 1 );
+			expect( domRoot.childNodes[ 0 ].data ).to.equal( 'foo' );
+
+			expect( renderer.markedChildren.size ).to.equal( 1 );
+		} );
+
+		it( 'should block rendering during composition (update text)', () => {
+			const viewText = new ViewText( 'foo' );
+			viewRoot.appendChildren( viewText );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			expect( domRoot.childNodes.length ).to.equal( 1 );
+			expect( domRoot.childNodes[ 0 ].data ).to.equal( 'foo' );
+
+			renderer.isComposing = true;
+
+			viewText.data = 'bar';
+
+			renderer.markToSync( 'text', viewText );
+			renderer.render();
+
+			expect( domRoot.childNodes.length ).to.equal( 1 );
+			expect( domRoot.childNodes[ 0 ].data ).to.equal( 'foo' );
+
+			expect( renderer.markedTexts.size ).to.equal( 1 );
+		} );
+
 		describe( 'fake selection', () => {
 			beforeEach( () => {
 				const { view: viewP, selection: newSelection } = parse(


### PR DESCRIPTION
Fix: Rendering is suspended during composition. Closes #460.

---

### Additional information

The fix introduces `CompositionObserver` which listens to native composition events. If composition is in progress the `renderer` will not update the DOM.