### PR TITLE
T/919 ViewConverterBuilder#fromAttribute() sets wrong matcher

### DIFF
--- a/src/conversion/buildviewconverter.js
+++ b/src/conversion/buildviewconverter.js
@@ -141,7 +141,7 @@ class ViewConverterBuilder {
 	 * @param {String|RegExp} [value] View attribute value.
 	 * @returns {module:engine/conversion/buildviewconverter~ViewConverterBuilder}
 	 */
-	fromAttribute( key, value = /.+/ ) {
+	fromAttribute( key, value = /.*/ ) {
 		let pattern = {};
 
 		if ( key === 'style' || key === 'class' ) {

--- a/src/conversion/buildviewconverter.js
+++ b/src/conversion/buildviewconverter.js
@@ -141,9 +141,15 @@ class ViewConverterBuilder {
 	 * @param {String|RegExp} [value] View attribute value.
 	 * @returns {module:engine/conversion/buildviewconverter~ViewConverterBuilder}
 	 */
-	fromAttribute( key, value = /.*/ ) {
+	fromAttribute( key, value = /.+/ ) {
 		let pattern = {};
-		pattern[ key ] = value;
+
+		if ( key === 'style' || key === 'class' ) {
+			pattern[ key ] = value;
+		} else {
+			pattern.attribute = {};
+			pattern.attribute[ key ] = value;
+		}
 
 		return this.from( pattern );
 	}

--- a/src/conversion/buildviewconverter.js
+++ b/src/conversion/buildviewconverter.js
@@ -151,9 +151,14 @@ class ViewConverterBuilder {
 			pattern.attribute[ key ] = value;
 		}
 
-		this.from( pattern );
+		const matcher = new Matcher( pattern );
 
-		this._from[ this._from.length - 1 ].attributeKey = key;
+		this._from.push( {
+			matcher: matcher,
+			consume: false,
+			priority: null,
+			attributeKey: key
+		} );
 
 		return this;
 	}

--- a/src/view/matcher.js
+++ b/src/view/matcher.js
@@ -40,7 +40,7 @@ export default class Matcher {
 	 * Example pattern matching element's attributes:
 	 *
 	 *		matcher.add( {
-	 *			attributes: {
+	 *			attribute: {
 	 *				title: 'foobar',
 	 *				foo: /^\w+/
 	 *			}
@@ -130,7 +130,7 @@ export default class Matcher {
 	 *			pattern: <pattern used to match found element>,
 	 *			match: {
 	 *				name: true,
- 	 *				attributes: [ 'title', 'href' ],
+	 *				attribute: [ 'title', 'href' ],
 	 *				classes: [ 'foo' ],
  	 *				styles: [ 'color', 'position' ]
 	 *			}
@@ -302,7 +302,7 @@ function matchAttributes( patterns, element ) {
 				} else {
 					return null;
 				}
-			} else if ( attribute === pattern  ) {
+			} else if ( attribute === pattern ) {
 				match.push( name );
 			} else {
 				return null;

--- a/src/view/matcher.js
+++ b/src/view/matcher.js
@@ -131,8 +131,8 @@ export default class Matcher {
 	 *			match: {
 	 *				name: true,
 	 *				attribute: [ 'title', 'href' ],
-	 *				classes: [ 'foo' ],
- 	 *				styles: [ 'color', 'position' ]
+	 *				class: [ 'foo' ],
+	 *				style: [ 'color', 'position' ]
 	 *			}
 	 *		}
 	 *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `ViewConverterBuilder#fromAttribute()` was creating incorrect matcher object for `Matcher` if passed attribute was other than `class` or `style`. Closes #919.

Minor upgrades to `ViewConversionBuilder`:
* converters from `ViewConversionBuilder` will not convert if "creator function" returned `null`.
* simplified view converters building by making `ViewConversionBuilder#toAttribute()` `value` param optional. If not set, the attribute value is taken from converted view element.