### PR TITLE
Range#_getTransformedByDocumentChange will be "inclusive"

### DIFF
--- a/src/model/delta/basic-transformations.js
+++ b/src/model/delta/basic-transformations.js
@@ -111,6 +111,8 @@ addTransformationCase( MarkerDelta, SplitDelta, transformMarkerDelta );
 addTransformationCase( MarkerDelta, MergeDelta, transformMarkerDelta );
 addTransformationCase( MarkerDelta, WrapDelta, transformMarkerDelta );
 addTransformationCase( MarkerDelta, UnwrapDelta, transformMarkerDelta );
+addTransformationCase( MarkerDelta, MoveDelta, transformMarkerDelta );
+addTransformationCase( MarkerDelta, RenameDelta, transformMarkerDelta );
 
 // Add special case for MoveDelta x MergeDelta transformation.
 addTransformationCase( MoveDelta, MergeDelta, ( a, b, isStrong ) => {

--- a/tests/model/liverange.js
+++ b/tests/model/liverange.js
@@ -292,7 +292,7 @@ describe( 'LiveRange', () => {
 				doc.fire( 'change', 'move', changes, null );
 
 				expect( live.start.path ).to.deep.equal( [ 0, 1, 4 ] );
-				expect( live.end.path ).to.deep.equal( [ 0, 2, 1 ] );
+				expect( live.end.path ).to.deep.equal( [ 2, 1 ] ); // Included some nodes.
 				expect( spy.calledOnce ).to.be.true;
 			} );
 
@@ -307,7 +307,7 @@ describe( 'LiveRange', () => {
 				doc.fire( 'change', 'move', changes, null );
 
 				expect( live.start.path ).to.deep.equal( [ 0, 1, 4 ] );
-				expect( live.end.path ).to.deep.equal( [ 0, 2, 6 ] );
+				expect( live.end.path ).to.deep.equal( [ 0, 2, 1 ] );
 				expect( spy.calledOnce ).to.be.true;
 			} );
 
@@ -357,7 +357,7 @@ describe( 'LiveRange', () => {
 				};
 				doc.fire( 'change', 'move', changes, null );
 
-				expect( live.start.path ).to.deep.equal( [ 0, 1, 2 ] );
+				expect( live.start.path ).to.deep.equal( [ 0, 1, 9 ] );
 				expect( live.end.path ).to.deep.equal( [ 0, 1, 12 ] );
 				expect( spy.calledOnce ).to.be.true;
 			} );

--- a/tests/model/liveselection.js
+++ b/tests/model/liveselection.js
@@ -453,7 +453,7 @@ describe( 'LiveSelection', () => {
 				let range = selection.getFirstRange();
 
 				expect( range.start.path ).to.deep.equal( [ 0, 2 ] );
-				expect( range.end.path ).to.deep.equal( [ 1, 3 ] );
+				expect( range.end.path ).to.deep.equal( [ 5 ] );
 				expect( spyRange.calledOnce ).to.be.true;
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `Range#_getTransformedByDocumentChange` will now include model items when range boundary is moved "out of" range. Closes #877.

BREAKING CHANGE: Significantly changed how `Range#_getTransformedByDocumentChange` works, which is a base for `LiveRange` and `LiveSelection` and markers transformations. See https://github.com/ckeditor/ckeditor5-engine/issues/877#issuecomment-287740021 for reasoning behind the change and examples.