### PR TITLE
T/992 Fixes in selection rendering

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -625,7 +625,7 @@ export default class Renderer {
 
 		for ( const markedElement of this.markedChildren ) {
 			for ( const selectionRange of selectionRanges ) {
-				if ( selectionRange.getIntersection( ViewRange.createOn( markedElement ) ) ) {
+				if ( selectionRange.getIntersection( ViewRange.createIn( markedElement ) ) ) {
 					return true;
 				}
 			}

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -583,12 +583,13 @@ export default class Renderer {
 	 */
 	_updateDomSelection( domRoot ) {
 		const domSelection = domRoot.ownerDocument.defaultView.getSelection();
-		const oldViewSelection = domSelection && this.domConverter.domSelectionToView( domSelection );
 
 		// Check selection is the same if children are not changed.
 		// When children are changed, renderer operations might change DOM selection and we need to re-render it
-		// even if view selection is not changed.
+		// even if view selection is the same.
 		if ( !this._areChildrenChangedInSelection() ) {
+			const oldViewSelection = domSelection && this.domConverter.domSelectionToView( domSelection );
+
 			if ( oldViewSelection && this.selection.isEqual( oldViewSelection ) ) {
 				return;
 			}
@@ -620,6 +621,13 @@ export default class Renderer {
 		domSelection.extend( focus.parent, focus.offset );
 	}
 
+	/**
+	 * Checks if any child nodes {@link #markedChildren marked as changed} are inside current
+	 * {@link module:engine/view/selection~Selection view selection}.
+	 *
+	 * @private
+	 * @returns {Boolean}
+	 */
 	_areChildrenChangedInSelection() {
 		const selectionRanges = this.selection.getRanges();
 

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -500,6 +500,7 @@ export function move( sourceRange, targetPosition ) {
  * @function module:engine/view/writer~writer.wrap
  * @param {module:engine/view/range~Range} range Range to wrap.
  * @param {module:engine/view/attributeelement~AttributeElement} attribute Attribute element to use as wrapper.
+ * @returns {module:engine/view/range~Range} New range after wrapping.
  */
 export function wrap( range, attribute ) {
 	if ( !( attribute instanceof AttributeElement ) ) {
@@ -627,6 +628,7 @@ export function wrapPosition( position, attribute ) {
  *
  * @param {module:engine/view/range~Range} range
  * @param {module:engine/view/attributeelement~AttributeElement} element
+ * @returns {module:engine/view/range~Range} New range after unwrapping.
  */
 export function unwrap( range, attribute ) {
 	if ( !( attribute instanceof AttributeElement ) ) {

--- a/tests/manual/markers.js
+++ b/tests/manual/markers.js
@@ -40,12 +40,29 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 			return new ViewAttributeElement( 'span', { class: 'h-' + color } );
 		} );
 
-	window.document.getElementById( 'add-yellow' ).addEventListener( 'click', () => addHighlight( 'yellow' ) );
-	window.document.getElementById( 'add-red' ).addEventListener( 'click', () => addHighlight( 'red' ) );
-	window.document.getElementById( 'remove-marker' ).addEventListener( 'click', () => removeHighlight() );
-	window.document.getElementById( 'move-to-start' ).addEventListener( 'click', () => moveSelectionToStart() );
-	window.document.getElementById( 'move-left' ).addEventListener( 'click', () => moveSelectionByOffset( -1 ) );
-	window.document.getElementById( 'move-right' ).addEventListener( 'click', () => moveSelectionByOffset( 1 ) );
+	const addYellowButton = window.document.getElementById( 'add-yellow' );
+	addYellowButton.addEventListener( 'click', () => addHighlight( 'yellow' ) );
+	addYellowButton.addEventListener( 'mousedown', e => e.preventDefault() );
+
+	const addRedButton = window.document.getElementById( 'add-red' );
+	addRedButton.addEventListener( 'click', () => addHighlight( 'red' ) );
+	addRedButton.addEventListener( 'mousedown', e => e.preventDefault() );
+
+	const removeMarkerButton = window.document.getElementById( 'remove-marker' );
+	removeMarkerButton.addEventListener( 'click', () => removeHighlight() );
+	removeMarkerButton.addEventListener( 'mousedown', e => e.preventDefault() );
+
+	const moveToStartButton = window.document.getElementById( 'move-to-start' );
+	moveToStartButton.addEventListener( 'click', () => moveSelectionToStart() );
+	moveToStartButton.addEventListener( 'mousedown', e => e.preventDefault() );
+
+	const moveLeftButton = window.document.getElementById( 'move-left' );
+	moveLeftButton.addEventListener( 'click', () => moveSelectionByOffset( -1 ) );
+	moveLeftButton.addEventListener( 'mousedown', e => e.preventDefault() );
+
+	const moveRightButton = window.document.getElementById( 'move-right' );
+	moveRightButton.addEventListener( 'click', () => moveSelectionByOffset( 1 ) );
+	moveRightButton.addEventListener( 'mousedown', e => e.preventDefault() );
 
 	model.enqueueChanges( () => {
 		const root = model.getRoot();

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1596,7 +1596,6 @@ describe( 'Renderer', () => {
 					new ViewRange( new ViewPosition( viewP.getChild( 0 ), 3 ), new ViewPosition( viewB.getChild( 0 ), 2 ) )
 				] );
 
-				renderer.markToSync( 'children', viewP );
 				renderer.render();
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
@@ -1635,7 +1634,6 @@ describe( 'Renderer', () => {
 					new ViewRange( new ViewPosition( viewB.getChild( 0 ), 1 ), new ViewPosition( viewP.getChild( 2 ), 0 ) )
 				] );
 
-				renderer.markToSync( 'children', viewP );
 				renderer.render();
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
@@ -1674,7 +1672,6 @@ describe( 'Renderer', () => {
 					new ViewRange( new ViewPosition( viewP.getChild( 0 ), 3 ), new ViewPosition( viewI.getChild( 0 ), 2 ) )
 				] );
 
-				renderer.markToSync( 'children', viewP );
 				renderer.render();
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
@@ -1712,7 +1709,6 @@ describe( 'Renderer', () => {
 					new ViewRange( new ViewPosition( viewP.getChild( 0 ), 1 ), new ViewPosition( viewP.getChild( 2 ), 0 ) )
 				] );
 
-				renderer.markToSync( 'children', viewP );
 				renderer.render();
 
 				expect( selectionCollapseSpy.notCalled ).to.true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: DOM selection is updated when child elements inside that selection are changed. Closes #992. Closes #701.

