### PR TITLE
Added: Better logging for `InsertDelta` and `InsertOperation`.

### DIFF
--- a/src/dev-utils/enableenginedebug.js
+++ b/src/dev-utils/enableenginedebug.js
@@ -274,8 +274,9 @@ function enableLoggingTools() {
 	};
 
 	InsertOperation.prototype.toString = function() {
-		return getClassName( this ) + `( ${ this.baseVersion } ): ` +
-			`[ ${ this.nodes.length } ] -> ${ this.position }`;
+		const nodeString = this.nodes.length > 1 ? `[ ${ this.nodes.length } ]` : this.nodes.getNode( 0 );
+
+		return getClassName( this ) + `( ${ this.baseVersion } ): ${ nodeString } -> ${ this.position }`;
 	};
 
 	MarkerOperation.prototype.toString = function() {
@@ -367,9 +368,9 @@ function enableLoggingTools() {
 
 	InsertDelta.prototype.toString = function() {
 		const op = this._insertOperation;
+		const nodeString = op.nodes.length > 1 ? `[ ${ op.nodes.length } ]` : op.nodes.getNode( 0 );
 
-		return getClassName( this ) + `( ${ this.baseVersion } ): ` +
-			`[ ${ op.nodes.length } ] -> ${ op.position }`;
+		return getClassName( this ) + `( ${ this.baseVersion } ): ${ nodeString } -> ${ op.position }`;
 	};
 
 	MarkerDelta.prototype.toString = function() {

--- a/tests/dev-utils/enableenginedebug.js
+++ b/tests/dev-utils/enableenginedebug.js
@@ -209,10 +209,29 @@ describe( 'debug tools', () => {
 				expect( log.calledWithExactly( op.toString() ) ).to.be.true;
 			} );
 
-			it( 'InsertOperation', () => {
+			it( 'InsertOperation (text node)', () => {
 				const op = new InsertOperation( ModelPosition.createAt( modelRoot, 3 ), [ new ModelText( 'abc' ) ], 0 );
 
-				expect( op.toString() ).to.equal( 'InsertOperation( 0 ): [ 1 ] -> main [ 3 ]' );
+				expect( op.toString() ).to.equal( 'InsertOperation( 0 ): #abc -> main [ 3 ]' );
+
+				op.log();
+				expect( log.calledWithExactly( op.toString() ) ).to.be.true;
+			} );
+
+			it( 'InsertOperation (element)', () => {
+				const op = new InsertOperation( ModelPosition.createAt( modelRoot, 3 ), [ new ModelElement( 'paragraph' ) ], 0 );
+
+				expect( op.toString() ).to.equal( 'InsertOperation( 0 ): <paragraph> -> main [ 3 ]' );
+
+				op.log();
+				expect( log.calledWithExactly( op.toString() ) ).to.be.true;
+			} );
+
+			it( 'InsertOperation (multiple nodes)', () => {
+				const nodes = [ new ModelText( 'x' ), new ModelElement( 'y' ), new ModelText( 'z' ) ];
+				const op = new InsertOperation( ModelPosition.createAt( modelRoot, 3 ), nodes, 0 );
+
+				expect( op.toString() ).to.equal( 'InsertOperation( 0 ): [ 3 ] -> main [ 3 ]' );
 
 				op.log();
 				expect( log.calledWithExactly( op.toString() ) ).to.be.true;
@@ -301,13 +320,38 @@ describe( 'debug tools', () => {
 				expect( log.calledWithExactly( delta.toString() ) ).to.be.true;
 			} );
 
-			it( 'InsertDelta', () => {
+			it( 'InsertDelta (text node)', () => {
 				const delta = new InsertDelta();
 				const op = new InsertOperation( ModelPosition.createAt( modelRoot, 3 ), [ new ModelText( 'abc' ) ], 0 );
 
 				delta.addOperation( op );
 
-				expect( delta.toString() ).to.equal( 'InsertDelta( 0 ): [ 1 ] -> main [ 3 ]' );
+				expect( delta.toString() ).to.equal( 'InsertDelta( 0 ): #abc -> main [ 3 ]' );
+
+				delta.log();
+				expect( log.calledWithExactly( delta.toString() ) ).to.be.true;
+			} );
+
+			it( 'InsertDelta (element)', () => {
+				const delta = new InsertDelta();
+				const op = new InsertOperation( ModelPosition.createAt( modelRoot, 3 ), [ new ModelElement( 'paragraph' ) ], 0 );
+
+				delta.addOperation( op );
+
+				expect( delta.toString() ).to.equal( 'InsertDelta( 0 ): <paragraph> -> main [ 3 ]' );
+
+				delta.log();
+				expect( log.calledWithExactly( delta.toString() ) ).to.be.true;
+			} );
+
+			it( 'InsertDelta (multiple nodes)', () => {
+				const delta = new InsertDelta();
+				const nodes = [ new ModelText( 'x' ), new ModelElement( 'y' ), new ModelText( 'z' ) ];
+				const op = new InsertOperation( ModelPosition.createAt( modelRoot, 3 ), nodes, 0 );
+
+				delta.addOperation( op );
+
+				expect( delta.toString() ).to.equal( 'InsertDelta( 0 ): [ 3 ] -> main [ 3 ]' );
 
 				delta.log();
 				expect( log.calledWithExactly( delta.toString() ) ).to.be.true;
@@ -453,7 +497,7 @@ describe( 'debug tools', () => {
 
 			modelDoc.applyOperation( op );
 
-			expect( log.calledWithExactly( 'Applying InsertOperation( 0 ): [ 1 ] -> main [ 0 ]' ) ).to.be.true;
+			expect( log.calledWithExactly( 'Applying InsertOperation( 0 ): #foo -> main [ 0 ]' ) ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Logging `InsertDelta` and `InsertOperation` now shows element's name or text node's data if the delta/operation inserts only one node. Closes #821.