### PR TITLE
T/1002: Introduce Position#getCommonAncestor( otherPosition ) and Range#getCommonAncestor()

### DIFF
--- a/src/model/documentfragment.js
+++ b/src/model/documentfragment.js
@@ -172,6 +172,27 @@ export default class DocumentFragment {
 	}
 
 	/**
+	 * Returns a descendant node by its path relative to this element.
+	 *
+	 *		// <this>a<b>c</b></this>
+	 *		this.getNodeByPath( [ 0 ] );     // -> "a"
+	 *		this.getNodeByPath( [ 1 ] );     // -> <b>
+	 *		this.getNodeByPath( [ 1, 0 ] );  // -> "c"
+	 *
+	 * @param {Array.<Number>} relativePath Path of the node to find, relative to this element.
+	 * @returns {module:engine/model/node~Node|module:engine/model/documentfragment~DocumentFragment}
+	 */
+	getNodeByPath( relativePath ) {
+		let node = this; // eslint-disable-line consistent-this
+
+		for ( const index of relativePath ) {
+			node = node.getChild( index );
+		}
+
+		return node;
+	}
+
+	/**
 	 * Converts offset "position" to index "position".
 	 *
 	 * Returns index of a node that occupies given offset. If given offset is too low, returns `0`. If given offset is

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -332,6 +332,7 @@ export default class Position {
 
 		const node = this.root.getNodeByPath( this.getCommonPath( position ) );
 
+		// Although paths can indicate a text node, text node is not an ancestor of a position.
 		if ( node.is( 'text' ) ) {
 			return node.parent;
 		}

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -319,27 +319,24 @@ export default class Position {
 	}
 
 	/**
-	 * Returns a {@link module:engine/model/node~Node} which is a common ancestor for both positions. The {@link #root roots}
-	 * of these two positions must be identical.
+	 * Returns an {@link module:engine/model/element~Element} or {@link module:engine/model/documentfragment~DocumentFragment}
+	 * which is a common ancestor for both positions. The {@link #root roots} of these two positions must be identical.
 	 *
 	 * @param {module:engine/model/position~Position} position The second position.
-	 * @returns {module:engine/model/node~Node|null} Node that contains both positions.
+	 * @returns {module:engine/model/element~Element|module:engine/model/documentfragment~DocumentFragment|null}
 	 */
 	getCommonAncestor( position ) {
 		if ( this.root !== position.root ) {
 			return null;
 		}
 
-		const ancestorsA = this.getAncestors();
-		const ancestorsB = position.getAncestors();
+		const node = this.root.getNodeByPath( this.getCommonPath( position ) );
 
-		let i = 0;
-
-		while ( ancestorsA[ i ] == ancestorsB[ i ] && ancestorsA[ i ] ) {
-			i++;
+		if ( node.is( 'text' ) ) {
+			return node.parent;
 		}
 
-		return i === 0 ? null : ancestorsA[ i - 1 ];
+		return node;
 	}
 
 	/**

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -319,6 +319,30 @@ export default class Position {
 	}
 
 	/**
+	 * Returns a {@link module:engine/model/node~Node} which is a common ancestor for both positions. The {@link #root roots}
+	 * of these two positions must be identical.
+	 *
+	 * @param {module:engine/model/position~Position} position The second position.
+	 * @returns {module:engine/model/node~Node|null} Node that contains both positions.
+	 */
+	getCommonAncestor( position ) {
+		if ( this.root !== position.root ) {
+			return null;
+		}
+
+		const ancestorsA = this.getAncestors();
+		const ancestorsB = position.getAncestors();
+
+		let i = 0;
+
+		while ( ancestorsA[ i ] == ancestorsB[ i ] && ancestorsA[ i ] ) {
+			i++;
+		}
+
+		return i === 0 ? null : ancestorsA[ i - 1 ];
+	}
+
+	/**
 	 * Returns a new instance of `Position`, that has same {@link #parent parent} but it's offset
 	 * is shifted by `shift` value (can be a negative value).
 	 *

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -330,14 +330,16 @@ export default class Position {
 			return null;
 		}
 
-		const node = this.root.getNodeByPath( this.getCommonPath( position ) );
+		const ancestorsA = this.getAncestors();
+		const ancestorsB = position.getAncestors();
 
-		// Although paths can indicate a text node, text node is not an ancestor of a position.
-		if ( node.is( 'text' ) ) {
-			return node.parent;
+		let i = 0;
+
+		while ( ancestorsA[ i ] == ancestorsB[ i ] && ancestorsA[ i ] ) {
+			i++;
 		}
 
-		return node;
+		return i === 0 ? null : ancestorsA[ i - 1 ];
 	}
 
 	/**

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -320,16 +320,12 @@ export default class Position {
 
 	/**
 	 * Returns an {@link module:engine/model/element~Element} or {@link module:engine/model/documentfragment~DocumentFragment}
-	 * which is a common ancestor for both positions. The {@link #root roots} of these two positions must be identical.
+	 * which is a common ancestor of both positions. The {@link #root roots} of these two positions must be identical.
 	 *
 	 * @param {module:engine/model/position~Position} position The second position.
 	 * @returns {module:engine/model/element~Element|module:engine/model/documentfragment~DocumentFragment|null}
 	 */
 	getCommonAncestor( position ) {
-		if ( this.root !== position.root ) {
-			return null;
-		}
-
 		const ancestorsA = this.getAncestors();
 		const ancestorsB = position.getAncestors();
 

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -447,7 +447,7 @@ export default class Range {
 
 	/**
 	 * Returns an {@link module:engine/model/element~Element} or {@link module:engine/model/documentfragment~DocumentFragment}
-	 * which is a common ancestor for both positions.
+	 * which is a common ancestor of the range's both ends (in which the entire range is contained).
 	 *
 	 * @returns {module:engine/model/element~Element|module:engine/model/documentfragment~DocumentFragment|null}
 	 */

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -446,6 +446,15 @@ export default class Range {
 	}
 
 	/**
+	 * Returns a {@link module:engine/model/node~Node} which is a common ancestor for both positions.
+	 *
+	 * @returns {module:engine/model/node~Node|null}
+	 */
+	getCommonAncestor() {
+		return this.start.getCommonAncestor( this.end );
+	}
+
+	/**
 	 * Returns a range that is a result of transforming this range by a change in the model document.
 	 *
 	 * @protected

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -446,9 +446,10 @@ export default class Range {
 	}
 
 	/**
-	 * Returns a {@link module:engine/model/node~Node} which is a common ancestor for both positions.
+	 * Returns an {@link module:engine/model/element~Element} or {@link module:engine/model/documentfragment~DocumentFragment}
+	 * which is a common ancestor for both positions.
 	 *
-	 * @returns {module:engine/model/node~Node|null}
+	 * @returns {module:engine/model/element~Element|module:engine/model/documentfragment~DocumentFragment|null}
 	 */
 	getCommonAncestor() {
 		return this.start.getCommonAncestor( this.end );

--- a/src/view/position.js
+++ b/src/view/position.js
@@ -176,10 +176,11 @@ export default class Position {
 	}
 
 	/**
-	 * Returns a {@link module:engine/view/node~Node} which is a common ancestor for both positions.
+	 * Returns a {@link module:engine/view/node~Node} or {@link module:engine/view/documentfragment~DocumentFragment}
+	 * which is a common ancestor for both positions.
 	 *
 	 * @param {module:engine/view/position~Position} position
-	 * @returns {module:engine/view/node~Node|null}
+	 * @returns {module:engine/view/node~Node|module:engine/view/documentfragment~DocumentFragment|null}
 	 */
 	getCommonAncestor( position ) {
 		const ancestorsA = this.getAncestors();

--- a/src/view/position.js
+++ b/src/view/position.js
@@ -177,7 +177,7 @@ export default class Position {
 
 	/**
 	 * Returns a {@link module:engine/view/node~Node} or {@link module:engine/view/documentfragment~DocumentFragment}
-	 * which is a common ancestor for both positions.
+	 * which is a common ancestor of both positions.
 	 *
 	 * @param {module:engine/view/position~Position} position
 	 * @returns {module:engine/view/node~Node|module:engine/view/documentfragment~DocumentFragment|null}

--- a/src/view/position.js
+++ b/src/view/position.js
@@ -176,6 +176,25 @@ export default class Position {
 	}
 
 	/**
+	 * Returns a {@link module:engine/view/node~Node} which is a common ancestor for both positions.
+	 *
+	 * @param {module:engine/view/position~Position} position
+	 * @returns {module:engine/view/node~Node|null}
+	 */
+	getCommonAncestor( position ) {
+		const ancestorsA = this.getAncestors();
+		const ancestorsB = position.getAncestors();
+
+		let i = 0;
+
+		while ( ancestorsA[ i ] == ancestorsB[ i ] && ancestorsA[ i ] ) {
+			i++;
+		}
+
+		return i === 0 ? null : ancestorsA[ i - 1 ];
+	}
+
+	/**
 	 * Checks whether this position equals given position.
 	 *
 	 * @param {module:engine/view/position~Position} otherPosition Position to compare with.

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -305,9 +305,10 @@ export default class Range {
 	}
 
 	/**
-	 * Returns a {@link module:engine/view/node~Node} which is a common ancestor for both positions.
+	 * Returns a {@link module:engine/view/node~Node} or {@link module:engine/view/documentfragment~DocumentFragment}
+	 * which is a common ancestor for both positions.
 	 *
-	 * @returns {module:engine/view/node~Node|null}
+	 * @returns {module:engine/view/node~Node|module:engine/view/documentfragment~DocumentFragment|null}
 	 */
 	getCommonAncestor() {
 		return this.start.getCommonAncestor( this.end );

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -306,7 +306,7 @@ export default class Range {
 
 	/**
 	 * Returns a {@link module:engine/view/node~Node} or {@link module:engine/view/documentfragment~DocumentFragment}
-	 * which is a common ancestor for both positions.
+	 * which is a common ancestor of range's both ends (in which the entire range is contained).
 	 *
 	 * @returns {module:engine/view/node~Node|module:engine/view/documentfragment~DocumentFragment|null}
 	 */

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -305,6 +305,15 @@ export default class Range {
 	}
 
 	/**
+	 * Returns a {@link module:engine/view/node~Node} which is a common ancestor for both positions.
+	 *
+	 * @returns {module:engine/view/node~Node|null}
+	 */
+	getCommonAncestor() {
+		return this.start.getCommonAncestor( this.end );
+	}
+
+	/**
 	 * Returns an iterator that iterates over all {@link module:engine/view/item~Item view items} that are in this range and returns
 	 * them.
 	 *

--- a/tests/model/documentfragment.js
+++ b/tests/model/documentfragment.js
@@ -300,4 +300,25 @@ describe( 'DocumentFragment', () => {
 			expect( deserialized.getChild( 1 ).parent ).to.equal( deserialized );
 		} );
 	} );
+
+	describe( 'getNodeByPath', () => {
+		it( 'should return the whole document fragment if path is empty', () => {
+			const frag = new DocumentFragment();
+
+			expect( frag.getNodeByPath( [] ) ).to.equal( frag );
+		} );
+
+		it( 'should return a descendant of this node', () => {
+			const image = new Element( 'image' );
+			const element = new Element( 'elem', [], [
+				new Element( 'elem', [], [
+					new Text( 'foo' ),
+					image
+				] )
+			] );
+			const frag = new DocumentFragment( element );
+
+			expect( frag.getNodeByPath( [ 0, 0, 1 ] ) ).to.equal( image );
+		} );
+	} );
 } );

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -853,11 +853,24 @@ describe( 'Position', () => {
 			test( pos1, pos2, null );
 		} );
 
-		it( 'for two the same positions returns the parent element', () => {
+		it( 'for two the same positions returns the parent element #1', () => {
 			const fPosition = new Position( root, [ 1, 0, 0 ] );
 			const otherPosition = new Position( root, [ 1, 0, 0 ] );
 
 			test( fPosition, otherPosition, li1 );
+		} );
+
+		it( 'for two the same positions returns the parent element #2', () => {
+			const doc = new Document();
+			const root = doc.createRoot();
+
+			const p = new Element( 'p', null, 'foobar' );
+
+			root.appendChildren( p );
+
+			const postion = new Position( root, [ 0, 3 ] ); // <p>foo^bar</p>
+
+			test( postion, postion, p );
 		} );
 
 		it( 'for two positions in the same element returns the element', () => {
@@ -872,6 +885,19 @@ describe( 'Position', () => {
 			const liPosition = new Position( root, [ 1, 1 ] );
 
 			test( liPosition, zPosition, ul );
+		} );
+
+		it( 'works if position is hooked before an empty element', () => {
+			const doc = new Document();
+			const root = doc.createRoot();
+
+			const p = new Element( 'p', null, new Element( 'a', null, [] ) );
+
+			root.appendChildren( p );
+
+			const postion = new Position( root, [ 0, 0 ] ); // <p>^<a></a></p>
+
+			test( postion, postion, p );
 		} );
 
 		it( 'works fine with positions hooked in `DocumentFragment`', () => {

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -846,9 +846,9 @@ describe( 'Position', () => {
 	} );
 
 	describe( 'getCommonAncestor()', () => {
-		it( 'returns null when roots of the position are not the same', () => {
+		it( 'returns null when roots of both positions are not the same', () => {
 			const pos1 = new Position( root, [ 0 ] );
-			const pos2 = new Position( otherRoot, [ 1, 1 ] );
+			const pos2 = new Position( otherRoot, [ 0 ] );
 
 			test( pos1, pos2, null );
 		} );
@@ -887,11 +887,12 @@ describe( 'Position', () => {
 			test( liPosition, zPosition, ul );
 		} );
 
-		it( 'works if position is hooked before an empty element', () => {
+		// Checks if by mistake someone didn't use getCommonPath() + getNodeByPath().
+		it( 'works if position is located before an element', () => {
 			const doc = new Document();
 			const root = doc.createRoot();
 
-			const p = new Element( 'p', null, new Element( 'a', null, [] ) );
+			const p = new Element( 'p', null, new Element( 'a' ) );
 
 			root.appendChildren( p );
 
@@ -900,7 +901,7 @@ describe( 'Position', () => {
 			test( postion, postion, p );
 		} );
 
-		it( 'works fine with positions hooked in `DocumentFragment`', () => {
+		it( 'works fine with positions located in DocumentFragment', () => {
 			const docFrag = new DocumentFragment( [ p, ul ] );
 			const zPosition = new Position( docFrag, [ 1, 0, 2 ] );
 			const afterLiPosition = new Position( docFrag, [ 1, 2 ] );

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -847,7 +847,7 @@ describe( 'Position', () => {
 
 	describe( 'getCommonAncestor()', () => {
 		it( 'returns null when roots of the position are not the same', () => {
-			const pos1 = new Position( root, [ 1, 1 ] );
+			const pos1 = new Position( root, [ 0 ] );
 			const pos2 = new Position( otherRoot, [ 1, 1 ] );
 
 			test( pos1, pos2, null );
@@ -855,11 +855,12 @@ describe( 'Position', () => {
 
 		it( 'for two the same positions returns the parent element', () => {
 			const fPosition = new Position( root, [ 1, 0, 0 ] );
+			const otherPosition = new Position( root, [ 1, 0, 0 ] );
 
-			test( fPosition, fPosition, li1 );
+			test( fPosition, otherPosition, li1 );
 		} );
 
-		it( 'for two positions in the same parent returns the parent element', () => {
+		it( 'for two positions in the same element returns the element', () => {
 			const fPosition = new Position( root, [ 1, 0, 0 ] );
 			const zPosition = new Position( root, [ 1, 0, 2 ] );
 
@@ -868,17 +869,17 @@ describe( 'Position', () => {
 
 		it( 'for two different positions returns first element which contains both positions', () => {
 			const zPosition = new Position( root, [ 1, 0, 2 ] );
-			const rPosition = new Position( root, [ 1, 1, 2 ] );
+			const liPosition = new Position( root, [ 1, 1 ] );
 
-			test( rPosition, zPosition, ul );
+			test( liPosition, zPosition, ul );
 		} );
 
 		it( 'works fine with positions hooked in `DocumentFragment`', () => {
 			const docFrag = new DocumentFragment( [ p, ul ] );
 			const zPosition = new Position( docFrag, [ 1, 0, 2 ] );
-			const rPosition = new Position( docFrag, [ 1, 1, 2 ] );
+			const afterLiPosition = new Position( docFrag, [ 1, 2 ] );
 
-			test( zPosition, rPosition, ul );
+			test( zPosition, afterLiPosition, ul );
 		} );
 
 		function test( positionA, positionB, lca ) {

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -867,7 +867,7 @@ describe( 'Position', () => {
 			test( fPosition, zPosition, li1 );
 		} );
 
-		it( 'for two different positions returns first element which contains both positions', () => {
+		it( 'works when one positions is nested deeper than the other', () => {
 			const zPosition = new Position( root, [ 1, 0, 2 ] );
 			const liPosition = new Position( root, [ 1, 1 ] );
 

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -844,4 +844,46 @@ describe( 'Position', () => {
 			).to.throw( CKEditorError, /model-position-fromjson-no-root/ );
 		} );
 	} );
+
+	describe( 'getCommonAncestor()', () => {
+		it( 'returns null when roots of the position are not the same', () => {
+			const pos1 = new Position( root, [ 1, 1 ] );
+			const pos2 = new Position( otherRoot, [ 1, 1 ] );
+
+			test( pos1, pos2, null );
+		} );
+
+		it( 'for two the same positions returns the parent element', () => {
+			const fPosition = new Position( root, [ 1, 0, 0 ] );
+
+			test( fPosition, fPosition, li1 );
+		} );
+
+		it( 'for two positions in the same parent returns the parent element', () => {
+			const fPosition = new Position( root, [ 1, 0, 0 ] );
+			const zPosition = new Position( root, [ 1, 0, 2 ] );
+
+			test( fPosition, zPosition, li1 );
+		} );
+
+		it( 'for two different positions returns first element which contains both positions', () => {
+			const zPosition = new Position( root, [ 1, 0, 2 ] );
+			const rPosition = new Position( root, [ 1, 1, 2 ] );
+
+			test( rPosition, zPosition, ul );
+		} );
+
+		it( 'works fine with positions hooked in `DocumentFragment`', () => {
+			const docFrag = new DocumentFragment( [ p, ul ] );
+			const zPosition = new Position( docFrag, [ 1, 0, 2 ] );
+			const rPosition = new Position( docFrag, [ 1, 1, 2 ] );
+
+			test( zPosition, rPosition, ul );
+		} );
+
+		function test( positionA, positionB, lca ) {
+			expect( positionA.getCommonAncestor( positionB ) ).to.equal( lca );
+			expect( positionB.getCommonAncestor( positionA ) ).to.equal( lca );
+		}
+	} );
 } );

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -1223,6 +1223,12 @@ describe( 'Range', () => {
 		} );
 	} );
 
+	describe( 'getCommonAncestor()', () => {
+		it( 'should return common ancestor for positions from Range', () => {
+			expect( range.getCommonAncestor() ).to.equal( root );
+		} );
+	} );
+
 	function mapNodesToNames( nodes ) {
 		return nodes.map( node => {
 			return ( node instanceof Element ) ? 'E:' + node.name : 'T:' + node.data;

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -521,62 +521,77 @@ describe( 'Position', () => {
 	} );
 
 	describe( 'getCommonAncestor()', () => {
-		let div, section, article, p, ul, li1, li2, foz, bar, lipsum;
+		let div, ul, liUl1, liUl2, texts, section, article, ol, liOl1, liOl2, p;
 
 		// |- div
 		//   |- ul
 		//   |  |- li
-		//   |  |  |- f
-		//   |  |  |- o
-		//   |  |  |- z
+		//   |  |  |- foz
 		//   |  |- li
-		//   |     |- b
-		//   |     |- a
-		//   |     |- r
+		//   |     |- bar
 		//   |- section
+		//      |- Sed id libero at libero tristique
 		//      |- article
-		//         |- p
-		//            |- l
-		//            |- i
-		//            |- p
-		//            |- s
-		//            |- u
-		//            |- m
+		//      |  |- ol
+		//      |  |  |- li
+		//      |  |  |  |- Lorem ipsum dolor sit amet.
+		//      |  |  |- li
+		//      |  |     |- Mauris tincidunt tincidunt leo ac rutrum.
+		//      |  |- p
+		//      |  |  |- Maecenas accumsan tellus.
 
 		beforeEach( () => {
-			foz = new Text( 'foz' );
-			bar = new Text( 'bar' );
-			li1 = new Element( 'li', null, foz );
-			li2 = new Element( 'li', null, bar );
-			ul = new Element( 'ul', null, [ li1, li2 ] );
+			texts = {
+				foz: new Text( 'foz' ),
+				bar: new Text( 'bar' ),
+				lorem: new Text( 'Lorem ipsum dolor sit amet.' ),
+				mauris: new Text( 'Mauris tincidunt tincidunt leo ac rutrum.' ),
+				maecenas: new Text( 'Maecenas accumsan tellus.' ),
+				sed: new Text( 'Sed id libero at libero tristique.' )
+			};
 
-			lipsum = new Text( 'lipsum' );
-			p = new Element( 'p', null, lipsum );
-			article = new Element( 'article', null, p );
-			section = new Element( 'section', null, article );
+			liUl1 = new Element( 'li', null, texts.foz );
+			liUl2 = new Element( 'li', null, texts.bar );
+			ul = new Element( 'ul', null, [ liUl1, liUl2 ] );
+
+			liOl1 = new Element( 'li', null, texts.lorem );
+			liOl2 = new Element( 'li', null, texts.mauris );
+			ol = new Element( 'ol', null, [ liOl1, liOl2 ] );
+
+			p = new Element( 'p', null, texts.maecenas );
+
+			article = new Element( 'article', null, [ ol, p ] );
+			section = new Element( 'section', null, [ texts.sed, article ] );
 
 			div = new Element( 'div', null, [ ul, section ] );
 		} );
 
 		it( 'for two the same positions returns the parent element', () => {
-			const fPosition = new Position( li1, 0 );
-			const otherPosition = Position.createFromPosition( fPosition );
+			const afterLoremPosition = new Position( liOl1, 5 );
+			const otherPosition = Position.createFromPosition( afterLoremPosition );
 
-			test( fPosition, otherPosition, li1 );
+			test( afterLoremPosition, otherPosition, liOl1 );
 		} );
 
 		it( 'for two positions in the same element returns the element', () => {
-			const fPosition = new Position( li1, 0 );
-			const zPosition = new Position( li1, 2 );
+			const startMaecenasPosition = Position.createAt( liOl2 );
+			const beforeTellusPosition = new Position( liOl2, 18 );
 
-			test( fPosition, zPosition, li1 );
+			test( startMaecenasPosition, beforeTellusPosition, liOl2 );
 		} );
 
-		it( 'works when one positions is nested deeper than the other', () => {
-			const zPosition = new Position( li1, 2 );
-			const iPosition = Position.createAt( lipsum, 'start' );
+		it( 'works when one of the positions is nested deeper than the other #1', () => {
+			const firstPosition = new Position( liUl1, 1 );
+			const secondPosition = new Position( p, 3 );
 
-			test( iPosition, zPosition, div );
+			test( firstPosition, secondPosition, div );
+		} );
+
+		it( 'works when one of the positions is nested deeper than the other #2', () => {
+			const firstPosition = new Position( liOl2, 10 );
+			const secondPosition = new Position( section, 1 );
+
+			test( firstPosition, secondPosition, section );
 		} );
 
 		function test( positionA, positionB, lca ) {

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -519,4 +519,43 @@ describe( 'Position', () => {
 			document.destroy();
 		} );
 	} );
+
+	describe( 'getCommonAncestor()', () => {
+		let ul, li1, li2, foz, bar;
+
+		beforeEach( () => {
+			foz = new Text( 'foz' );
+			bar = new Text( 'bar' );
+
+			li1 = new Element( 'li', null, foz );
+			li2 = new Element( 'li', null, bar );
+
+			ul = new Element( 'ul', null, [ li1, li2 ] );
+		} );
+
+		it( 'for two the same positions returns the parent element', () => {
+			const fPosition = new Position( li1, 0 );
+
+			test( fPosition, fPosition, li1 );
+		} );
+
+		it( 'for two positions in the same parent returns the parent element', () => {
+			const fPosition = new Position( li1, 0 );
+			const zPosition = new Position( li1, 2 );
+
+			test( fPosition, zPosition, li1 );
+		} );
+
+		it( 'for two different positions returns first element which contains both positions', () => {
+			const zPosition = new Position( li1, 2 );
+			const bPosition = new Position( li2, 0 );
+
+			test( bPosition, zPosition, ul );
+		} );
+
+		function test( positionA, positionB, lca ) {
+			expect( positionA.getCommonAncestor( positionB ) ).to.equal( lca );
+			expect( positionB.getCommonAncestor( positionA ) ).to.equal( lca );
+		}
+	} );
 } );

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -534,14 +534,14 @@ describe( 'Position', () => {
 		//   |     |- a
 		//   |     |- r
 		//   |- section
-		//     |- article
-		//       |- p
-		//         |- l
-		//         |- i
+		//      |- article
 		//         |- p
-		//         |- s
-		//         |- u
-		//         |- m
+		//            |- l
+		//            |- i
+		//            |- p
+		//            |- s
+		//            |- u
+		//            |- m
 
 		beforeEach( () => {
 			foz = new Text( 'foz' );

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -521,7 +521,7 @@ describe( 'Position', () => {
 	} );
 
 	describe( 'getCommonAncestor()', () => {
-		let div, p, ul, li1, li2, foz, bar, ipsum;
+		let div, section, article, p, ul, li1, li2, foz, bar, lipsum;
 
 		// |- div
 		//   |- ul
@@ -533,25 +533,29 @@ describe( 'Position', () => {
 		//   |     |- b
 		//   |     |- a
 		//   |     |- r
-		//   |- p
-		//     |- i
-		//     |- p
-		//     |- s
-		//     |- u
-		//     |- m
+		//   |- section
+		//     |- article
+		//       |- p
+		//         |- l
+		//         |- i
+		//         |- p
+		//         |- s
+		//         |- u
+		//         |- m
 
 		beforeEach( () => {
 			foz = new Text( 'foz' );
 			bar = new Text( 'bar' );
-			ipsum = new Text( 'ipsum' );
-
 			li1 = new Element( 'li', null, foz );
 			li2 = new Element( 'li', null, bar );
-
-			p = new Element( 'p', null, ipsum );
-
 			ul = new Element( 'ul', null, [ li1, li2 ] );
-			div = new Element( 'div', null, [ ul, p ] );
+
+			lipsum = new Text( 'lipsum' );
+			p = new Element( 'p', null, lipsum );
+			article = new Element( 'article', null, p );
+			section = new Element( 'section', null, article );
+
+			div = new Element( 'div', null, [ ul, section ] );
 		} );
 
 		it( 'for two the same positions returns the parent element', () => {
@@ -568,9 +572,9 @@ describe( 'Position', () => {
 			test( fPosition, zPosition, li1 );
 		} );
 
-		it( 'for two different positions returns first element which contains both positions', () => {
+		it( 'works when one positions is nested deeper than the other', () => {
 			const zPosition = new Position( li1, 2 );
-			const iPosition = Position.createAt( ipsum, 'start' );
+			const iPosition = Position.createAt( lipsum, 'start' );
 
 			test( iPosition, zPosition, div );
 		} );

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -521,25 +521,47 @@ describe( 'Position', () => {
 	} );
 
 	describe( 'getCommonAncestor()', () => {
-		let ul, li1, li2, foz, bar;
+		let div, p, ul, li1, li2, foz, bar, ipsum;
+
+		// |- div
+		//   |- ul
+		//   |  |- li
+		//   |  |  |- f
+		//   |  |  |- o
+		//   |  |  |- z
+		//   |  |- li
+		//   |     |- b
+		//   |     |- a
+		//   |     |- r
+		//   |- p
+		//     |- i
+		//     |- p
+		//     |- s
+		//     |- u
+		//     |- m
 
 		beforeEach( () => {
 			foz = new Text( 'foz' );
 			bar = new Text( 'bar' );
+			ipsum = new Text( 'ipsum' );
 
 			li1 = new Element( 'li', null, foz );
 			li2 = new Element( 'li', null, bar );
 
+			p = new Element( 'p', null, ipsum );
+
 			ul = new Element( 'ul', null, [ li1, li2 ] );
+			div = new Element( 'div', null, [ ul, p ] );
 		} );
 
 		it( 'for two the same positions returns the parent element', () => {
 			const fPosition = new Position( li1, 0 );
+			const otherPosition = Position.createFromPosition( fPosition );
 
-			test( fPosition, fPosition, li1 );
+			test( fPosition, otherPosition, li1 );
 		} );
 
-		it( 'for two positions in the same parent returns the parent element', () => {
+		it( 'for two positions in the same element returns the element', () => {
 			const fPosition = new Position( li1, 0 );
 			const zPosition = new Position( li1, 2 );
 
@@ -548,9 +570,9 @@ describe( 'Position', () => {
 
 		it( 'for two different positions returns first element which contains both positions', () => {
 			const zPosition = new Position( li1, 2 );
-			const bPosition = new Position( li2, 0 );
+			const iPosition = Position.createAt( ipsum, 'start' );
 
-			test( bPosition, zPosition, ul );
+			test( iPosition, zPosition, div );
 		} );
 
 		function test( positionA, positionB, lca ) {

--- a/tests/view/range.js
+++ b/tests/view/range.js
@@ -692,4 +692,20 @@ describe( 'Range', () => {
 			} );
 		} );
 	} );
+
+	describe( 'getCommonAncestor()', () => {
+		it( 'should return common ancestor for positions from Range', () => {
+			const foz = new Text( 'foz' );
+			const bar = new Text( 'bar' );
+
+			const li1 = new Element( 'li', null, foz );
+			const li2 = new Element( 'li', null, bar );
+
+			const ul = new Element( 'ul', null, [ li1, li2 ] );
+
+			const range = new Range( new Position( li1, 0 ), new Position( li2, 2 ) );
+
+			expect( range.getCommonAncestor() ).to.equal( ul );
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `Position#getCommonAncestor( position )` and `Range#getCommonAncestor()` methods for `view` and `model`. Closes #1002.