### PR TITLE
T/887 Renderer should not rerender similar non-collapsed selection.

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -582,13 +582,13 @@ export default class Renderer {
 			return;
 		}
 
-		if ( oldViewSelection && this._areSimilarSelections( oldViewSelection, this.selection ) ) {
+		if ( oldViewSelection && areSimilarSelections( oldViewSelection, this.selection ) ) {
 			const data = {
 				oldSelection: oldViewSelection,
 				currentSelection: this.selection
 			};
 
-			log.warn( 'renderer-selection-similar: Rendering selection was skipped due to its similarity to the previous selection.', data );
+			log.warn( 'renderer-skipped-selection-rendering: The selection was not rendered due to its similarity to the current one.', data );
 
 			return;
 		}
@@ -652,42 +652,38 @@ export default class Renderer {
 			}
 		}
 	}
-
-	/**
-	 * Checks if two given selections are similar. Selections are considered similar if they are non-collapsed
-	 * and their trimmed (see {@link #_trimSelection}) representations are equal.
-	 *
-	 * @private
-	 * @param {module:engine/view/selection~Selection} current
-	 * @param {module:engine/view/selection~Selection} previous
-	 * @returns {Boolean}
-	 */
-	_areSimilarSelections( current, previous ) {
-		return !current.isCollapsed && this._trimSelection( current ).isEqual( this._trimSelection( previous ) );
-	}
-
-	/**
-	 * Creates a copy of a given selection with all of its ranges
-	 * trimmed (see {@link module:engine/view/range~Range#getTrimmed getTrimmed}).
-	 *
-	 * @private
-	 * @param {module:engine/view/selection~Selection} selection
-	 * @returns {module:engine/view/selection~Selection} Selection copy with all ranges trimmed.
-	 */
-	_trimSelection( selection ) {
-		const newSelection = Selection.createFromSelection( selection );
-		const ranges = newSelection.getRanges();
-
-		let trimmedRanges = [];
-
-		for ( let range of ranges ) {
-			trimmedRanges.push( range.getTrimmed() );
-		}
-
-		newSelection.setRanges( trimmedRanges );
-
-		return newSelection;
-	}
 }
 
 mix( Renderer, ObservableMixin );
+
+// Checks if two given selections are similar. Selections are considered similar if they are non-collapsed
+// and their trimmed (see {@link #_trimSelection}) representations are equal.
+//
+// @private
+// @param {module:engine/view/selection~Selection} selection1
+// @param {module:engine/view/selection~Selection} selection2
+// @returns {Boolean}
+function areSimilarSelections( selection1, selection2 ) {
+	return !selection1.isCollapsed && trimSelection( selection1 ).isEqual( trimSelection( selection2 ) );
+}
+
+// Creates a copy of a given selection with all of its ranges
+// trimmed (see {@link module:engine/view/range~Range#getTrimmed getTrimmed}).
+//
+// @private
+// @param {module:engine/view/selection~Selection} selection
+// @returns {module:engine/view/selection~Selection} Selection copy with all ranges trimmed.
+function trimSelection( selection ) {
+	const newSelection = Selection.createFromSelection( selection );
+	const ranges = newSelection.getRanges();
+
+	let trimmedRanges = [];
+
+	for ( let range of ranges ) {
+		trimmedRanges.push( range.getTrimmed() );
+	}
+
+	newSelection.setRanges( trimmedRanges, newSelection.isBackward );
+
+	return newSelection;
+}

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -9,6 +9,7 @@
 
 import ViewText from './text';
 import ViewPosition from './position';
+import Selection from './selection';
 import { INLINE_FILLER, INLINE_FILLER_LENGTH, startsWithFiller, isInlineFiller, isBlockFiller } from './filler';
 
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
@@ -577,7 +578,7 @@ export default class Renderer {
 		const oldViewSelection = domSelection && this.domConverter.domSelectionToView( domSelection );
 
 		if ( oldViewSelection && ( this.selection.isEqual( oldViewSelection ) ||
-			!this.selection.isCollapsed && this.selection.isSimilar( oldViewSelection ) ) ) {
+			this._areSimilarSelections( oldViewSelection, this.selection ) ) ) {
 			return;
 		}
 
