### PR TITLE
T/969: Added schema helpers

### DIFF
--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -13,7 +13,6 @@ import clone from '@ckeditor/ckeditor5-utils/src/lib/lodash/clone';
 import isArray from '@ckeditor/ckeditor5-utils/src/lib/lodash/isArray';
 import isString from '@ckeditor/ckeditor5-utils/src/lib/lodash/isString';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
-import TreeWalker from '@ckeditor/ckeditor5-engine/src/model/treewalker';
 
 /**
  * Schema is a definition of the structure of the document. It allows to define which tree model items (element, text, etc.)
@@ -326,22 +325,14 @@ export default class Schema {
 
 			// For all ranges, check nodes in them until you find a node that is allowed to have the attribute.
 			for ( const range of ranges ) {
-				const walker = new TreeWalker( { boundaries: range, mergeCharacters: true } );
-				let last = walker.position;
-				let step = walker.next();
-
-				// Walk the range.
-				while ( !step.done ) {
+				for ( const value of range ) {
 					// If returned item does not have name property, it is a TextFragment.
-					const name = step.value.item.name || '$text';
+					const name = value.item.name || '$text';
 
-					if ( this.check( { name, inside: last, attributes: attribute } ) ) {
+					if ( this.check( { name, inside: value.previousPosition, attributes: attribute } ) ) {
 						// If we found a node that is allowed to have the attribute, return true.
 						return true;
 					}
-
-					last = walker.position;
-					step = walker.next();
 				}
 			}
 		}

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -13,7 +13,6 @@ import clone from '@ckeditor/ckeditor5-utils/src/lib/lodash/clone';
 import isArray from '@ckeditor/ckeditor5-utils/src/lib/lodash/isArray';
 import isString from '@ckeditor/ckeditor5-utils/src/lib/lodash/isString';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
-import TreeWalker from './treewalker';
 import Range from './range';
 
 /**
@@ -354,27 +353,23 @@ export default class Schema {
 		const validRanges = [];
 
 		for ( const range of ranges ) {
-			const walker = new TreeWalker( { boundaries: range, mergeCharacters: true } );
-			let step = walker.next();
-
 			let last = range.start;
 			let from = range.start;
 			const to = range.end;
 
-			while ( !step.done ) {
-				const name = step.value.item.name || '$text';
-				const itemPosition = Position.createBefore( step.value.item );
+			for ( const value of range.getWalker() ) {
+				const name = value.item.name || '$text';
+				const itemPosition = Position.createBefore( value.item );
 
 				if ( !this.check( { name, inside: itemPosition, attributes: attribute } ) ) {
 					if ( !from.isEqual( last ) ) {
 						validRanges.push( new Range( from, last ) );
 					}
 
-					from = walker.position;
+					from = value.nextPosition;
 				}
 
-				last = walker.position;
-				step = walker.next();
+				last = value.nextPosition;
 			}
 
 			if ( from && !from.isEqual( to ) ) {

--- a/tests/model/schema/schema.js
+++ b/tests/model/schema/schema.js
@@ -9,6 +9,7 @@ import Element from '../../../src/model/element';
 import Position from '../../../src/model/position';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+import { setData } from '../../../src/dev-utils/model';
 
 testUtils.createSinonSandbox();
 
@@ -61,7 +62,7 @@ describe( 'Schema', () => {
 		} );
 	} );
 
-	describe( 'registerItem', () => {
+	describe( 'registerItem()', () => {
 		it( 'should register in schema item under given name', () => {
 			schema.registerItem( 'new' );
 
@@ -101,7 +102,7 @@ describe( 'Schema', () => {
 		} );
 	} );
 
-	describe( 'hasItem', () => {
+	describe( 'hasItem()', () => {
 		it( 'should return true if given item name has been registered in schema', () => {
 			expect( schema.hasItem( '$block' ) ).to.be.true;
 		} );
@@ -111,7 +112,7 @@ describe( 'Schema', () => {
 		} );
 	} );
 
-	describe( '_getItem', () => {
+	describe( '_getItem()', () => {
 		it( 'should return SchemaItem registered under given name', () => {
 			schema.registerItem( 'new' );
 
@@ -127,7 +128,7 @@ describe( 'Schema', () => {
 		} );
 	} );
 
-	describe( 'allow', () => {
+	describe( 'allow()', () => {
 		it( 'should add passed query to allowed in schema', () => {
 			schema.registerItem( 'p', '$block' );
 			schema.registerItem( 'div', '$block' );
@@ -140,7 +141,7 @@ describe( 'Schema', () => {
 		} );
 	} );
 
-	describe( 'disallow', () => {
+	describe( 'disallow()', () => {
 		it( 'should add passed query to disallowed in schema', () => {
 			schema.registerItem( 'p', '$block' );
 			schema.registerItem( 'div', '$block' );
@@ -155,7 +156,7 @@ describe( 'Schema', () => {
 		} );
 	} );
 
-	describe( 'check', () => {
+	describe( 'check()', () => {
 		describe( 'string or array of strings as inside', () => {
 			it( 'should return false if given element is not registered in schema', () => {
 				expect( schema.check( { name: 'new', inside: [ 'div', 'header' ] } ) ).to.be.false;
@@ -409,7 +410,7 @@ describe( 'Schema', () => {
 		} );
 	} );
 
-	describe( 'itemExtends', () => {
+	describe( 'itemExtends()', () => {
 		it( 'should return true if given item extends another given item', () => {
 			schema.registerItem( 'div', '$block' );
 			schema.registerItem( 'myDiv', 'div' );
@@ -438,7 +439,7 @@ describe( 'Schema', () => {
 		} );
 	} );
 
-	describe( '_normalizeQueryPath', () => {
+	describe( '_normalizeQueryPath()', () => {
 		it( 'should normalize string with spaces to an array of strings', () => {
 			expect( Schema._normalizeQueryPath( '$root div strong' ) ).to.deep.equal( [ '$root', 'div', 'strong' ] );
 		} );
@@ -469,6 +470,74 @@ describe( 'Schema', () => {
 			];
 
 			expect( Schema._normalizeQueryPath( input ) ).to.deep.equal( [ '$root', 'div', 'p', 'strong' ] );
+		} );
+	} );
+
+	describe( 'checkAttributeInSelection()', () => {
+		const attribute = 'bold';
+		let doc, schema;
+
+		beforeEach( () => {
+			doc = new Document();
+			doc.createRoot();
+
+			schema = doc.schema;
+
+			schema.registerItem( 'p', '$block' );
+			schema.registerItem( 'h1', '$block' );
+			schema.registerItem( 'img', '$inline' );
+
+			// Bold text is allowed only in P.
+			schema.allow( { name: '$text', attributes: 'bold', inside: 'p' } );
+			schema.allow( { name: 'p', attributes: 'bold', inside: '$root' } );
+
+			// Disallow bold on image.
+			schema.disallow( { name: 'img', attributes: 'bold', inside: '$root' } );
+		} );
+
+		describe( 'when selection is collapsed', () => {
+			it( 'should return true if characters with the attribute can be placed at caret position', () => {
+				setData( doc, '<p>f[]oo</p>' );
+				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.true;
+			} );
+
+			it( 'should return false if characters with the attribute cannot be placed at caret position', () => {
+				setData( doc, '<h1>[]</h1>' );
+				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.false;
+
+				setData( doc, '[]' );
+				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.false;
+			} );
+		} );
+
+		describe( 'when selection is not collapsed', () => {
+			it( 'should return true if there is at least one node in selection that can have the attribute', () => {
+				// Simple selection on a few characters.
+				setData( doc, '<p>[foo]</p>' );
+				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.true;
+
+				// Selection spans over characters but also include nodes that can't have attribute.
+				setData( doc, '<p>fo[o<img />b]ar</p>' );
+				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.true;
+
+				// Selection on whole root content. Characters in P can have an attribute so it's valid.
+				setData( doc, '[<p>foo<img />bar</p><h1></h1>]' );
+				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.true;
+
+				// Selection on empty P. P can have the attribute.
+				setData( doc, '[<p></p>]' );
+				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.true;
+			} );
+
+			it( 'should return false if there are no nodes in selection that can have the attribute', () => {
+				// Selection on DIV which can't have bold text.
+				setData( doc, '[<h1></h1>]' );
+				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.false;
+
+				// Selection on two images which can't be bold.
+				setData( doc, '<p>foo[<img /><img />]bar</p>' );
+				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.false;
+			} );
 		} );
 	} );
 } );

--- a/tests/model/schema/schema.js
+++ b/tests/model/schema/schema.js
@@ -7,9 +7,11 @@ import { default as Schema, SchemaItem } from '../../../src/model/schema';
 import Document from '../../../src/model/document';
 import Element from '../../../src/model/element';
 import Position from '../../../src/model/position';
+import Range from '../../../src/model/range';
+import Selection from '../../../src/model/selection';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
-import { setData } from '../../../src/dev-utils/model';
+import { setData, stringify } from '../../../src/dev-utils/model';
 
 testUtils.createSinonSandbox();
 
@@ -538,6 +540,79 @@ describe( 'Schema', () => {
 				setData( doc, '<p>foo[<img /><img />]bar</p>' );
 				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.false;
 			} );
+		} );
+	} );
+
+	describe( 'getValidRanges()', () => {
+		const attribute = 'bold';
+		let document, root, schema, ranges;
+
+		beforeEach( () => {
+			document = new Document();
+			schema = document.schema;
+			root = document.createRoot();
+
+			schema.registerItem( 'p', '$block' );
+			schema.registerItem( 'h1', '$block' );
+			schema.registerItem( 'img', '$inline' );
+
+			schema.allow( { name: '$text', attributes: 'bold', inside: 'p' } );
+			schema.allow( { name: 'p', attributes: 'bold', inside: '$root' } );
+
+			setData( document, '<p>foo<img />bar</p>' );
+			ranges = [ Range.createOn( root.getChild( 0 ) ) ];
+		} );
+
+		it( 'should return unmodified ranges when attribute is allowed on each item (text is not allowed in img)', () => {
+			schema.allow( { name: 'img', attributes: 'bold', inside: 'p' } );
+
+			expect( schema.getValidRanges( ranges, attribute ) ).to.deep.equal( ranges );
+		} );
+
+		it( 'should return unmodified ranges when attribute is allowed on each item (text is allowed in img)', () => {
+			schema.allow( { name: 'img', attributes: 'bold', inside: 'p' } );
+			schema.allow( { name: '$text', inside: 'img' } );
+
+			expect( schema.getValidRanges( ranges, attribute ) ).to.deep.equal( ranges );
+		} );
+
+		it( 'should return two ranges when attribute is not allowed on one item', () => {
+			schema.allow( { name: 'img', attributes: 'bold', inside: 'p' } );
+			schema.allow( { name: '$text', inside: 'img' } );
+
+			setData( document, '<p>foo<img>xxx</img>bar</p>' );
+
+			const validRanges = schema.getValidRanges( ranges, attribute );
+			const sel = new Selection();
+			sel.setRanges( validRanges );
+
+			expect( stringify( root, sel ) ).to.equal( '[<p>foo<img>]xxx[</img>bar</p>]' );
+		} );
+
+		it( 'should return three ranges when attribute is not allowed on one element but is allowed on its child', () => {
+			schema.allow( { name: '$text', inside: 'img' } );
+			schema.allow( { name: '$text', attributes: 'bold', inside: 'img' } );
+
+			setData( document, '<p>foo<img>xxx</img>bar</p>' );
+
+			const validRanges = schema.getValidRanges( ranges, attribute );
+			const sel = new Selection();
+			sel.setRanges( validRanges );
+
+			expect( stringify( root, sel ) ).to.equal( '[<p>foo]<img>[xxx]</img>[bar</p>]' );
+		} );
+
+		it( 'should split range into two ranges and omit disallowed element', () => {
+			// Disallow bold on img.
+			document.schema.disallow( { name: 'img', attributes: 'bold', inside: 'p' } );
+
+			const result = schema.getValidRanges( ranges, attribute );
+
+			expect( result ).to.length( 2 );
+			expect( result[ 0 ].start.path ).to.members( [ 0 ] );
+			expect( result[ 0 ].end.path ).to.members( [ 0, 3 ] );
+			expect( result[ 1 ].start.path ).to.members( [ 0, 4 ] );
+			expect( result[ 1 ].end.path ).to.members( [ 1 ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced two `Schema` helpers – `#checkAttributeInSelection()` and `#getValidRanges()`. Closes #969.

---

### Additional information

I ported those methods as they were defined in ckeditor5-core, without much of rethinking because the schema will be soon rewritten anyway.