### PR TITLE
T/986: Toggle attribute command is on when selecting an object with bolded text in a nested editable

### DIFF
--- a/src/model/liveselection.js
+++ b/src/model/liveselection.js
@@ -7,7 +7,6 @@
  * @module engine/model/liveselection
  */
 
-import Element from './element';
 import Position from './position';
 import Range from './range';
 import LiveRange from './liverange';
@@ -568,7 +567,7 @@ export default class LiveSelection extends Selection {
 			// ...look for a first character node in that range and take attributes from it.
 			for ( const item of range ) {
 				// If the item is an object, we don't want to get attributes from its children.
-				if ( item.item instanceof Element && schema.objects.has( item.item.name ) ) {
+				if ( item.item.is( 'element' ) && schema.objects.has( item.item.name ) ) {
 					break;
 				}
 

--- a/src/model/liveselection.js
+++ b/src/model/liveselection.js
@@ -7,6 +7,7 @@
  * @module engine/model/liveselection
  */
 
+import Element from './element';
 import Position from './position';
 import Range from './range';
 import LiveRange from './liverange';
@@ -556,6 +557,7 @@ export default class LiveSelection extends Selection {
 	 */
 	_getSurroundingAttributes() {
 		const position = this.getFirstPosition();
+		const schema = this._document.schema;
 
 		let attrs = null;
 
@@ -565,6 +567,11 @@ export default class LiveSelection extends Selection {
 
 			// ...look for a first character node in that range and take attributes from it.
 			for ( const item of range ) {
+				// If the item is an object, we don't want to get attributes from its children.
+				if ( item.item instanceof Element && schema.objects.has( item.item.name ) ) {
+					break;
+				}
+
 				// This is not an optimal solution because of https://github.com/ckeditor/ckeditor5-engine/issues/454.
 				// It can be done better by using `break;` instead of checking `attrs === null`.
 				if ( item.type == 'text' && attrs === null ) {

--- a/src/model/liveselection.js
+++ b/src/model/liveselection.js
@@ -565,16 +565,16 @@ export default class LiveSelection extends Selection {
 			const range = this.getFirstRange();
 
 			// ...look for a first character node in that range and take attributes from it.
-			for ( const item of range ) {
+			for ( const value of range ) {
 				// If the item is an object, we don't want to get attributes from its children.
-				if ( item.item.is( 'element' ) && schema.objects.has( item.item.name ) ) {
+				if ( value.item.is( 'element' ) && schema.objects.has( value.item.name ) ) {
 					break;
 				}
 
 				// This is not an optimal solution because of https://github.com/ckeditor/ckeditor5-engine/issues/454.
 				// It can be done better by using `break;` instead of checking `attrs === null`.
-				if ( item.type == 'text' && attrs === null ) {
-					attrs = item.item.getAttributes();
+				if ( value.type == 'text' && attrs === null ) {
+					attrs = value.item.getAttributes();
 				}
 			}
 		} else {

--- a/tests/model/liveselection.js
+++ b/tests/model/liveselection.js
@@ -885,24 +885,30 @@ describe( 'LiveSelection', () => {
 			doc.schema.allow( { name: '$text', attributes: 'bold', inside: 'caption' } );
 
 			root.removeChildren( 0, root.childCount );
-
-			root.insertChildren( 0, [
-				new Element( 'p', null, [
-					new Element( 'image', [], [
-						new Element( 'caption', [], [
-							new Text( 'Caption for the image.', { bold: true } )
-						] )
-					] )
-				] )
-			] );
-
-			selection.addRange( new Range( new Position( root, [ 0 ] ), new Position( root, [ 1 ] ) ) );
 		} );
 
 		it( 'ignores attributes from nested editable if selection contains an object', () => {
+			setData( doc, '<p>[<image><caption>Caption for the image.</caption></image>]</p>' );
+
 			const liveSelection = LiveSelection.createFromSelection( selection );
 
 			expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
+		} );
+
+		it( 'read attributes from text even if the selection contains an object', () => {
+			setData( doc, '<p>x[<$text bold="true">bar</$text><image></image>foo]</p>' );
+
+			const liveSelection = LiveSelection.createFromSelection( selection );
+
+			expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( true );
+		} );
+
+		it( 'read attributes from editable if selection contains elements inside the object', () => {
+			setData( doc, '<p><image>[<caption><$text bold="true">bar</$text></caption>]</image></p>' );
+
+			const liveSelection = LiveSelection.createFromSelection( selection );
+
+			expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( true );
 		} );
 	} );
 } );

--- a/tests/model/liveselection.js
+++ b/tests/model/liveselection.js
@@ -883,8 +883,6 @@ describe( 'LiveSelection', () => {
 			doc.schema.allow( { name: '$inline', inside: 'caption' } );
 			doc.schema.allow( { name: 'caption', inside: 'image' } );
 			doc.schema.allow( { name: '$text', attributes: 'bold', inside: 'caption' } );
-
-			root.removeChildren( 0, root.childCount );
 		} );
 
 		it( 'ignores attributes from nested editable if selection contains an object', () => {

--- a/tests/model/liveselection.js
+++ b/tests/model/liveselection.js
@@ -872,4 +872,37 @@ describe( 'LiveSelection', () => {
 			expect( values ).to.deep.equal( [] );
 		} );
 	} );
+
+	describe( '_updateAttributes()', () => {
+		beforeEach( () => {
+			doc.schema.registerItem( 'image', '$inline' );
+			doc.schema.disallow( { name: 'image', attributes: 'bold', inside: '$root' } );
+			doc.schema.objects.add( 'image' );
+
+			doc.schema.registerItem( 'caption', '$block' );
+			doc.schema.allow( { name: '$inline', inside: 'caption' } );
+			doc.schema.allow( { name: 'caption', inside: 'image' } );
+			doc.schema.allow( { name: '$text', attributes: 'bold', inside: 'caption' } );
+
+			root.removeChildren( 0, root.childCount );
+
+			root.insertChildren( 0, [
+				new Element( 'p', null, [
+					new Element( 'image', [], [
+						new Element( 'caption', [], [
+							new Text( 'Caption for the image.', { bold: true } )
+						] )
+					] )
+				] )
+			] );
+
+			selection.addRange( new Range( new Position( root, [ 0 ] ), new Position( root, [ 1 ] ) ) );
+		} );
+
+		it( 'ignores attributes from nested editable if selection contains an object', () => {
+			const liveSelection = LiveSelection.createFromSelection( selection );
+
+			expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `LiveSelection` will not read attributes from object element and its children. Closes #986.