@@ -639,6 +640,42 @@ export default class Renderer {
 				this.domConverter.focus( editable );
 			}
 		}
+	}
+
+	/**
+	 * Checks if two given selections are similar. Selections are considered similar if they are non-collapsed
+	 * and their trimmed (see {@link #_trimSelection}) representations are equal.
+	 *
+	 * @private
+	 * @param {module:engine/view/selection~Selection} current
+	 * @param {module:engine/view/selection~Selection} previous
+	 * @returns {Boolean}
+	 */
+	_areSimilarSelections( current, previous ) {
+		return !current.isCollapsed && this._trimSelection( current ).isEqual( this._trimSelection( previous ) );
+	}
+
+	/**
+	 * Creates a copy of a given selection with all of its ranges
+	 * trimmed (see {@link module:engine/view/range~Range#getTrimmed getTrimmed}).
+	 *
+	 * @private
+	 * @param {module:engine/view/selection~Selection} selection
+	 * @returns {module:engine/view/selection~Selection} Selection copy with all ranges trimmed.
+	 */
+	_trimSelection( selection ) {
+		const newSelection = Selection.createFromSelection( selection );
+		const ranges = newSelection.getRanges();
+
+		let trimmedRanges = [];
+
+		for ( let range of ranges ) {
+			trimmedRanges.push( range.getTrimmed() );
+		}
+
+		newSelection.setRanges( trimmedRanges );
+
+		return newSelection;
 	}
 }
 

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -16,6 +16,7 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import diff from '@ckeditor/ckeditor5-utils/src/diff';
 import insertAt from '@ckeditor/ckeditor5-utils/src/dom/insertat';
 import remove from '@ckeditor/ckeditor5-utils/src/dom/remove';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
