### PR TITLE
T/884 Mapper: default position mapping algorithms may crash editor

### DIFF
--- a/src/conversion/mapper.js
+++ b/src/conversion/mapper.js
@@ -471,9 +471,6 @@ mix( Mapper, EmitterMixin );
  * @event modelToViewPosition
  * @param {Object} data Data pipeline object that can store and pass data between callbacks. The callback should add
  * `viewPosition` value to that object with calculated {@link module:engine/view/position~Position view position}.
- * @param {module:engine/model/position~Position} data.modelPosition Model position to be mapped.
- * @param {module:engine/view/position~Position} data.viewPosition View position that is a result of mapping
- * `modelPosition` using `Mapper` default algorithm.
  * @param {module:engine/conversion/mapper~Mapper} data.mapper Mapper instance that fired the event.
  */
 
@@ -497,8 +494,5 @@ mix( Mapper, EmitterMixin );
  * @event viewToModelPosition
  * @param {Object} data Data pipeline object that can store and pass data between callbacks. The callback should add
  * `modelPosition` value to that object with calculated {@link module:engine/model/position~Position model position}.
- * @param {module:engine/view/position~Position} data.viewPosition View position to be mapped.
- * @param {module:engine/model/position~Position} data.modelPosition Model position that is a result of mapping
- * `viewPosition` using `Mapper` default algorithm.
  * @param {module:engine/conversion/mapper~Mapper} data.mapper Mapper instance that fired the event.
  */

