### PR TITLE
Fixing Renderer, part two.

### DIFF
--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -134,15 +134,22 @@ export default class DomConverter {
 	}
 
 	/**
-	 * Unbinds given `domElement` from the view element it was bound to.
+	 * Unbinds given `domElement` from the view element it was bound to. Unbinding is deep, meaning that all children of
+	 * `domElement` will be unbound too.
 	 *
 	 * @param {HTMLElement} domElement DOM element to unbind.
 	 */
 	unbindDomElement( domElement ) {
 		const viewElement = this._domToViewMapping.get( domElement );
 
-		this._domToViewMapping.delete( domElement );
-		this._viewToDomMapping.delete( viewElement );
+		if ( viewElement ) {
+			this._domToViewMapping.delete( domElement );
+			this._viewToDomMapping.delete( viewElement );
+
+			for ( let child of domElement.childNodes ) {
+				this.unbindDomElement( child );
+			}
+		}
 	}
 
 	/**

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -473,7 +473,7 @@ export default class Renderer {
 				i++;
 			} else if ( action === 'delete' ) {
 				// Whenever element is removed from DOM, unbind it and all of its children.
-				unbindDeep( actualDomChildren[ i ], this.domConverter );
+				this.domConverter.unbindDomElement( actualDomChildren[ i ] );
 				remove( actualDomChildren[ i ] );
 			} else { // 'equal'
 				i++;
@@ -686,17 +686,4 @@ function trimSelection( selection ) {
 	newSelection.setRanges( trimmedRanges, newSelection.isBackward );
 
 	return newSelection;
-}
-
-// Unbind given `domElement` and all of its children from view using given `domConverter`.
-//
-// @private
-// @param {HTMLElement} domElement
-// @param {module:engine/view/domconverter~DomConverter}
-function unbindDeep( domElement, domConverter ) {
-	domConverter.unbindDomElement( domElement );
-
-	for ( let child of domElement.childNodes ) {
-		unbindDeep( child, domConverter );
-	}
 }

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -472,8 +472,8 @@ export default class Renderer {
 				insertAt( domElement, i, expectedDomChildren[ i ] );
 				i++;
 			} else if ( action === 'delete' ) {
-				// Whenever element is removed from DOM, unbind it.
-				this.domConverter.unbindDomElement( actualDomChildren[ i ] );
+				// Whenever element is removed from DOM, unbind it and all of its children.
+				unbindDeep( actualDomChildren[ i ], this.domConverter );
 				remove( actualDomChildren[ i ] );
 			} else { // 'equal'
 				i++;
@@ -686,4 +686,17 @@ function trimSelection( selection ) {
 	newSelection.setRanges( trimmedRanges, newSelection.isBackward );
 
 	return newSelection;
+}
+
+// Unbind given `domElement` and all of its children from view using given `domConverter`.
+//
+// @private
+// @param {HTMLElement} domElement
+// @param {module:engine/view/domconverter~DomConverter}
+function unbindDeep( domElement, domConverter ) {
+	domConverter.unbindDomElement( domElement );
+
+	for ( let child of domElement.childNodes ) {
+		unbindDeep( child, domConverter );
+	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `view.Renderer` will deeply unbind DOM elements when they are removed from DOM. Closes #888.