### PR TITLE
t/951: DomConverter should actively prevent unwanted scrolling on focus

### DIFF
--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -19,8 +19,6 @@ import ViewTreeWalker from './treewalker';
 import { BR_FILLER, INLINE_FILLER_LENGTH, isBlockFiller, isInlineFiller, startsWithFiller, getDataWithoutFiller } from './filler';
 
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
-import env from '@ckeditor/ckeditor5-utils/src/env';
-
 import indexOf from '@ckeditor/ckeditor5-utils/src/dom/indexof';
 import getAncestors from '@ckeditor/ckeditor5-utils/src/dom/getancestors';
 import getCommonAncestor from '@ckeditor/ckeditor5-utils/src/dom/getcommonancestor';
@@ -743,12 +741,9 @@ export default class DomConverter {
 			domEditable.focus();
 
 			// https://github.com/ckeditor/ckeditor5-engine/issues/951
-			if ( env.webkit ) {
-				domEditable.scrollLeft = scrollLeft;
-				domEditable.scrollTop = scrollTop;
-
-				global.window.scrollTo( scrollX, scrollY );
-			}
+			domEditable.scrollLeft = scrollLeft;
+			domEditable.scrollTop = scrollTop;
+			global.window.scrollTo( scrollX, scrollY );
 		}
 	}
 

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -738,11 +738,15 @@ export default class DomConverter {
 
 		if ( domEditable && domEditable.ownerDocument.activeElement !== domEditable ) {
 			const { scrollX, scrollY } = global.window;
+			const { scrollLeft, scrollTop } = domEditable;
 
 			domEditable.focus();
 
 			// https://github.com/ckeditor/ckeditor5-engine/issues/951
 			if ( env.webkit ) {
+				domEditable.scrollLeft = scrollLeft;
+				domEditable.scrollTop = scrollTop;
+
 				global.window.scrollTo( scrollX, scrollY );
 			}
 		}

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -18,6 +18,9 @@ import ViewDocumentFragment from './documentfragment';
 import ViewTreeWalker from './treewalker';
 import { BR_FILLER, INLINE_FILLER_LENGTH, isBlockFiller, isInlineFiller, startsWithFiller, getDataWithoutFiller } from './filler';
 
+import global from '@ckeditor/ckeditor5-utils/src/dom/global';
+import env from '@ckeditor/ckeditor5-utils/src/env';
+
 import indexOf from '@ckeditor/ckeditor5-utils/src/dom/indexof';
 import getAncestors from '@ckeditor/ckeditor5-utils/src/dom/getancestors';
 import getCommonAncestor from '@ckeditor/ckeditor5-utils/src/dom/getcommonancestor';
@@ -734,7 +737,14 @@ export default class DomConverter {
 		const domEditable = this.getCorrespondingDomElement( viewEditable );
 
 		if ( domEditable && domEditable.ownerDocument.activeElement !== domEditable ) {
+			const { scrollX, scrollY } = global.window;
+
 			domEditable.focus();
+
+			// https://github.com/ckeditor/ckeditor5-engine/issues/951
+			if ( env.webkit ) {
+				global.window.scrollTo( scrollX, scrollY );
+			}
 		}
 	}
 

--- a/tests/view/domconverter/domconverter.js
+++ b/tests/view/domconverter/domconverter.js
@@ -72,8 +72,21 @@ describe( 'DomConverter', () => {
 
 		// https://github.com/ckeditor/ckeditor5-engine/issues/951
 		it( 'should actively prevent window scroll in WebKit', () => {
-			const spy = testUtils.sinon.stub( global.window, 'scrollTo' );
+			const scrollToSpy = testUtils.sinon.stub( global.window, 'scrollTo' );
 			const initialEnvWebkit = env.webkit;
+			const scrollLeftSpy = sinon.spy();
+			const scrollTopSpy = sinon.spy();
+
+			Object.defineProperties( domEditable, {
+				scrollLeft: {
+					get: () => 20,
+					set: scrollLeftSpy
+				},
+				scrollTop: {
+					get: () => 200,
+					set: scrollTopSpy
+				}
+			} );
 
 			env.webkit = true;
 
@@ -81,12 +94,14 @@ describe( 'DomConverter', () => {
 			global.window.scrollY = 100;
 
 			converter.focus( viewEditable );
-			sinon.assert.calledWithExactly( spy, 10, 100 );
+			sinon.assert.calledWithExactly( scrollToSpy, 10, 100 );
+			sinon.assert.calledWithExactly( scrollLeftSpy, 20 );
+			sinon.assert.calledWithExactly( scrollTopSpy, 200 );
 
 			env.webkit = false;
 
 			converter.focus( viewEditable );
-			sinon.assert.calledOnce( spy );
+			sinon.assert.calledOnce( scrollToSpy );
 
 			env.webkit = initialEnvWebkit;
 		} );

--- a/tests/view/domconverter/domconverter.js
+++ b/tests/view/domconverter/domconverter.js
@@ -11,6 +11,9 @@ import ViewDocument from '../../../src/view/document';
 import { BR_FILLER, NBSP_FILLER } from '../../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
+import global from '@ckeditor/ckeditor5-utils/src/dom/global';
+import env from '@ckeditor/ckeditor5-utils/src/env';
+
 testUtils.createSinonSandbox();
 
 describe( 'DomConverter', () => {
@@ -65,6 +68,27 @@ describe( 'DomConverter', () => {
 			converter.focus( viewEditable );
 
 			expect( focusSpy.calledOnce ).to.be.true;
+		} );
+
+		// https://github.com/ckeditor/ckeditor5-engine/issues/951
+		it( 'should actively prevent window scroll in WebKit', () => {
+			const spy = testUtils.sinon.stub( global.window, 'scrollTo' );
+			const initialEnvWebkit = env.webkit;
+
+			env.webkit = true;
+
+			global.window.scrollX = 10;
+			global.window.scrollY = 100;
+
+			converter.focus( viewEditable );
+			sinon.assert.calledWithExactly( spy, 10, 100 );
+
+			env.webkit = false;
+
+			converter.focus( viewEditable );
+			sinon.assert.calledOnce( spy );
+
+			env.webkit = initialEnvWebkit;
 		} );
 	} );
 

--- a/tests/view/domconverter/domconverter.js
+++ b/tests/view/domconverter/domconverter.js
@@ -10,9 +10,7 @@ import ViewEditable from '../../../src/view/editableelement';
 import ViewDocument from '../../../src/view/document';
 import { BR_FILLER, NBSP_FILLER } from '../../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
-
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
-import env from '@ckeditor/ckeditor5-utils/src/env';
 
 testUtils.createSinonSandbox();
 
@@ -73,7 +71,6 @@ describe( 'DomConverter', () => {
 		// https://github.com/ckeditor/ckeditor5-engine/issues/951
 		it( 'should actively prevent window scroll in WebKit', () => {
 			const scrollToSpy = testUtils.sinon.stub( global.window, 'scrollTo' );
-			const initialEnvWebkit = env.webkit;
 			const scrollLeftSpy = sinon.spy();
 			const scrollTopSpy = sinon.spy();
 
@@ -88,8 +85,6 @@ describe( 'DomConverter', () => {
 				}
 			} );
 
-			env.webkit = true;
-
 			global.window.scrollX = 10;
 			global.window.scrollY = 100;
 
@@ -97,13 +92,6 @@ describe( 'DomConverter', () => {
 			sinon.assert.calledWithExactly( scrollToSpy, 10, 100 );
 			sinon.assert.calledWithExactly( scrollLeftSpy, 20 );
 			sinon.assert.calledWithExactly( scrollTopSpy, 200 );
-
-			env.webkit = false;
-
-			converter.focus( viewEditable );
-			sinon.assert.calledOnce( scrollToSpy );
-
-			env.webkit = initialEnvWebkit;
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `DomConverter` should actively prevent unwanted scrolling on focus. Closes #951. Closes #707.

---

### Additional information

~~Requires https://github.com/ckeditor/ckeditor5-utils/pull/156.~~
