### PR TITLE
Changed: empty AttributeDeltas should not be added to batch. Fixes #875.

### DIFF
--- a/src/model/delta/attributedelta.js
+++ b/src/model/delta/attributedelta.js
@@ -165,9 +165,10 @@ function changeItem( batch, doc, key, value, item ) {
 	let range, operation;
 
 	const delta = item.is( 'rootElement' ) ? new RootAttributeDelta() : new AttributeDelta();
-	batch.addDelta( delta );
 
 	if ( previousValue != value ) {
+		batch.addDelta( delta );
+
 		if ( item.is( 'rootElement' ) ) {
 			// If we change attributes of root element, we have to use `RootAttributeOperation`.
 			operation = new RootAttributeOperation( item, key, previousValue, value, doc.version );
@@ -195,7 +196,6 @@ function changeItem( batch, doc, key, value, item ) {
 // into smaller parts.
 function changeRange( batch, doc, attributeKey, attributeValue, range ) {
 	const delta = new AttributeDelta();
-	batch.addDelta( delta );
 
 	// Position of the last split, the beginning of the new range.
 	let lastSplitPosition = range.start;
@@ -233,6 +233,11 @@ function changeRange( batch, doc, attributeKey, attributeValue, range ) {
 	}
 
 	function addOperation() {
+		// Add delta to the batch only if there is at least operation in the delta. Add delta only once.
+		if ( delta.operations.length === 0 ) {
+			batch.addDelta( delta );
+		}
+
 		let range = new Range( lastSplitPosition, position );
 		const operation = new AttributeOperation( range, attributeKey, attributeValueBefore, attributeValue, doc.version );
 

--- a/tests/model/delta/attributedelta.js
+++ b/tests/model/delta/attributedelta.js
@@ -393,6 +393,20 @@ describe( 'Batch', () => {
 			} );
 		} );
 	} );
+
+	it( 'should not add empty delta to the batch', () => {
+		let nodeA = new Element( 'p', { a: 1 } );
+		let nodeB = new Element( 'p', { b: 2 } );
+		root.insertChildren( 0, [ nodeA, nodeB ] );
+
+		batch.setAttribute( nodeA, 'a', 1 );
+
+		expect( batch.deltas.length ).to.equal( 0 );
+
+		batch.removeAttribute( Range.createIn( root ), 'x' );
+
+		expect( batch.deltas.length ).to.equal( 0 );
+	} );
 } );
 
 describe( 'AttributeDelta', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Empty `AttributeDelta`s will not be added to batch anymore. Closes #875.