### PR TITLE
T/889 Fixing tests in SelectionObserver

### DIFF
--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -148,7 +148,9 @@ export default class SelectionObserver extends Observer {
 		}
 
 		// Ensure we are not in the infinite loop (#400).
-		if ( this._isInfiniteLoop() ) {
+		// This counter is reset every 1 seconds. 200 selection changes in 1 seconds is enough high number
+		// to be very difficult (impossible) to achieve using just keyboard keys (during normal editor use).
+		if ( ++this._loopbackCounter > 200 ) {
 			/**
 			 * Selection change observer detected an infinite rendering loop.
 			 * Most probably you try to put the selection in the position which is not allowed
@@ -176,19 +178,6 @@ export default class SelectionObserver extends Observer {
 		// defined int the function time will elapse since the last time the function was called.
 		// So `selectionChangeDone` will be fired when selection will stop changing.
 		this._fireSelectionChangeDoneDebounced( data );
-	}
-
-	/**
-	 * Checks if selection rendering entered an infinite loop.
-	 *
-	 * See https://github.com/ckeditor/ckeditor5-engine/issues/400.
-	 *
-	 * @private
-	 * @param {module:engine/view/selection~Selection} newSelection DOM selection converted to view.
-	 * @returns {Boolean} True is the same selection repeat more then 10 times.
-	 */
-	_isInfiniteLoop() {
-		return ++this._loopbackCounter > 200;
 	}
 
 	/**

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -83,21 +83,7 @@ export default class SelectionObserver extends Observer {
 		 */
 		this._fireSelectionChangeDoneDebounced = debounce( data => this.document.fire( 'selectionChangeDone', data ), 200 );
 
-		this._clearInfiniteLoopInterval = setInterval( () => this._clearInfiniteLoop(), 2000 );
-
-		/**
-		 * Private property to store the last selection, to check if the code does not enter infinite loop.
-		 *
-		 * @private
-		 * @member {module:engine/view/selection~Selection} module:engine/view/observer/selectionobserver~SelectionObserver#_lastSelection
-		 */
-
-		/**
-		 * Private property to store the last but one selection, to check if the code does not enter infinite loop.
-		 *
-		 * @private
-		 * @member {module:engine/view/selection~Selection} module:engine/view/observer/selectionobserver~SelectionObserver#_lastButOneSelection
-		 */
+		this._clearInfiniteLoopInterval = setInterval( () => this._clearInfiniteLoop(), 1000 );
 
 		/**
 		 * Private property to check if the code does not enter infinite loop.
@@ -105,6 +91,7 @@ export default class SelectionObserver extends Observer {
 		 * @private
 		 * @member {Number} module:engine/view/observer/selectionobserver~SelectionObserver#_loopbackCounter
 		 */
+		this._loopbackCounter = 0;
 	}
 
 	/**
@@ -161,7 +148,7 @@ export default class SelectionObserver extends Observer {
 		}
 
 		// Ensure we are not in the infinite loop (#400).
-		if ( this._isInfiniteLoop( newViewSelection ) ) {
+		if ( this._isInfiniteLoop() ) {
 			/**
 			 * Selection change observer detected an infinite rendering loop.
 			 * Most probably you try to put the selection in the position which is not allowed
@@ -200,26 +187,8 @@ export default class SelectionObserver extends Observer {
 	 * @param {module:engine/view/selection~Selection} newSelection DOM selection converted to view.
 	 * @returns {Boolean} True is the same selection repeat more then 10 times.
 	 */
-	_isInfiniteLoop( newSelection ) {
-		// If the position is the same a the last one or the last but one we increment the counter.
-		// We need to check last two selections because the browser will first fire a selectionchange event
-		// for an incorrect selection and then for a corrected one.
-		if ( this._lastSelection && this._lastButOneSelection &&
-			( newSelection.isEqual( this._lastSelection ) || newSelection.isEqual( this._lastButOneSelection ) ) ) {
-			this._loopbackCounter++;
-		} else {
-			this._lastButOneSelection = this._lastSelection;
-			this._lastSelection = newSelection;
-			this._loopbackCounter = 0;
-		}
-
-		// This counter is reset every 2 seconds. 50 selection changes in 2 seconds is enough high number
-		// to be very difficult (impossible) to achieve using just keyboard keys (during normal editor use).
-		if ( this._loopbackCounter > 50 ) {
-			return true;
-		}
-
-		return false;
+	_isInfiniteLoop() {
+		return ++this._loopbackCounter > 200;
 	}
 
 	/**
@@ -228,8 +197,6 @@ export default class SelectionObserver extends Observer {
 	 * @protected
 	 */
 	_clearInfiniteLoop() {
-		this._lastSelection = null;
-		this._lastButOneSelection = null;
 		this._loopbackCounter = 0;
 	}
 }

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -148,9 +148,9 @@ export default class SelectionObserver extends Observer {
 		}
 
 		// Ensure we are not in the infinite loop (#400).
-		// This counter is reset every 1 seconds. 200 selection changes in 1 seconds is enough high number
+		// This counter is reset each second. 60 selection changes in 1 second is enough high number
 		// to be very difficult (impossible) to achieve using just keyboard keys (during normal editor use).
-		if ( ++this._loopbackCounter > 200 ) {
+		if ( ++this._loopbackCounter > 60 ) {
 			/**
 			 * Selection change observer detected an infinite rendering loop.
 			 * Most probably you try to put the selection in the position which is not allowed

--- a/tests/view/observer/selectionobserver.js
+++ b/tests/view/observer/selectionobserver.js
@@ -181,7 +181,6 @@ describe( 'SelectionObserver', () => {
 	it( 'should not be treated as an infinite loop if changes are not often', () => {
 		const clock = testUtils.sinon.useFakeTimers( 'setInterval', 'clearInterval' );
 		const stub = testUtils.sinon.stub( log, 'warn' );
-		const changeCount = 75;
 
 		// We need to recreate SelectionObserver, so it will use mocked setInterval.
 		selectionObserver.disable();
@@ -196,7 +195,8 @@ describe( 'SelectionObserver', () => {
 				clock.restore();
 			} );
 
-		// Does changes in DOM that should not trigger infinite loop warning. Then skips clock to reset loop counter.
+		// Selectionchange event is called twice per `changeDomSelection()` execution. We call it 75 times to get
+		// 150 events. Infinite loop counter is reset, so calling this method twice should not show any warning.
 		function doChanges() {
 			return new Promise( resolve => {
 				viewDocument.once( 'selectionChangeDone', () => {
@@ -204,7 +204,7 @@ describe( 'SelectionObserver', () => {
 					resolve();
 				} );
 
-				for ( let i = 0; i < changeCount; i++ ) {
+				for ( let i = 0; i < 75; i++ ) {
 					changeDomSelection();
 				}
 			} );

--- a/tests/view/observer/selectionobserver.js
+++ b/tests/view/observer/selectionobserver.js
@@ -138,7 +138,7 @@ describe( 'SelectionObserver', () => {
 
 	it( 'should warn and not enter infinite loop', () => {
 		// Selectionchange event is called twice per `changeDomSelection()` execution.
-		let counter = 105;
+		let counter = 35;
 
 		const viewFoo = viewDocument.getRoot().getChild( 0 ).getChild( 0 );
 		viewDocument.selection.addRange( ViewRange.createFromParentsAndOffsets( viewFoo, 0, viewFoo, 0 ) );
@@ -195,8 +195,8 @@ describe( 'SelectionObserver', () => {
 				clock.restore();
 			} );
 
-		// Selectionchange event is called twice per `changeDomSelection()` execution. We call it 75 times to get
-		// 150 events. Infinite loop counter is reset, so calling this method twice should not show any warning.
+		// Selectionchange event is called twice per `changeDomSelection()` execution. We call it 25 times to get
+		// 50 events. Infinite loop counter is reset, so calling this method twice should not show any warning.
 		function doChanges() {
 			return new Promise( resolve => {
 				viewDocument.once( 'selectionChangeDone', () => {
@@ -204,7 +204,7 @@ describe( 'SelectionObserver', () => {
 					resolve();
 				} );
 
-				for ( let i = 0; i < 75; i++ ) {
+				for ( let i = 0; i < 30; i++ ) {
 					changeDomSelection();
 				}
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improved tests stability by changing how infinite loop detection works in SelectionObserver. Closes #889.

---

### Additional information

We decided to totally remove checking if selection is same as previous. Only counter is used now and I've manually tested its settings. I've decided that it will be cleared each second and warning will be showed if counter is greater than `200` before that time. I've managed to get the counter to `~150` by dragging selection around inline elements.
