### PR TITLE
T/869 `insertContent` shouldn't clone given nodes

### DIFF
--- a/src/controller/insertcontent.js
+++ b/src/controller/insertcontent.js
@@ -135,7 +135,7 @@ class Insertion {
 		nodes = Array.from( nodes );
 
 		for ( let i = 0; i < nodes.length; i++ ) {
-			const node = nodes[ i ].clone();
+			const node = nodes[ i ];
 
 			this._handleNode( node, {
 				isFirst: i === 0 && parentContext.isFirst,

--- a/tests/controller/insertcontent.js
+++ b/tests/controller/insertcontent.js
@@ -9,6 +9,7 @@ import insertContent from '../../src/controller/insertcontent';
 
 import DocumentFragment from '../../src/model/documentfragment';
 import Text from '../../src/model/text';
+import Element from '../../src/model/element';
 
 import { setData, getData, parse } from '../../src/dev-utils/model';
 
@@ -62,55 +63,23 @@ describe( 'DataController', () => {
 			expect( getData( doc ) ).to.equal( 'xa[]x' );
 		} );
 
-		describe( 'saves the reference to the original object', () => {
-			it( 'inline-widget', () => {
-				doc = new Document();
-				doc.createRoot();
+		it( 'should save the reference to the original object', () => {
+			const doc = new Document();
+			const dataController = new DataController( doc );
+			const batch = doc.batch();
+			const content = new Element( 'image' );
 
-				doc.schema.registerItem( 'paragraph', '$block' );
-				doc.schema.registerItem( 'inlineWidget' );
-				doc.schema.allow( { name: 'inlineWidget', inside: '$block' } );
-				doc.schema.allow( { name: 'inlineWidget', inside: '$clipboardHolder' } );
-				doc.schema.objects.add( 'inlineWidget' );
+			doc.createRoot();
 
-				dataController = new DataController( doc );
+			doc.schema.registerItem( 'paragraph', '$block' );
+			doc.schema.registerItem( 'image', '$inline' );
+			doc.schema.objects.add( 'image' );
 
-				const batch = doc.batch();
+			setData( doc, '<paragraph>foo[]</paragraph>' );
 
-				setData( doc, '<paragraph>f[]oo</paragraph>' );
+			insertContent( dataController, content, doc.selection, batch );
 
-				const content = parse( '<inlineWidget></inlineWidget>', doc.schema, {
-					context: [ '$clipboardHolder' ]
-				} );
-
-				insertContent( dataController, content, doc.selection, batch );
-
-				expect( doc.getRoot().getChild( 0 ).getChild( 1 ) ).to.equal( content );
-			} );
-
-			it( 'image', () => {
-				doc = new Document();
-				doc.createRoot();
-
-				doc.schema.registerItem( 'paragraph', '$block' );
-				doc.schema.registerItem( 'image', '$inline' );
-				doc.schema.allow( { name: 'image', inside: '$clipboardHolder' } );
-				doc.schema.objects.add( 'image' );
-
-				dataController = new DataController( doc );
-
-				const batch = doc.batch();
-
-				setData( doc, '<paragraph>foo[]</paragraph>' );
-
-				const content = parse( '<image></image>', doc.schema, {
-					context: [ '$clipboardHolder' ]
-				} );
-
-				insertContent( dataController, content, doc.selection, batch );
-
-				expect( doc.getRoot().getChild( 0 ).getChild( 1 ) ).to.equal( content );
-			} );
+			expect( doc.getRoot().getChild( 0 ).getChild( 1 ) ).to.equal( content );
 		} );
 
 		describe( 'in simple scenarios', () => {

--- a/tests/controller/insertcontent.js
+++ b/tests/controller/insertcontent.js
@@ -62,6 +62,57 @@ describe( 'DataController', () => {
 			expect( getData( doc ) ).to.equal( 'xa[]x' );
 		} );
 
+		describe( 'saves the reference to the original object', () => {
+			it( 'inline-widget', () => {
+				doc = new Document();
+				doc.createRoot();
+
+				doc.schema.registerItem( 'paragraph', '$block' );
+				doc.schema.registerItem( 'inlineWidget' );
+				doc.schema.allow( { name: 'inlineWidget', inside: '$block' } );
+				doc.schema.allow( { name: 'inlineWidget', inside: '$clipboardHolder' } );
+				doc.schema.objects.add( 'inlineWidget' );
+
+				dataController = new DataController( doc );
+
+				const batch = doc.batch();
+
+				setData( doc, '<paragraph>f[]oo</paragraph>' );
+
+				const content = parse( '<inlineWidget></inlineWidget>', doc.schema, {
+					context: [ '$clipboardHolder' ]
+				} );
+
+				insertContent( dataController, content, doc.selection, batch );
+
+				expect( doc.getRoot().getChild( 0 ).getChild( 1 ) ).to.equal( content );
+			} );
+
+			it( 'image', () => {
+				doc = new Document();
+				doc.createRoot();
+
+				doc.schema.registerItem( 'paragraph', '$block' );
+				doc.schema.registerItem( 'image', '$inline' );
+				doc.schema.allow( { name: 'image', inside: '$clipboardHolder' } );
+				doc.schema.objects.add( 'image' );
+
+				dataController = new DataController( doc );
+
+				const batch = doc.batch();
+
+				setData( doc, '<paragraph>foo[]</paragraph>' );
+
+				const content = parse( '<image></image>', doc.schema, {
+					context: [ '$clipboardHolder' ]
+				} );
+
+				insertContent( dataController, content, doc.selection, batch );
+
+				expect( doc.getRoot().getChild( 0 ).getChild( 1 ) ).to.equal( content );
+			} );
+		} );
+
 		describe( 'in simple scenarios', () => {
 			beforeEach( () => {
 				doc = new Document();
@@ -645,5 +696,7 @@ describe( 'DataController', () => {
 		}
 
 		insertContent( dataController, content, doc.selection );
+
+		return content;
 	}
 } );

--- a/tests/controller/insertcontent.js
+++ b/tests/controller/insertcontent.js
@@ -696,7 +696,5 @@ describe( 'DataController', () => {
 		}
 
 		insertContent( dataController, content, doc.selection );
-
-		return content;
 	}
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Changed `insertContent` behaviour, so it doesn't clone given nodes. Closes #869.