--- a/src/conversion/mapper.js
+++ b/src/conversion/mapper.js
@@ -159,13 +159,12 @@ export default class Mapper {
 	toModelPosition( viewPosition ) {
 		const data = {
 			viewPosition: viewPosition,
-			modelPosition: this._defaultToModelPosition( viewPosition ),
 			mapper: this
 		};
 
 		this.fire( 'viewToModelPosition', data );
 
-		return data.modelPosition;
+		return data.modelPosition ? data.modelPosition : this._defaultToModelPosition( viewPosition );
 	}
 
 	/**
@@ -190,14 +189,13 @@ export default class Mapper {
 	 */
 	toViewPosition( modelPosition ) {
 		const data = {
-			viewPosition: this._defaultToViewPosition( modelPosition ),
 			modelPosition: modelPosition,
 			mapper: this
 		};
 
 		this.fire( 'modelToViewPosition', data );
 
-		return data.viewPosition;
+		return data.viewPosition ? data.viewPosition : this._defaultToViewPosition( modelPosition );
 	}
 
 	/**

--- a/src/model/delta/insertdelta.js
+++ b/src/model/delta/insertdelta.js
@@ -8,10 +8,11 @@
  */
 
 import Delta from './delta';
-import DeltaFactory from './deltafactory';
 import RemoveDelta from './removedelta';
-import { register } from '../batch';
+import DeltaFactory from './deltafactory';
 import InsertOperation from '../operation/insertoperation';
+import { register } from '../batch';
+import { normalizeNodes } from './../writer';
 
 import DocumentFragment from '../documentfragment';
 import Range from '../../model/range.js';
@@ -95,8 +96,15 @@ export default class InsertDelta extends Delta {
  * @param {module:engine/model/node~NodeSet} nodes The list of nodes to be inserted.
  */
 register( 'insert', function( position, nodes ) {
+	const normalizedNodes = normalizeNodes( nodes );
+
+	// If nothing is inserted do not create delta and operation.
+	if ( normalizedNodes.length === 0 ) {
+		return this;
+	}
+
 	const delta = new InsertDelta();
-	const insert = new InsertOperation( position, nodes, this.document.version );
+	const insert = new InsertOperation( position, normalizedNodes, this.document.version );
 
 	this.addDelta( delta );
 	delta.addOperation( insert );

--- a/tests/conversion/mapper.js
+++ b/tests/conversion/mapper.js
@@ -214,7 +214,7 @@ describe( 'Mapper', () => {
 					expect( data.viewPosition.isEqual( viewPosition ) ).to.be.true;
 
 					data.modelPosition = stub;
-					// Do not stop the event. Test whether default algorithm was not called if data.viewPosition is already set.
+					// Do not stop the event. Test whether default algorithm was not called if data.modelPosition is already set.
 				} );
 
 				const result = mapper.toModelPosition( viewPosition );

--- a/tests/conversion/mapper.js
+++ b/tests/conversion/mapper.js
@@ -211,10 +211,10 @@ describe( 'Mapper', () => {
 				const stub = {};
 
 				mapper.on( 'viewToModelPosition', ( evt, data ) => {
-					expect( data.viewPosition ).to.equal( viewPosition );
+					expect( data.viewPosition.isEqual( viewPosition ) ).to.be.true;
 
 					data.modelPosition = stub;
-					evt.stop();
+					// Do not stop the event. Test whether default algorithm was not called if data.viewPosition is already set.
 				} );
 
 				const result = mapper.toModelPosition( viewPosition );
@@ -222,6 +222,27 @@ describe( 'Mapper', () => {
 				expect( result ).to.equal( stub );
 			} );
 
+			it( 'should be possible to add custom position mapping callback after default callback', () => {
+				const viewPosition = new ViewPosition( viewDiv, 0 );
+
+				// Model position to which default algorithm should map `viewPosition`.
+				// This mapping is tested in a test below.
+				const modelPosition = new ModelPosition( modelDiv, [ 0 ] );
+				const stub = {};
+
+				mapper.on( 'viewToModelPosition', ( evt, data ) => {
+					expect( data.viewPosition.isEqual( viewPosition ) ).to.be.true;
+					expect( data.modelPosition.isEqual( modelPosition ) ).to.be.true;
+
+					data.modelPosition = stub;
+				}, { priority: 'low' } );
+
+				const result = mapper.toModelPosition( viewPosition );
+
+				expect( result ).to.equal( stub );
+			} );
+
+			// Default algorithm tests.
 			it( 'should transform viewDiv 0', () => createToModelTest( viewDiv, 0, modelDiv, 0 ) );
 			it( 'should transform viewDiv 1', () => createToModelTest( viewDiv, 1, modelDiv, 1 ) );
 			it( 'should transform viewDiv 2', () => createToModelTest( viewDiv, 2, modelDiv, 2 ) );
@@ -284,10 +305,10 @@ describe( 'Mapper', () => {
 				const stub = {};
 
 				mapper.on( 'modelToViewPosition', ( evt, data ) => {
-					expect( data.modelPosition ).to.equal( modelPosition );
+					expect( data.modelPosition.isEqual( modelPosition ) ).to.be.true;
 
 					data.viewPosition = stub;
-					evt.stop();
+					// Do not stop the event. Test whether default algorithm was not called if data.viewPosition is already set.
 				} );
 
 				const result = mapper.toViewPosition( modelPosition );
@@ -295,6 +316,27 @@ describe( 'Mapper', () => {
 				expect( result ).to.equal( stub );
 			} );
 
+			it( 'should be possible to add custom position mapping callback after default callback', () => {
+				const modelPosition = new ModelPosition( modelDiv, [ 0 ] );
+
+				// View position to which default algorithm should map `viewPosition`.
+				// This mapping is tested in a test below.
+				const viewPosition = new ViewPosition( viewTextX, 0 );
+				const stub = {};
+
+				mapper.on( 'modelToViewPosition', ( evt, data ) => {
+					expect( data.modelPosition.isEqual( modelPosition ) ).to.be.true;
+					expect( data.viewPosition.isEqual( viewPosition ) ).to.be.true;
+
+					data.viewPosition = stub;
+				}, { priority: 'low' } );
+
+				const result = mapper.toViewPosition( modelPosition );
+
+				expect( result ).to.equal( stub );
+			} );
+
+			// Default algorithm tests.
 			it( 'should transform modelDiv 0', () => createToViewTest( modelDiv, 0, viewTextX, 0 ) );
 			it( 'should transform modelDiv 1', () => createToViewTest( modelDiv, 1, viewTextX, 1 ) );
 			it( 'should transform modelDiv 2', () => createToViewTest( modelDiv, 2, viewTextZZ, 0 ) );

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -904,7 +904,7 @@ describe( 'model-to-view-converters', () => {
 	} );
 
 	describe( 'remove', () => {
-		it( 'should remove items from view accordingly to changes in model', () => {
+		it( 'should remove items from view accordingly to changes in model #1', () => {
 			const modelDiv = new ModelElement( 'div', null, [
 				new ModelText( 'foo' ),
 				new ModelElement( 'image' ),
@@ -1001,6 +1001,30 @@ describe( 'model-to-view-converters', () => {
 			);
 
 			expect( viewToString( viewRoot ) ).to.equal( '<div>foo<span></span>ar</div>' );
+		} );
+
+		it( 'should remove correct amount of text when it is split by view ui element', () => {
+			modelRoot.appendChildren( new ModelText( 'foobar' ) );
+			viewRoot.appendChildren( [
+				new ViewText( 'foo' ),
+				new ViewUIElement( 'span' ),
+				new ViewText( 'bar' )
+			] );
+
+			dispatcher.on( 'remove', remove() );
+
+			// Remove 'o<span></span>b'.
+			modelWriter.move(
+				ModelRange.createFromParentsAndOffsets( modelRoot, 2, modelRoot, 4 ),
+				ModelPosition.createAt( modelDoc.graveyard, 'end' )
+			);
+
+			dispatcher.convertRemove(
+				ModelPosition.createFromParentAndOffset( modelRoot, 2 ),
+				ModelRange.createFromParentsAndOffsets( modelDoc.graveyard, 0, modelDoc.graveyard, 2 )
+			);
+
+			expect( viewToString( viewRoot ) ).to.equal( '<div>foar</div>' );
 		} );
 
 		it( 'should not unbind element that has not been moved to graveyard', () => {

--- a/tests/model/delta/insertdelta.js
+++ b/tests/model/delta/insertdelta.js
@@ -87,6 +87,17 @@ describe( 'Batch', () => {
 			expect( doc.applyOperation.secondCall.calledWith( sinon.match( ( operation ) => operation instanceof MarkerOperation ) ) );
 			expect( doc.applyOperation.thirdCall.calledWith( sinon.match( ( operation ) => operation instanceof MarkerOperation ) ) );
 		} );
+
+		it( 'should not create a delta and an operation if no nodes were inserted', () => {
+			sinon.spy( doc, 'applyOperation' );
+
+			batch = doc.batch();
+
+			batch.insert( new Position( root, [ 0 ] ), [] );
+
+			expect( batch.deltas.length ).to.equal( 0 );
+			expect( doc.applyOperation.called ).to.be.false;
+		} );
 	} );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Default `conversion.Mapper` position mapping algorithms are now added as callbacks with `low` priority and are fired only if earlier callbacks did not provide a result. Closes #884.

BREAKING CHANGES: Since default position mapping algorithms are attached with `low` priority, custom position mapping callbacks added with higher priority won't receive position calculated by default algorithms in `data`. To execute default position mapping algorithms and use their value, hook custom callback with lower priority.