### PR TITLE
Reversed `ReinsertOperation` targets back to same graveyard holder

### DIFF
--- a/src/model/operation/reinsertoperation.js
+++ b/src/model/operation/reinsertoperation.js
@@ -45,7 +45,12 @@ export default class ReinsertOperation extends MoveOperation {
 	 * @returns {module:engine/model/operation/removeoperation~RemoveOperation}
 	 */
 	getReversed() {
-		return new RemoveOperation( this.targetPosition, this.howMany, this.baseVersion + 1 );
+		const removeOp = new RemoveOperation( this.targetPosition, this.howMany, this.baseVersion + 1 );
+
+		// Make sure that nodes are put back into the `$graveyardHolder` from which they got reinserted.
+		removeOp.targetPosition = this.sourcePosition;
+
+		return removeOp;
 	}
 
 	/**

--- a/src/model/operation/reinsertoperation.js
+++ b/src/model/operation/reinsertoperation.js
@@ -49,6 +49,7 @@ export default class ReinsertOperation extends MoveOperation {
 
 		// Make sure that nodes are put back into the `$graveyardHolder` from which they got reinserted.
 		removeOp.targetPosition = this.sourcePosition;
+		removeOp._needsHolderElement = false;
 
 		return removeOp;
 	}

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -388,7 +388,7 @@ const ot = {
 				const aTarget = a.targetPosition.path[ 0 ];
 				const bTarget = b.targetPosition.path[ 0 ];
 
-				if ( aTarget >= bTarget && isStrong ) {
+				if ( aTarget > bTarget || ( aTarget == bTarget && isStrong ) ) {
 					// Do not change original operation!
 					a = a.clone();
 					a.targetPosition.path[ 0 ]++;

--- a/tests/model/operation/reinsertoperation.js
+++ b/tests/model/operation/reinsertoperation.js
@@ -61,14 +61,19 @@ describe( 'ReinsertOperation', () => {
 		expect( clone.baseVersion ).to.equal( operation.baseVersion );
 	} );
 
-	it( 'should create a RemoveOperation as a reverse', () => {
+	it( 'should create a correct RemoveOperation as a reverse', () => {
+		// Test reversed operation's target position.
+		graveyard.appendChildren( new Element( '$graveyardHolder' ) );
+
 		let reverse = operation.getReversed();
 
 		expect( reverse ).to.be.an.instanceof( RemoveOperation );
 		expect( reverse.baseVersion ).to.equal( 1 );
 		expect( reverse.howMany ).to.equal( 2 );
 		expect( reverse.sourcePosition.isEqual( rootPosition ) ).to.be.true;
-		expect( reverse.targetPosition.root ).to.equal( graveyardPosition.root );
+
+		// Reversed `ReinsertOperation` should target back to the same graveyard holder.
+		expect( reverse.targetPosition.isEqual( graveyardPosition ) ).to.be.true;
 	} );
 
 	it( 'should undo reinsert set of nodes by applying reverse operation', () => {

--- a/tests/model/operation/reinsertoperation.js
+++ b/tests/model/operation/reinsertoperation.js
@@ -74,6 +74,9 @@ describe( 'ReinsertOperation', () => {
 
 		// Reversed `ReinsertOperation` should target back to the same graveyard holder.
 		expect( reverse.targetPosition.isEqual( graveyardPosition ) ).to.be.true;
+
+		// Reversed `ReinsertOperation` should not create new graveyard holder.
+		expect( reverse._needsHolderElement ).to.be.false;
 	} );
 
 	it( 'should undo reinsert set of nodes by applying reverse operation', () => {

--- a/tests/model/operation/transform.js
+++ b/tests/model/operation/transform.js
@@ -2757,6 +2757,47 @@ describe( 'transform', () => {
 	} );
 
 	describe( 'RemoveOperation', () => {
+		describe( 'by InsertOperation', () => {
+			it( 'should not need new graveyard holder if original operation did not needed it either', () => {
+				let op = new RemoveOperation( new Position( root, [ 1 ] ), 1, baseVersion );
+				op._needsHolderElement = false;
+
+				let transformBy = new InsertOperation( new Position( root, [ 0 ] ), [ new Node() ], baseVersion );
+
+				let transOp = transform( op, transformBy )[ 0 ];
+
+				expect( transOp._needsHolderElement ).to.be.false;
+			} );
+		} );
+
+		describe( 'by MoveOperation', () => {
+			it( 'should create not more than RemoveOperation that needs new graveyard holder', () => {
+				let op = new RemoveOperation( new Position( root, [ 1 ] ), 4, baseVersion );
+				let transformBy = new MoveOperation( new Position( root, [ 0 ] ), 2, new Position( root, [ 8 ] ), baseVersion );
+
+				let transOp = transform( op, transformBy );
+
+				expect( transOp.length ).to.equal( 2 );
+
+				expect( transOp[ 0 ]._needsHolderElement ).to.be.true;
+				expect( transOp[ 1 ]._needsHolderElement ).to.be.false;
+			} );
+
+			it( 'should not need new graveyard holder if original operation did not needed it either', () => {
+				let op = new RemoveOperation( new Position( root, [ 1 ] ), 4, baseVersion );
+				op._needsHolderElement = false;
+
+				let transformBy = new MoveOperation( new Position( root, [ 0 ] ), 2, new Position( root, [ 8 ] ), baseVersion );
+
+				let transOp = transform( op, transformBy );
+
+				expect( transOp.length ).to.equal( 2 );
+
+				expect( transOp[ 0 ]._needsHolderElement ).to.be.false;
+				expect( transOp[ 1 ]._needsHolderElement ).to.be.false;
+			} );
+		} );
+
 		describe( 'by RemoveOperation', () => {
 			it( 'removes same nodes and transformed is weak: change howMany to 0', () => {
 				let position = new Position( root, [ 2, 1 ] );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Reversed `ReinsertOperation` targets back to same graveyard holder from which the nodes were re-inserted. Closes #891.