### PR TITLE
MarkerDelta transformation should consider ranges equal to null.

### DIFF
--- a/src/model/delta/basic-transformations.js
+++ b/src/model/delta/basic-transformations.js
@@ -103,8 +103,13 @@ function transformMarkerDelta( a, b ) {
 	const transformedDelta = a.clone();
 	const transformedOp = transformedDelta.operations[ 0 ];
 
-	transformedOp.oldRange = transformedOp.oldRange.getTransformedByDelta( b )[ 0 ];
-	transformedOp.newRange = transformedOp.newRange.getTransformedByDelta( b )[ 0 ];
+	if ( transformedOp.oldRange ) {
+		transformedOp.oldRange = transformedOp.oldRange.getTransformedByDelta( b )[ 0 ];
+	}
+
+	if ( transformedOp.newRange ) {
+		transformedOp.newRange = transformedOp.newRange.getTransformedByDelta( b )[ 0 ];
+	}
 
 	return [ transformedDelta ];
 }

--- a/tests/model/delta/transform/markerdelta.js
+++ b/tests/model/delta/transform/markerdelta.js
@@ -233,7 +233,7 @@ describe( 'transform', () => {
 		} );
 	} );
 
-	it( 'transforming MarkerDelta with null ranges should not crash', () => {
+	it( 'null ranges of MarkerDelta should not be changed during transformation', () => {
 		const markerDelta = getMarkerDelta( 'name', null, null, baseVersion );
 
 		// Transform `markerDelta` by any other delta that has a special transformation case with `MarkerDelta`.
@@ -241,8 +241,16 @@ describe( 'transform', () => {
 		const wrapRange = new Range( new Position( root, [ 1 ] ), new Position( root, [ 2 ] ) );
 		const wrapDelta = getWrapDelta( wrapRange, wrapElement, baseVersion );
 
-		expect( () => {
-			transform( markerDelta, wrapDelta );
-		} ).not.to.throw();
+		const transformed = transform( markerDelta, wrapDelta );
+
+		expect( transformed.length ).to.equal( 1 );
+		expect( transformed[ 0 ].operations.length ).to.equal( 1 );
+
+		const transformedOp = transformed[ 0 ].operations[ 0 ];
+
+		expect( transformedOp ).to.be.instanceof( MarkerOperation );
+		expect( transformedOp.oldRange ).to.be.null;
+		expect( transformedOp.newRange ).to.be.null;
+		expect( transformedOp.name ).to.equal( 'name' );
 	} );
 } );

--- a/tests/model/delta/transform/markerdelta.js
+++ b/tests/model/delta/transform/markerdelta.js
@@ -232,4 +232,17 @@ describe( 'transform', () => {
 			} );
 		} );
 	} );
+
+	it( 'transforming MarkerDelta with null ranges should not crash', () => {
+		const markerDelta = getMarkerDelta( 'name', null, null, baseVersion );
+
+		// Transform `markerDelta` by any other delta that has a special transformation case with `MarkerDelta`.
+		const wrapElement = new Element( 'w' );
+		const wrapRange = new Range( new Position( root, [ 1 ] ), new Position( root, [ 2 ] ) );
+		const wrapDelta = getWrapDelta( wrapRange, wrapElement, baseVersion );
+
+		expect( () => {
+			transform( markerDelta, wrapDelta );
+		} ).not.to.throw();
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `MarkerDelta` transformation should no longer cause editor to crash, if a `MarkerOperation` had `null` as it's `oldRange` or `newRange`. Closes #943.