### PR TITLE
Changed the behaviour of deleteContent() in case of nested elements

### DIFF
--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -98,7 +98,9 @@ function mergeBranches( batch, startPos, endPos ) {
 	startPos = Position.createAfter( startParent );
 	endPos = Position.createBefore( endParent );
 
-	if ( endParent.childCount > 0 ) {
+	if ( endParent.isEmpty ) {
+		batch.remove( endParent );
+	} else {
 		// At the moment, next startPos is also the position to which the endParent
 		// needs to be moved:
 		// <a><b>x[]</b></a><c><d>{}y</d></c>
@@ -114,8 +116,19 @@ function mergeBranches( batch, startPos, endPos ) {
 		// To then become:
 		// <a><b>xy</b>[]</a><c>{}</c>
 		batch.merge( startPos );
-	} else {
-		batch.remove( endParent );
+	}
+
+	// Removes empty end ancestors:
+	// <a>fo[o</a><b><a><c>bar]</c></a></b>
+	// becomes:
+	// <a>fo[]</a><b><a>{}</a></b>
+	// So we can remove <a> and <b>.
+	while ( endPos.parent.isEmpty ) {
+		const parentToRemove = endPos.parent;
+
+		endPos = Position.createBefore( parentToRemove );
+
+		batch.remove( parentToRemove );
 	}
 
 	// Continue merging next level.

--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -78,7 +78,7 @@ function mergeBranches( batch, startPos, endPos ) {
 	}
 
 	// If one of the positions is a root, then there's nothing more to merge (at least in the current state of implementation).
-	// Theoretically in this case we could unwrap the <p>: <$root>x[]<p>[]y</p></$root>, but we don't need to support it yet
+	// Theoretically in this case we could unwrap the <p>: <$root>x[]<p>{}y</p></$root>, but we don't need to support it yet
 	// so let's just abort.
 	if ( !startParent.parent || !endParent.parent ) {
 		return;
@@ -92,18 +92,18 @@ function mergeBranches( batch, startPos, endPos ) {
 	}
 
 	// Remember next positions to merge. For example:
-	// <a><b>x[]</b></a><c><d>[]y</d></c>
+	// <a><b>x[]</b></a><c><d>{}y</d></c>
 	// will become:
-	// <a><b>xy</b>[]</a><c>[]</c>
+	// <a><b>xy</b>[]</a><c>{}</c>
 	startPos = Position.createAfter( startParent );
 	endPos = Position.createBefore( endParent );
 
 	if ( endParent.childCount > 0 ) {
 		// At the moment, next startPos is also the position to which the endParent
 		// needs to be moved:
-		// <a><b>x[]</b></a><c><d>[]y</d></c>
+		// <a><b>x[]</b></a><c><d>{}y</d></c>
 		// becomes:
-		// <a><b>x</b>[]<d>y</d></a><c>[]</c>
+		// <a><b>x</b>[]<d>y</d></a><c>{}</c>
 
 		// Move the end parent only if needed.
 		// E.g. not in this case: <p>ab</p>[]{}<p>cd</p>
@@ -112,7 +112,7 @@ function mergeBranches( batch, startPos, endPos ) {
 		}
 
 		// To then become:
-		// <a><b>xy</b>[]</a><c>[]</c>
+		// <a><b>xy</b>[]</a><c>{}</c>
 		batch.merge( startPos );
 	} else {
 		batch.remove( endParent );

--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -104,7 +104,12 @@ function mergeBranches( batch, startPos, endPos ) {
 		// <a><b>x[]</b></a><c><d>[]y</d></c>
 		// becomes:
 		// <a><b>x</b>[]<d>y</d></a><c>[]</c>
-		batch.move( endParent, startPos );
+
+		// Move the end parent only if needed.
+		// E.g. not in this case: <p>ab</p>[]{}<p>cd</p>
+		if ( !endPos.isEqual( startPos ) ) {
+			batch.move( endParent, startPos );
+		}
 
 		// To then become:
 		// <a><b>xy</b>[]</a><c>[]</c>

--- a/tests/controller/deletecontent.js
+++ b/tests/controller/deletecontent.js
@@ -255,6 +255,21 @@ describe( 'DataController', () => {
 				expect( spyRemove.called ).to.be.true;
 			} );
 
+			it( 'does not try to move the second block if not needed', () => {
+				setData( doc, '<paragraph>ab[cd</paragraph><paragraph>ef]gh</paragraph>' );
+
+				const batch = doc.batch();
+				const spyMerge = sinon.spy( batch, 'merge' );
+				const spyMove = sinon.spy( batch, 'move' );
+
+				deleteContent( doc.selection, batch, { merge: true } );
+
+				expect( getData( doc ) ).to.equal( '<paragraph>ab[]gh</paragraph>' );
+
+				expect( spyMove.called ).to.be.false;
+				expect( spyMerge.called ).to.be.true;
+			} );
+
 			// Note: in all these cases we ignore the direction of merge.
 			// If https://github.com/ckeditor/ckeditor5-engine/issues/470 was fixed we could differently treat
 			// forward and backward delete.

--- a/tests/controller/deletecontent.js
+++ b/tests/controller/deletecontent.js
@@ -4,6 +4,9 @@
  */
 
 import Document from '../../src/model/document';
+import Position from '../../src/model/position';
+import Range from '../../src/model/range';
+import Element from '../../src/model/element';
 import deleteContent from '../../src/controller/deletecontent';
 import { setData, getData } from '../../src/dev-utils/model';
 
@@ -154,10 +157,16 @@ describe( 'DataController', () => {
 				schema.registerItem( 'paragraph', '$block' );
 				schema.registerItem( 'heading1', '$block' );
 				schema.registerItem( 'pchild' );
+				schema.registerItem( 'pparent' );
 				schema.registerItem( 'image', '$inline' );
 
 				schema.allow( { name: 'pchild', inside: 'paragraph' } );
 				schema.allow( { name: '$text', inside: 'pchild' } );
+
+				schema.allow( { name: 'paragraph', inside: 'pparent' } );
+				schema.allow( { name: 'pparent', inside: '$root' } );
+				schema.allow( { name: '$text', inside: 'pparent' } );
+
 				schema.allow( { name: 'paragraph', attributes: [ 'align' ] } );
 			} );
 
@@ -195,6 +204,9 @@ describe( 'DataController', () => {
 				{ merge: true }
 			);
 
+			// Note: in all these cases we ignore the direction of merge.
+			// If https://github.com/ckeditor/ckeditor5-engine/issues/470 was fixed we could differently treat
+			// forward and backward delete.
 			it( 'merges second element into the first one (different name, backward selection)', () => {
 				setData(
 					doc,
@@ -222,44 +234,6 @@ describe( 'DataController', () => {
 			);
 
 			test(
-				'merges elements when deep nested',
-				'<paragraph>x<pchild>fo[o</pchild></paragraph><paragraph><pchild>b]ar</pchild>y</paragraph>',
-				'<paragraph>x<pchild>fo[]ar</pchild>y</paragraph>',
-				{ merge: true }
-			);
-
-			// For code coverage reasons.
-			test(
-				'merges element when selection is in two consecutive nodes even when it is empty',
-				'<paragraph>foo[</paragraph><paragraph>]bar</paragraph>',
-				'<paragraph>foo[]bar</paragraph>',
-				{ merge: true }
-			);
-
-			// If you disagree with this case please read the notes before this section.
-			test(
-				'merges elements when left end deep nested',
-				'<paragraph>x<pchild>fo[o</pchild></paragraph><paragraph>b]ary</paragraph>',
-				'<paragraph>x<pchild>fo[]</pchild>ary</paragraph>',
-				{ merge: true }
-			);
-
-			// If you disagree with this case please read the notes before this section.
-			test(
-				'merges elements when right end deep nested',
-				'<paragraph>xfo[o</paragraph><paragraph><pchild>b]ar</pchild>y<image></image></paragraph>',
-				'<paragraph>xfo[]<pchild>ar</pchild>y<image></image></paragraph>',
-				{ merge: true }
-			);
-
-			test(
-				'merges elements when more content in the right branch',
-				'<paragraph>xfo[o</paragraph><paragraph>b]a<pchild>r</pchild>y</paragraph>',
-				'<paragraph>xfo[]a<pchild>r</pchild>y</paragraph>',
-				{ merge: true }
-			);
-
-			test(
 				'leaves just one element when all selected',
 				'<heading1>[x</heading1><paragraph>foo</paragraph><paragraph>y]</paragraph>',
 				'<heading1>[]</heading1>',
@@ -281,7 +255,106 @@ describe( 'DataController', () => {
 				expect( spyRemove.called ).to.be.true;
 			} );
 
-			describe( 'object elements', () => {
+			// Note: in all these cases we ignore the direction of merge.
+			// If https://github.com/ckeditor/ckeditor5-engine/issues/470 was fixed we could differently treat
+			// forward and backward delete.
+			describe( 'with nested elements', () => {
+				test(
+					'merges elements when deep nested',
+					'<paragraph>x<pchild>fo[o</pchild></paragraph><paragraph><pchild>b]ar</pchild>y</paragraph>',
+					'<paragraph>x<pchild>fo[]ar</pchild>y</paragraph>',
+					{ merge: true }
+				);
+
+				it( 'merges elements when deep nested (3rd level)', () => {
+					const root = doc.getRoot();
+
+					// We need to use the raw API due to https://github.com/ckeditor/ckeditor5-engine/issues/905.
+					// <pparent>x<paragraph>x<pchild>fo[o</pchild></paragraph></pparent>
+					// <pparent><paragraph><pchild>b]ar</pchild>y</paragraph>y</pparent>
+
+					root.appendChildren(
+						new Element( 'pparent', null, [
+							'x',
+							new Element( 'paragraph', null, [
+								'x',
+								new Element( 'pchild', null, 'foo' )
+							] )
+						] )
+					);
+
+					root.appendChildren(
+						new Element( 'pparent', null, [
+							new Element( 'paragraph', null, [
+								new Element( 'pchild', null, 'bar' ),
+								'y'
+							] ),
+							'y'
+						] )
+					);
+
+					const range = new Range(
+						new Position( doc.getRoot(), [ 0, 1, 1, 2 ] ), // fo[o
+						new Position( doc.getRoot(), [ 1, 0, 0, 1 ] ) // b]ar
+					);
+
+					doc.selection.setRanges( [ range ] );
+
+					deleteContent( doc.selection, doc.batch(), { merge: true } );
+
+					expect( getData( doc ) )
+						.to.equal( '<pparent>x<paragraph>x<pchild>fo[]ar</pchild>y</paragraph>y</pparent>' );
+				} );
+
+				test(
+					'merges elements when left end deep nested',
+					'<paragraph>x<pchild>fo[o</pchild></paragraph><paragraph>b]ary</paragraph><paragraph>x</paragraph>',
+					'<paragraph>x<pchild>fo[]ary</pchild></paragraph><paragraph>x</paragraph>',
+					{ merge: true }
+				);
+
+				test(
+					'merges elements when right end deep nested',
+					'<paragraph>x</paragraph><paragraph>fo[o</paragraph><paragraph><pchild>b]ar</pchild>x</paragraph>',
+					'<paragraph>x</paragraph><paragraph>fo[]ar</paragraph><paragraph>x</paragraph>',
+					{ merge: true }
+				);
+
+				it( 'merges elements when left end deep nested (3rd level)', () => {
+					const root = doc.getRoot();
+
+					// We need to use the raw API due to https://github.com/ckeditor/ckeditor5-engine/issues/905.
+					// <pparent>x<paragraph>foo<pchild>ba[r</pchild></paragraph></pparent><paragraph>b]om</paragraph>
+
+					root.appendChildren(
+						new Element( 'pparent', null, [
+							'x',
+							new Element( 'paragraph', null, [
+								'foo',
+								new Element( 'pchild', null, 'bar' )
+							] )
+						] )
+					);
+
+					root.appendChildren(
+						new Element( 'paragraph', null, 'bom' )
+					);
+
+					const range = new Range(
+						new Position( doc.getRoot(), [ 0, 1, 3, 2 ] ), // ba[r
+						new Position( doc.getRoot(), [ 1, 1 ] ) // b]om
+					);
+
+					doc.selection.setRanges( [ range ] );
+
+					deleteContent( doc.selection, doc.batch(), { merge: true } );
+
+					expect( getData( doc ) )
+						.to.equal( '<pparent>x<paragraph>foo<pchild>ba[]om</pchild></paragraph></pparent>' );
+				} );
+			} );
+
+			describe( 'with object elements', () => {
 				beforeEach( () => {
 					const schema = doc.schema;
 
@@ -512,7 +585,7 @@ describe( 'DataController', () => {
 			);
 
 			test(
-				'should delete inside block limit element',
+				'should delete inside block limit element (with merge)',
 				'<blockLimit><paragraph>fo[o</paragraph><paragraph>b]ar</paragraph></blockLimit>',
 				'<blockLimit><paragraph>fo[]ar</paragraph></blockLimit>',
 				{ merge: true }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Changed the behaviour of `DataController.deleteContent()` in a case of nested elements to better match situations like using <kbd>Backspace</kbd> after a block quotation. Closes #710.

---

### Additional information

Have fun analysing the code :).