### PR TITLE
model.Element#clone now does not clone children when passed false and clones children deeply when passed true

### DIFF
--- a/src/model/element.js
+++ b/src/model/element.js
@@ -149,12 +149,11 @@ export default class Element extends Node {
 	}
 
 	/**
-	 * Creates a copy of this element and returns it. Created element has same name and attributes as original element.
-	 * If clone is not deep, children of copied element are references to the same nodes as in original element.
-	 * If clone is deep, original element's children are also cloned.
+	 * Creates a copy of this element and returns it. Created element has the same name and attributes as the original element.
+	 * If clone is deep, the original element's children are also cloned. If not, then empty element is removed.
 	 *
 	 * @param {Boolean} [deep=false] If set to `true` clones element and all its children recursively. When set to `false`,
-	 * element will be cloned without any children.
+	 * element will be cloned without any child.
 	 */
 	clone( deep = false ) {
 		const children = deep ? Array.from( this._children ).map( ( node ) => node.clone( true ) ) : null;

--- a/src/model/element.js
+++ b/src/model/element.js
@@ -153,12 +153,11 @@ export default class Element extends Node {
 	 * If clone is not deep, children of copied element are references to the same nodes as in original element.
 	 * If clone is deep, original element's children are also cloned.
 	 *
-	 * @param {Boolean} [deep=false] Decides whether children of this element should also be cloned (`true`) or not (`false`).
+	 * @param {Boolean} [deep=false] If set to `true` clones element and all its children recursively. When set to `false`,
+	 * element will be cloned without any children.
 	 */
 	clone( deep = false ) {
-		const children = deep ?
-			Array.from( this._children ).map( ( node ) => node.clone() ) :
-			Array.from( this._children );
+		const children = deep ? Array.from( this._children ).map( ( node ) => node.clone( true ) ) : null;
 
 		return new Element( this.name, this.getAttributes(), children );
 	}

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -156,11 +156,11 @@ export default class Element extends Node {
 	/**
 	 * Clones provided element.
 	 *
-	 * @param {Boolean} deep If set to `true` clones element and all its children recursively. When set to `false`,
+	 * @param {Boolean} [deep=false] If set to `true` clones element and all its children recursively. When set to `false`,
 	 * element will be cloned without any children.
 	 * @returns {module:engine/view/element~Element} Clone of this element.
 	 */
-	clone( deep ) {
+	clone( deep = false ) {
 		const childrenClone = [];
 
 		if ( deep ) {

--- a/tests/model/element.js
+++ b/tests/model/element.js
@@ -71,7 +71,7 @@ describe( 'Element', () => {
 
 			expect( copy.name ).to.equal( 'elem' );
 			expect( Array.from( copy.getAttributes() ) ).to.deep.equal( [ [ 'bold', true ], [ 'italic', true ] ] );
-			expect( Array.from( copy.getChildren() ) ).to.deep.equal( [ p, foo ] );
+			expect( Array.from( copy.getChildren() ) ).to.deep.equal( [] );
 		} );
 
 		it( 'should clone children, if clone is deep', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `model.Element#clone` now does not clone children when passed `false` and clones children deeply when passed `true`. Closes #689.

BREAKING CHANGE: `model.Element#clone` does not clone children when no argument or `false` was passed.