@@ -577,8 +578,18 @@ export default class Renderer {
 		const domSelection = domRoot.ownerDocument.defaultView.getSelection();
 		const oldViewSelection = domSelection && this.domConverter.domSelectionToView( domSelection );
 
-		if ( oldViewSelection && ( this.selection.isEqual( oldViewSelection ) ||
-			this._areSimilarSelections( oldViewSelection, this.selection ) ) ) {
+		if ( oldViewSelection && this.selection.isEqual( oldViewSelection ) ) {
+			return;
+		}
+
+		if ( oldViewSelection && this._areSimilarSelections( oldViewSelection, this.selection ) ) {
+			const data = {
+				oldSelection: oldViewSelection,
+				currentSelection: this.selection
+			};
+
+			log.warn( 'renderer-selection-similar: Rendering selection was skipped due to its similarity to the previous selection.', data );
+
 			return;
 		}
 

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -576,7 +576,8 @@ export default class Renderer {
 		const domSelection = domRoot.ownerDocument.defaultView.getSelection();
 		const oldViewSelection = domSelection && this.domConverter.domSelectionToView( domSelection );
 
-		if ( oldViewSelection && this.selection.isEqual( oldViewSelection ) ) {
+		if ( oldViewSelection && ( this.selection.isEqual( oldViewSelection ) ||
+			!this.selection.isCollapsed && this.selection.isSimilar( oldViewSelection ) ) ) {
 			return;
 		}
 

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -331,6 +331,17 @@ export default class Selection {
 	}
 
 	/**
+	 * Checks whether, this selection is similar to given selection. Selections are similar if they are initially
+	 * equal (see {@link #isEqual isEqual}) or if their trimmed (see {@link #getTrimmed getTrimmed}) representations are equal.
+	 *
+	 * @param {module:engine/view/selection~Selection} otherSelection Selection to compare with.
+	 * @returns {Boolean} `true` if selections are similar, `false` otherwise.
+	 */
+	isSimilar( otherSelection ) {
+		return this.isEqual( otherSelection ) || this.getTrimmed().isEqual( otherSelection.getTrimmed() );
+	}
+
+	/**
 	 * Removes all ranges that were added to the selection.
 	 *
 	 * @fires change
@@ -480,6 +491,27 @@ export default class Selection {
 		const nodeBeforeEnd = range.end.nodeBefore;
 
 		return ( nodeAfterStart instanceof Element && nodeAfterStart == nodeBeforeEnd ) ? nodeAfterStart : null;
+	}
+
+	/**
+	 * Returns a copy of a selection with all of its ranges
+	 * trimmed (see {@link module:engine/view/range~Range#getTrimmed getTrimmed}).
+	 *
+	 * @returns {module:engine/view/selection~Selection} Selection with all ranges shrank.
+	 */
+	getTrimmed() {
+		const selection = Selection.createFromSelection( this );
+		const ranges = this.getRanges();
+
+		let trimmedRanges = [];
+
+		for ( let range of ranges ) {
+			trimmedRanges.push( range.getTrimmed() );
+		}
+
+		selection.setRanges( trimmedRanges );
+
+		return selection;
 	}
 
 	/**

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -331,17 +331,6 @@ export default class Selection {
 	}
 
 	/**
-	 * Checks whether, this selection is similar to given selection. Selections are similar if they are initially
-	 * equal (see {@link #isEqual isEqual}) or if their trimmed (see {@link #getTrimmed getTrimmed}) representations are equal.
-	 *
-	 * @param {module:engine/view/selection~Selection} otherSelection Selection to compare with.
-	 * @returns {Boolean} `true` if selections are similar, `false` otherwise.
-	 */
-	isSimilar( otherSelection ) {
-		return this.isEqual( otherSelection ) || this.getTrimmed().isEqual( otherSelection.getTrimmed() );
-	}
-
-	/**
 	 * Removes all ranges that were added to the selection.
 	 *
 	 * @fires change
@@ -491,27 +480,6 @@ export default class Selection {
 		const nodeBeforeEnd = range.end.nodeBefore;
 
 		return ( nodeAfterStart instanceof Element && nodeAfterStart == nodeBeforeEnd ) ? nodeAfterStart : null;
-	}
-
-	/**
-	 * Returns a copy of a selection with all of its ranges
-	 * trimmed (see {@link module:engine/view/range~Range#getTrimmed getTrimmed}).
-	 *
-	 * @returns {module:engine/view/selection~Selection} Selection with all ranges shrank.
-	 */
-	getTrimmed() {
-		const selection = Selection.createFromSelection( this );
-		const ranges = this.getRanges();
-
-		let trimmedRanges = [];
-
-		for ( let range of ranges ) {
-			trimmedRanges.push( range.getTrimmed() );
-		}
-
-		selection.setRanges( trimmedRanges );
-
-		return selection;
 	}
 
 	/**

--- a/tests/manual/tickets/880/1.html
+++ b/tests/manual/tickets/880/1.html
@@ -1,0 +1,3 @@
+<div id="editor">
+	<p>This is an <strong>editor</strong> instance.</p>
+</div>

--- a/tests/manual/tickets/880/1.js
+++ b/tests/manual/tickets/880/1.js
@@ -17,9 +17,9 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 .then( editor => {
 	window.editor = editor;
 
-	editor.editing.view.on( 'selectionChangeDone', () => {
+	editor.editing.view.on( 'selectionChange', () => {
 		editor.document.enqueueChanges( () => {} );
-		console.log( 'selectionChangeDone', ( new Date() ).getTime() );
+		console.log( 'selectionChange', ( new Date() ).getTime() );
 	} );
 } )
 .catch( err => {

--- a/tests/manual/tickets/880/1.js
+++ b/tests/manual/tickets/880/1.js
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classic';
+import EssentialsPreset from '@ckeditor/ckeditor5-presets/src/essentials';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+
+ClassicEditor.create( document.querySelector( '#editor' ), {
+	plugins: [ EssentialsPreset, Paragraph, Bold ],
+	toolbar: [ 'undo', 'redo' ]
+} )
+.then( editor => {
+	window.editor = editor;
+
+	editor.editing.view.on( 'selectionChangeDone', () => {
+		editor.document.enqueueChanges( () => {} );
+		console.log( 'selectionChangeDone', ( new Date() ).getTime() );
+	} );
+} )
+.catch( err => {
+	console.error( err.stack );
+} );

--- a/tests/manual/tickets/880/1.md
+++ b/tests/manual/tickets/880/1.md
@@ -1,0 +1,7 @@
+## Renderer - Infinite selectionChange event
+
+1. Focus editor.
+1. Place selection like `This is {an <strong>editor}</strong> instance.` (must end on the end of inline style)
+
+**Expected**: Every time selection is changed, console log with `selectionChangeDone` is printed once.
+While creating selection from **2.**, there might be `renderer-selection-similar` warning visible in the console.

--- a/tests/manual/tickets/880/1.md
+++ b/tests/manual/tickets/880/1.md
@@ -1,7 +1,14 @@
-## Renderer - Infinite selectionChange event
+## Renderer - infinite `selectionChange` event
 
-1. Focus editor.
-1. Place selection like `This is {an <strong>editor}</strong> instance.` (must end on the end of inline style)
+Place the selection like this:
 
-**Expected**: Every time selection is changed, console log with `selectionChangeDone` is printed once.
-While creating selection from **2.**, there might be `renderer-selection-similar` warning visible in the console.
+```
+This is {an <strong>editor}</strong> instance.
+```
+
+(it must end at the end of the inline style)
+
+**Expected**:
+
+* Every time selection is changed, console log with `selectionChange` is printed once.
+* While creating selection from **2.**, there might be `renderer-selection-similar` warning visible in the console.

--- a/tests/manual/tickets/887/1.html
+++ b/tests/manual/tickets/887/1.html
@@ -1,0 +1,3 @@
+<div id="editor">
+	<p>This is an <strong>editor</strong> instance.</p>
+</div>

--- a/tests/manual/tickets/887/1.js
+++ b/tests/manual/tickets/887/1.js
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classic';
+import EssentialsPreset from '@ckeditor/ckeditor5-presets/src/essentials';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+
+ClassicEditor.create( document.querySelector( '#editor' ), {
+	plugins: [ EssentialsPreset, Paragraph, Bold ],
+	toolbar: [ 'undo', 'redo' ]
+} )
+.then( editor => {
+	window.editor = editor;
+} )
+.catch( err => {
+	console.error( err.stack );
+} );

--- a/tests/manual/tickets/887/1.md
+++ b/tests/manual/tickets/887/1.md
@@ -5,4 +5,4 @@
 3. Navigate through balloon panel with arrow keys.
 
 **Expected**: It is possible to navigate with arrow keys inside MacOS balloon panel. While navigating, there
-might be `renderer-selection-similar` warning visible in the browser dev console.
+might be `renderer-selection-similar` warning visible in the console.

--- a/tests/manual/tickets/887/1.md
+++ b/tests/manual/tickets/887/1.md
@@ -1,8 +1,10 @@
-## Renderer - MacOS accent balloon similar selection
+## Renderer - MacOS accent balloon on inline element boundary
 
-1. Place selection like `This is an <strong>editor{}</strong> instance.`
+1. Place the selection like this:
+
+   `This is an <strong>editor{}</strong> instance.`
 2. Open MacOS accent balloon (e.g. long `a` press).
-3. Navigate through balloon panel with arrow keys.
+3. Navigate through the balloon panel using arrow keys.
 
-**Expected**: It is possible to navigate with arrow keys inside MacOS balloon panel. While navigating, there
+**Expected**: It is possible to navigate with arrow keys inside the MacOS balloon panel. While navigating, there
 might be `renderer-selection-similar` warning visible in the console.

--- a/tests/manual/tickets/887/1.md
+++ b/tests/manual/tickets/887/1.md
@@ -1,0 +1,8 @@
+## Renderer - MacOS accent balloon similar selection
+
+1. Place selection like `This is an <strong>editor{}</strong> instance.`
+2. Open MacOS accent balloon (e.g. long `a` press).
+3. Navigate through balloon panel with arrow keys.
+
+**Expected**: It is possible to navigate with arrow keys inside MacOS balloon panel. While navigating, there
+might be `renderer-selection-similar` warning visible in the browser dev console.

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -17,6 +17,7 @@ import { parse } from '../../src/dev-utils/view';
 import { INLINE_FILLER, INLINE_FILLER_LENGTH, isBlockFiller, BR_FILLER } from '../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 
 testUtils.createSinonSandbox();
 
@@ -1355,7 +1356,11 @@ describe( 'Renderer', () => {
 		describe( 'similar selection', () => {
 			// Use spies to check selection updates. Some selection positions are not achievable in some
 			// browsers (e.g. <p>Foo<b>{}Bar</b></p> in Chrome) so asserting dom selection after rendering would fail.
-			let selectionCollapseSpy, selectionExtendSpy;
+			let selectionCollapseSpy, selectionExtendSpy, logWarnStub;
+
+			before( () => {
+				logWarnStub = sinon.stub( log, 'warn' );
+			} );
 
 			afterEach( () => {
 				if ( selectionCollapseSpy ) {
@@ -1367,6 +1372,11 @@ describe( 'Renderer', () => {
 					selectionExtendSpy.restore();
 					selectionExtendSpy = null;
 				}
+				logWarnStub.reset();
+			} );
+
+			after( () => {
+				logWarnStub.restore();
 			} );
 
 			it( 'should always render collapsed selection even if it is similar', () => {
@@ -1405,6 +1415,7 @@ describe( 'Renderer', () => {
 				expect( selectionCollapseSpy.calledWith( domB.childNodes[ 0 ], 0 ) ).to.true;
 				expect( selectionExtendSpy.calledOnce ).to.true;
 				expect( selectionExtendSpy.calledWith( domB.childNodes[ 0 ], 0 ) ).to.true;
+				expect( logWarnStub.notCalled ).to.true;
 			} );
 
 			it( 'should always render collapsed selection even if it is similar (with empty element)', () => {
@@ -1442,6 +1453,7 @@ describe( 'Renderer', () => {
 				expect( selectionCollapseSpy.calledWith( domP.childNodes[ 0 ], 3 ) ).to.true;
 				expect( selectionExtendSpy.calledOnce ).to.true;
 				expect( selectionExtendSpy.calledWith( domP.childNodes[ 0 ], 3 ) ).to.true;
+				expect( logWarnStub.notCalled ).to.true;
 			} );
 
 			it( 'should always render non-collapsed selection if it not is similar', () => {
@@ -1480,6 +1492,7 @@ describe( 'Renderer', () => {
 				expect( selectionCollapseSpy.calledWith( domP.childNodes[ 0 ], 2 ) ).to.true;
 				expect( selectionExtendSpy.calledOnce ).to.true;
 				expect( selectionExtendSpy.calledWith( domB.childNodes[ 0 ], 1 ) ).to.true;
+				expect( logWarnStub.notCalled ).to.true;
 			} );
 
 			it( 'should not render non-collapsed selection it is similar (element start)', () => {
@@ -1516,6 +1529,7 @@ describe( 'Renderer', () => {
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
 				expect( selectionExtendSpy.notCalled ).to.true;
+				expect( logWarnStub.called ).to.true;
 			} );
 
 			it( 'should not render non-collapsed selection it is similar (element end)', () => {
@@ -1552,6 +1566,7 @@ describe( 'Renderer', () => {
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
 				expect( selectionExtendSpy.notCalled ).to.true;
+				expect( logWarnStub.called ).to.true;
 			} );
 
 			it( 'should not render non-collapsed selection it is similar (element start - nested)', () => {
@@ -1588,6 +1603,7 @@ describe( 'Renderer', () => {
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
 				expect( selectionExtendSpy.notCalled ).to.true;
+				expect( logWarnStub.called ).to.true;
 			} );
 
 			it( 'should not render non-collapsed selection it is similar (element end - nested)', () => {
@@ -1623,6 +1639,7 @@ describe( 'Renderer', () => {
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
 				expect( selectionExtendSpy.notCalled ).to.true;
+				expect( logWarnStub.called ).to.true;
 			} );
 		} );
 	} );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -8,6 +8,7 @@
 import ViewElement from '../../src/view/element';
 import ViewText from '../../src/view/text';
 import ViewRange from '../../src/view/range';
+import ViewPosition from '../../src/view/position';
 import Selection from '../../src/view/selection';
 import DomConverter from '../../src/view/domconverter';
 import Renderer from '../../src/view/renderer';
@@ -1347,6 +1348,281 @@ describe( 'Renderer', () => {
 				const bindSelection = renderer.domConverter.fakeSelectionToView( container );
 				expect( bindSelection ).to.be.defined;
 				expect( bindSelection.isEqual( selection ) ).to.be.true;
+			} );
+		} );
+
+		// #887
+		describe( 'similar selection', () => {
+			// Use spies to check selection updates. Some selection positions are not achievable in some
+			// browsers (e.g. <p>Foo<b>{}Bar</b></p> in Chrome) so asserting dom selection after rendering would fail.
+			let selectionCollapseSpy, selectionExtendSpy;
+
+			afterEach( () => {
+				if ( selectionCollapseSpy ) {
+					selectionCollapseSpy.restore();
+					selectionCollapseSpy = null;
+				}
+
+				if ( selectionExtendSpy ) {
+					selectionExtendSpy.restore();
+					selectionExtendSpy = null;
+				}
+			} );
+
+			it( 'should always render collapsed selection even if it is similar', () => {
+				const domSelection = document.getSelection();
+
+				const { view: viewP, selection: newSelection } = parse(
+					'<container:p>foo{}<attribute:b>bar</attribute:b></container:p>' );
+
+				viewRoot.appendChildren( viewP );
+				selection.setTo( newSelection );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const domP = domRoot.childNodes[ 0 ];
+				const domB = domP.childNodes[ 1 ];
+				const viewB = viewRoot.getChild( 0 ).getChild( 1 );
+
+				expect( domSelection.isCollapsed ).to.true;
+				expect( domSelection.rangeCount ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domP.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 3 );
+				expect( domSelection.getRangeAt( 0 ).endContainer ).to.equal( domP.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 3 );
+
+				selectionCollapseSpy = sinon.spy( window.Selection.prototype, 'collapse' );
+				selectionExtendSpy = sinon.spy( window.Selection.prototype, 'extend' );
+
+				// <container:p>foo<attribute:b>{}bar</attribute:b></container:p>
+				selection.setRanges( [ new ViewRange( new ViewPosition( viewB.getChild( 0 ), 0 ), new ViewPosition( viewB.getChild( 0 ), 0 ) ) ] );
+
+				renderer.markToSync( 'children', viewP );
+				renderer.render();
+
+				expect( selectionCollapseSpy.calledOnce ).to.true;
+				expect( selectionCollapseSpy.calledWith( domB.childNodes[ 0 ], 0 ) ).to.true;
+				expect( selectionExtendSpy.calledOnce ).to.true;
+				expect( selectionExtendSpy.calledWith( domB.childNodes[ 0 ], 0 ) ).to.true;
+			} );
+
+			it( 'should always render collapsed selection even if it is similar (with empty element)', () => {
+				const domSelection = document.getSelection();
+
+				const { view: viewP, selection: newSelection } = parse(
+					'<container:p>foo<attribute:b>[]</attribute:b></container:p>' );
+
+				viewRoot.appendChildren( viewP );
+				selection.setTo( newSelection );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const domP = domRoot.childNodes[ 0 ];
+				const domB = domP.childNodes[ 1 ];
+
+				expect( domSelection.isCollapsed ).to.true;
+				expect( domSelection.rangeCount ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domB.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( INLINE_FILLER_LENGTH );
+				expect( domSelection.getRangeAt( 0 ).endContainer ).to.equal( domB.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( INLINE_FILLER_LENGTH );
+
+				selectionCollapseSpy = sinon.spy( window.Selection.prototype, 'collapse' );
+				selectionExtendSpy = sinon.spy( window.Selection.prototype, 'extend' );
+
+				// <container:p>foo{}<attribute:b></attribute:b></container:p>
+				selection.setRanges( [ new ViewRange( new ViewPosition( viewP.getChild( 0 ), 3 ), new ViewPosition( viewP.getChild( 0 ), 3 ) ) ] );
+
+				renderer.markToSync( 'children', viewP );
+				renderer.render();
+
+				expect( selectionCollapseSpy.calledOnce ).to.true;
+				expect( selectionCollapseSpy.calledWith( domP.childNodes[ 0 ], 3 ) ).to.true;
+				expect( selectionExtendSpy.calledOnce ).to.true;
+				expect( selectionExtendSpy.calledWith( domP.childNodes[ 0 ], 3 ) ).to.true;
+			} );
+
+			it( 'should always render non-collapsed selection if it not is similar', () => {
+				const domSelection = document.getSelection();
+
+				const { view: viewP, selection: newSelection } = parse(
+					'<container:p>fo{o}<attribute:b>bar</attribute:b></container:p>' );
+
+				viewRoot.appendChildren( viewP );
+				selection.setTo( newSelection );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const domP = domRoot.childNodes[ 0 ];
+				const domB = domP.childNodes[ 1 ];
+				const viewB = viewRoot.getChild( 0 ).getChild( 1 );
+
+				expect( domSelection.isCollapsed ).to.false;
+				expect( domSelection.rangeCount ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domP.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 2 );
+				expect( domSelection.getRangeAt( 0 ).endContainer ).to.equal( domP.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 3 );
+
+				selectionCollapseSpy = sinon.spy( window.Selection.prototype, 'collapse' );
+				selectionExtendSpy = sinon.spy( window.Selection.prototype, 'extend' );
+
+				// <container:p>fo{o<attribute:b>b}ar</attribute:b></container:p>
+				selection.setRanges( [ new ViewRange( new ViewPosition( viewP.getChild( 0 ), 2 ), new ViewPosition( viewB.getChild( 0 ), 1 ) ) ] );
+
+				renderer.markToSync( 'children', viewP );
+				renderer.render();
+
+				expect( selectionCollapseSpy.calledOnce ).to.true;
+				expect( selectionCollapseSpy.calledWith( domP.childNodes[ 0 ], 2 ) ).to.true;
+				expect( selectionExtendSpy.calledOnce ).to.true;
+				expect( selectionExtendSpy.calledWith( domB.childNodes[ 0 ], 1 ) ).to.true;
+			} );
+
+			it( 'should not render non-collapsed selection it is similar (element start)', () => {
+				const domSelection = document.getSelection();
+
+				const { view: viewP, selection: newSelection } = parse(
+					'<container:p>foo<attribute:b>{ba}r</attribute:b></container:p>' );
+
+				viewRoot.appendChildren( viewP );
+				selection.setTo( newSelection );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const domP = domRoot.childNodes[ 0 ];
+				const domB = domP.childNodes[ 1 ];
+				const viewB = viewRoot.getChild( 0 ).getChild( 1 );
+
+				expect( domSelection.isCollapsed ).to.false;
+				expect( domSelection.rangeCount ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domB.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 0 );
+				expect( domSelection.getRangeAt( 0 ).endContainer ).to.equal( domB.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 2 );
+
+				selectionCollapseSpy = sinon.spy( window.Selection.prototype, 'collapse' );
+				selectionExtendSpy = sinon.spy( window.Selection.prototype, 'extend' );
+
+				// <container:p>foo{<attribute:b>ba}r</attribute:b></container:p>
+				selection.setRanges( [ new ViewRange( new ViewPosition( viewP.getChild( 0 ), 3 ), new ViewPosition( viewB.getChild( 0 ), 2 ) ) ] );
+
+				renderer.markToSync( 'children', viewP );
+				renderer.render();
+
+				expect( selectionCollapseSpy.notCalled ).to.true;
+				expect( selectionExtendSpy.notCalled ).to.true;
+			} );
+
+			it( 'should not render non-collapsed selection it is similar (element end)', () => {
+				const domSelection = document.getSelection();
+
+				const { view: viewP, selection: newSelection } = parse(
+					'<container:p>foo<attribute:b>b{ar}</attribute:b>baz</container:p>' );
+
+				viewRoot.appendChildren( viewP );
+				selection.setTo( newSelection );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const domP = domRoot.childNodes[ 0 ];
+				const domB = domP.childNodes[ 1 ];
+				const viewB = viewRoot.getChild( 0 ).getChild( 1 );
+
+				expect( domSelection.isCollapsed ).to.false;
+				expect( domSelection.rangeCount ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domB.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).endContainer ).to.equal( domB.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 3 );
+
+				selectionCollapseSpy = sinon.spy( window.Selection.prototype, 'collapse' );
+				selectionExtendSpy = sinon.spy( window.Selection.prototype, 'extend' );
+
+				// <container:p>foo<attribute:b>b{ar</attribute:b>}baz</container:p>
+				selection.setRanges( [ new ViewRange( new ViewPosition( viewB.getChild( 0 ), 1 ), new ViewPosition( viewP.getChild( 2 ), 0 ) ) ] );
+
+				renderer.markToSync( 'children', viewP );
+				renderer.render();
+
+				expect( selectionCollapseSpy.notCalled ).to.true;
+				expect( selectionExtendSpy.notCalled ).to.true;
+			} );
+
+			it( 'should not render non-collapsed selection it is similar (element start - nested)', () => {
+				const domSelection = document.getSelection();
+
+				const { view: viewP, selection: newSelection } = parse(
+					'<container:p>foo<attribute:b><attribute:i>{ba}r</attribute:i></attribute:b></container:p>' );
+
+				viewRoot.appendChildren( viewP );
+				selection.setTo( newSelection );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const domP = domRoot.childNodes[ 0 ];
+				const domB = domP.childNodes[ 1 ];
+				const viewI = viewRoot.getChild( 0 ).getChild( 1 ).getChild( 0 );
+
+				expect( domSelection.isCollapsed ).to.false;
+				expect( domSelection.rangeCount ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domB.childNodes[ 0 ].childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 0 );
+				expect( domSelection.getRangeAt( 0 ).endContainer ).to.equal( domB.childNodes[ 0 ].childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 2 );
+
+				selectionCollapseSpy = sinon.spy( window.Selection.prototype, 'collapse' );
+				selectionExtendSpy = sinon.spy( window.Selection.prototype, 'extend' );
+
+				// <container:p>foo{<attribute:b><attribute:i>ba}r</attribute:i></attribute:b></container:p>
+				selection.setRanges( [ new ViewRange( new ViewPosition( viewP.getChild( 0 ), 3 ), new ViewPosition( viewI.getChild( 0 ), 2 ) ) ] );
+
+				renderer.markToSync( 'children', viewP );
+				renderer.render();
+
+				expect( selectionCollapseSpy.notCalled ).to.true;
+				expect( selectionExtendSpy.notCalled ).to.true;
+			} );
+
+			it( 'should not render non-collapsed selection it is similar (element end - nested)', () => {
+				const domSelection = document.getSelection();
+
+				const { view: viewP, selection: newSelection } = parse(
+					'<container:p>f{oo<attribute:b><attribute:i>bar}</attribute:i></attribute:b>baz</container:p>' );
+
+				viewRoot.appendChildren( viewP );
+				selection.setTo( newSelection );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const domP = domRoot.childNodes[ 0 ];
+				const domB = domP.childNodes[ 1 ];
+
+				expect( domSelection.isCollapsed ).to.false;
+				expect( domSelection.rangeCount ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domP.childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).endContainer ).to.equal( domB.childNodes[ 0 ].childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 3 );
+
+				selectionCollapseSpy = sinon.spy( window.Selection.prototype, 'collapse' );
+				selectionExtendSpy = sinon.spy( window.Selection.prototype, 'extend' );
+
+				// <container:p>f{oo<attribute:b><attribute:i>bar</attribute:i></attribute:b>}baz</container:p>
+				selection.setRanges( [ new ViewRange( new ViewPosition( viewP.getChild( 0 ), 1 ), new ViewPosition( viewP.getChild( 2 ), 0 ) ) ] );
+
+				renderer.markToSync( 'children', viewP );
+				renderer.render();
+
+				expect( selectionCollapseSpy.notCalled ).to.true;
+				expect( selectionExtendSpy.notCalled ).to.true;
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Renderer does not rerender similar non-collapsed selection. Closes #887. Closes #880.

---

### Additional information

While working on this fix I have some doubts where logic checking if ranges are similar should be placed. It seems like a good place should be `view/selection` class (then it will have `isEqual` and `isSimilar` methods). But then it should also have method which trimms the selection (which is basically a selection with trimmed ranges).
Also the renderer is the one to decide how to check if selections are similar so any custom logic (some might be needed in the future) should be placed here. That was the reason the logic is placed in the `view/renderer` class (however, still not 100% sure about it).
