### PR TITLE
T/1001: Remove selection attributes stored in element once it's not empty any more

### DIFF
--- a/src/model/document.js
+++ b/src/model/document.js
@@ -429,6 +429,8 @@ export default class Document {
 	 * * 'remove' when nodes are removed,
 	 * * 'reinsert' when remove is undone,
 	 * * 'move' when nodes are moved,
+	 * * 'rename' when element is renamed,
+	 * * 'marker' when a marker changes (added, removed or its range is changed),
 	 * * 'addAttribute' when attributes are added,
 	 * * 'removeAttribute' when attributes are removed,
 	 * * 'changeAttribute' when attributes change,
@@ -439,9 +441,9 @@ export default class Document {
 	 * @event change
 	 * @param {String} type Change type, possible option: 'insert', 'remove', 'reinsert', 'move', 'attribute'.
 	 * @param {Object} data Additional information about the change.
-	 * @param {module:engine/model/range~Range} data.range Range in model containing changed nodes. Note that the range state is
+	 * @param {module:engine/model/range~Range} [data.range] Range in model containing changed nodes. Note that the range state is
 	 * after changes has been done, i.e. for 'remove' the range will be in the {@link #graveyard graveyard root}.
-	 * This is `undefined` for "...root..." types.
+	 * The range is not defined for root, rename and marker types.
 	 * @param {module:engine/model/position~Position} [data.sourcePosition] Change source position.
 	 * Exists for 'remove', 'reinsert' and 'move'.
 	 * Note that this position state is before changes has been done, i.e. for 'reinsert' the source position will be in the
@@ -451,7 +453,7 @@ export default class Document {
 	 * 'changeRootAttribute' type.
 	 * @param {*} [data.newValue] Only for 'addAttribute', 'addRootAttribute', 'changeAttribute' or
 	 * 'changeRootAttribute' type.
-	 * @param {module:engine/model/rootelement~RootElement} [changeInfo.root] Root element which attributes got changed. This is defined
+	 * @param {module:engine/model/rootelement~RootElement} [data.root] Root element which attributes got changed. This is defined
 	 * only for root types.
 	 * @param {module:engine/model/batch~Batch} batch A {@link module:engine/model/batch~Batch batch}
 	 * of changes which this change is a part of.

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -18,7 +18,7 @@ import Position from './position';
 import RootElement from './rootelement';
 import Batch from './batch';
 import History from './history';
-import LiveSelection from './liveselection';
+import DocumentSelection from './documentselection';
 import Schema from './schema';
 import TreeWalker from './treewalker';
 import MarkerCollection from './markercollection';
@@ -90,9 +90,9 @@ export default class Document {
 		 * Selection done on this document.
 		 *
 		 * @readonly
-		 * @member {module:engine/model/liveselection~LiveSelection}
+		 * @member {module:engine/model/documentselection~DocumentSelection}
 		 */
-		this.selection = new LiveSelection( this );
+		this.selection = new DocumentSelection( this );
 
 		/**
 		 * Array of pending changes. See: {@link #enqueueChanges}.
@@ -368,7 +368,7 @@ export default class Document {
 		const json = clone( this );
 
 		// Due to circular references we need to remove parent reference.
-		json.selection = '[engine.model.LiveSelection]';
+		json.selection = '[engine.model.DocumentSelection]';
 
 		return json;
 	}

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -678,8 +678,8 @@ export default class DocumentSelection extends Selection {
  */
 
 // Helper function for {@link module:engine/model/documentselection~DocumentSelection#_updateAttributes}.
-// It takes model item, checks whether
-// it is a text node (or text proxy) and if so, returns it's attributes. If not, returns `null`.
+//
+// It takes model item, checks whether it is a text node (or text proxy) and, if so, returns it's attributes. If not, returns `null`.
 //
 // @param {module:engine/model/item~Item|null}  node
 // @returns {Boolean}
@@ -691,7 +691,7 @@ function getAttrsIfCharacter( node ) {
 	return null;
 }
 
-// Removes selection attributes from element which is not anymore empty.
+// Removes selection attributes from element which is not empty anymore.
 function clearAttributesStoredInElement( changes, batch ) {
 	// Batch may not be passed to the document#change event in some tests.
 	// See https://github.com/ckeditor/ckeditor5-engine/issues/1001#issuecomment-314202352
@@ -702,7 +702,7 @@ function clearAttributesStoredInElement( changes, batch ) {
 
 	const changeParent = changes.range && changes.range.start.parent;
 
-	// changes.range is not set in case of rename, root and marker operations.
+	// `changes.range` is not set in case of rename, root and marker operations.
 	// None of them may lead to the element becoming non-empty.
 	if ( !changeParent || changeParent.isEmpty ) {
 		return;

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -241,17 +241,19 @@ export default class DocumentSelection extends Selection {
 	}
 
 	/**
-	 * Creates and returns an instance of `DocumentSelection` that is a clone of given selection, meaning that it has same
-	 * ranges and same direction as this selection.
-	 *
-	 * @params {module:engine/model/selection~Selection} otherSelection Selection to be cloned.
-	 * @returns {module:engine/model/documentselection~DocumentSelection} `Selection` instance that is a clone of given selection.
+	 * This method is not available in `DocumentSelection`. There can be only one
+	 * `DocumentSelection` per document instance, so creating new `DocumentSelection`s this way
+	 * would be unsafe.
 	 */
-	static createFromSelection( otherSelection ) {
-		const selection = new this( otherSelection._document );
-		selection.setTo( otherSelection );
-
-		return selection;
+	static createFromSelection() {
+		/**
+		 * `DocumentSelection#createFromSelection()` is not available. There can be only one
+		 * `DocumentSelection` per document instance, so creating new `DocumentSelection`s this way
+		 * would be unsafe.
+		 *
+		 * @error documentselection-cannot-create
+		 */
+		throw new CKEditorError( 'documentselection-cannot-create: Cannot create new DocumentSelection instance.' );
 	}
 
 	/**
@@ -671,7 +673,8 @@ export default class DocumentSelection extends Selection {
  * @event change:attribute
  */
 
-// Helper function for {@link module:engine/model/documentselection~DocumentSelection#_updateAttributes}. It takes model item, checks whether
+// Helper function for {@link module:engine/model/documentselection~DocumentSelection#_updateAttributes}.
+// It takes model item, checks whether
 // it is a text node (or text proxy) and if so, returns it's attributes. If not, returns `null`.
 //
 // @param {module:engine/model/item~Item|null}  node

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module engine/model/liveselection
+ * @module engine/model/documentselection
  */
 
 import Position from './position';
@@ -25,17 +25,20 @@ const attrOpTypes = new Set(
 );
 
 /**
- * `LiveSelection` is a type of {@link module:engine/model/selection~Selection selection} that listens to changes on a
- * {@link module:engine/model/document~Document document} and has it ranges updated accordingly. Internal implementation of this
- * mechanism bases on {@link module:engine/model/liverange~LiveRange live ranges}.
+ * `DocumentSelection` is a special selection which is used as the
+ * {@link module:engine/model/document~Document#selection document's selection}.
+ * There can be only one instance of `DocumentSelection` per document.
  *
- * Differences between {@link module:engine/model/selection~Selection} and `LiveSelection` are:
- * * there is always a range in `LiveSelection` - even if no ranges were added there is a
- * {@link module:engine/model/liveselection~LiveSelection#_getDefaultRange "default range"} present in the selection,
+ * `DocumentSelection` is automatically updated upon changes in the {@link module:engine/model/document~Document document}
+ * to always contain valid ranges. Its attributes are inherited from the text unless set explicitly.
+ *
+ * Differences between {@link module:engine/model/selection~Selection} and `DocumentSelection` are:
+ * * there is always a range in `DocumentSelection` - even if no ranges were added there is a "default range"
+ * present in the selection,
  * * ranges added to this selection updates automatically when the document changes,
- * * attributes of `LiveSelection` are updated automatically according to selection ranges.
+ * * attributes of `DocumentSelection` are updated automatically according to selection ranges.
  *
- * Since `LiveSelection` uses {@link module:engine/model/liverange~LiveRange live ranges}
+ * Since `DocumentSelection` uses {@link module:engine/model/liverange~LiveRange live ranges}
  * and is updated when {@link module:engine/model/document~Document document}
  * changes, it cannot be set on {@link module:engine/model/node~Node nodes}
  * that are inside {@link module:engine/model/documentfragment~DocumentFragment document fragment}.
@@ -44,7 +47,7 @@ const attrOpTypes = new Set(
  *
  * @extends module:engine/model/selection~Selection
  */
-export default class LiveSelection extends Selection {
+export default class DocumentSelection extends Selection {
 	/**
 	 * Creates an empty live selection for given {@link module:engine/model/document~Document}.
 	 *
@@ -57,7 +60,7 @@ export default class LiveSelection extends Selection {
 		 * Document which owns this selection.
 		 *
 		 * @protected
-		 * @member {module:engine/model/document~Document} module:engine/model/liveselection~LiveSelection#_document
+		 * @member {module:engine/model/document~Document} module:engine/model/documentselection~DocumentSelection#_document
 		 */
 		this._document = document;
 
@@ -65,11 +68,11 @@ export default class LiveSelection extends Selection {
 		 * Keeps mapping of attribute name to priority with which the attribute got modified (added/changed/removed)
 		 * last time. Possible values of priority are: `'low'` and `'normal'`.
 		 *
-		 * Priorities are used by internal `LiveSelection` mechanisms. All attributes set using `LiveSelection`
+		 * Priorities are used by internal `DocumentSelection` mechanisms. All attributes set using `DocumentSelection`
 		 * attributes API are set with `'normal'` priority.
 		 *
 		 * @private
-		 * @member {Map} module:engine/model/liveselection~LiveSelection#_attributePriority
+		 * @member {Map} module:engine/model/documentselection~DocumentSelection#_attributePriority
 		 */
 		this._attributePriority = new Map();
 
@@ -238,11 +241,11 @@ export default class LiveSelection extends Selection {
 	}
 
 	/**
-	 * Creates and returns an instance of `LiveSelection` that is a clone of given selection, meaning that it has same
+	 * Creates and returns an instance of `DocumentSelection` that is a clone of given selection, meaning that it has same
 	 * ranges and same direction as this selection.
 	 *
 	 * @params {module:engine/model/selection~Selection} otherSelection Selection to be cloned.
-	 * @returns {module:engine/model/liveselection~LiveSelection} `Selection` instance that is a clone of given selection.
+	 * @returns {module:engine/model/documentselection~DocumentSelection} `Selection` instance that is a clone of given selection.
 	 */
 	static createFromSelection( otherSelection ) {
 		const selection = new this( otherSelection._document );
@@ -383,7 +386,7 @@ export default class LiveSelection extends Selection {
 	}
 
 	/**
-	 * Internal method for setting `LiveSelection` attribute. Supports attribute priorities (through `directChange`
+	 * Internal method for setting `DocumentSelection` attribute. Supports attribute priorities (through `directChange`
 	 * parameter).
 	 *
 	 * @private
@@ -417,7 +420,7 @@ export default class LiveSelection extends Selection {
 	}
 
 	/**
-	 * Internal method for removing `LiveSelection` attribute. Supports attribute priorities (through `directChange`
+	 * Internal method for removing `DocumentSelection` attribute. Supports attribute priorities (through `directChange`
 	 * parameter).
 	 *
 	 * @private
@@ -449,7 +452,7 @@ export default class LiveSelection extends Selection {
 	}
 
 	/**
-	 * Internal method for setting multiple `LiveSelection` attributes. Supports attribute priorities (through
+	 * Internal method for setting multiple `DocumentSelection` attributes. Supports attribute priorities (through
 	 * `directChange` parameter).
 	 *
 	 * @private
@@ -512,7 +515,7 @@ export default class LiveSelection extends Selection {
 	 * @param {String} key Key of attribute to remove.
 	 */
 	_removeStoredAttribute( key ) {
-		const storeKey = LiveSelection._getStoreAttributeKey( key );
+		const storeKey = DocumentSelection._getStoreAttributeKey( key );
 
 		this._document.batch().removeAttribute( this.anchor.parent, storeKey );
 	}
@@ -525,7 +528,7 @@ export default class LiveSelection extends Selection {
 	 * @param {*} value Attribute value.
 	 */
 	_storeAttribute( key, value ) {
-		const storeKey = LiveSelection._getStoreAttributeKey( key );
+		const storeKey = DocumentSelection._getStoreAttributeKey( key );
 
 		this._document.batch().setAttribute( this.anchor.parent, storeKey, value );
 	}
@@ -541,13 +544,13 @@ export default class LiveSelection extends Selection {
 		const batch = this._document.batch();
 
 		for ( const [ oldKey ] of this._getStoredAttributes() ) {
-			const storeKey = LiveSelection._getStoreAttributeKey( oldKey );
+			const storeKey = DocumentSelection._getStoreAttributeKey( oldKey );
 
 			batch.removeAttribute( selectionParent, storeKey );
 		}
 
 		for ( const [ key, value ] of attrs ) {
-			const storeKey = LiveSelection._getStoreAttributeKey( key );
+			const storeKey = DocumentSelection._getStoreAttributeKey( key );
 
 			batch.setAttribute( selectionParent, storeKey, value );
 		}
@@ -668,7 +671,7 @@ export default class LiveSelection extends Selection {
  * @event change:attribute
  */
 
-// Helper function for {@link module:engine/model/liveselection~LiveSelection#_updateAttributes}. It takes model item, checks whether
+// Helper function for {@link module:engine/model/documentselection~DocumentSelection#_updateAttributes}. It takes model item, checks whether
 // it is a text node (or text proxy) and if so, returns it's attributes. If not, returns `null`.
 //
 // @param {module:engine/model/item~Item|null}  node

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -693,7 +693,10 @@ function getAttrsIfCharacter( node ) {
 
 // Removes selection attributes from element which is not anymore empty.
 function clearAttributesStoredInElement( changes, batch ) {
-	if ( batch.type == 'transparent' ) {
+	// Batch may not be passed to the document#change event in some tests.
+	// See https://github.com/ckeditor/ckeditor5-engine/issues/1001#issuecomment-314202352
+	// Ignore also transparent batches because they are... transparent.
+	if ( !batch || batch.type == 'transparent' ) {
 		return;
 	}
 

--- a/tests/model/_utils/utils.js
+++ b/tests/model/_utils/utils.js
@@ -8,6 +8,7 @@ import TreeWalker from '../../../src/model/treewalker';
 import Text from '../../../src/model/text';
 import TextProxy from '../../../src/model/textproxy';
 import Delta from '../../../src/model/delta/delta';
+import Batch from '../../../src/model/batch';
 
 /**
  * Returns tree structure as a simplified string. Elements are uppercase and characters are lowercase.
@@ -57,7 +58,12 @@ export function jsonParseStringify( object ) {
  */
 export function wrapInDelta( operation ) {
 	const delta = new Delta();
+	// Batch() requires the document but only a few lines of code needs batch in `document#changes`
+	// so we may have an invalid batch instance for some tests.
+	const batch = new Batch();
+
 	delta.addOperation( operation );
+	batch.addDelta( delta );
 
 	return operation;
 }

--- a/tests/model/delta/transform/_utils/utils.js
+++ b/tests/model/delta/transform/_utils/utils.js
@@ -10,6 +10,8 @@ import Text from '../../../../../src/model/text';
 import Position from '../../../../../src/model/position';
 import Range from '../../../../../src/model/range';
 
+import Batch from '../../../../../src/model/batch';
+
 import AttributeDelta from '../../../../../src/model/delta/attributedelta';
 import InsertDelta from '../../../../../src/model/delta/insertdelta';
 import WeakInsertDelta from '../../../../../src/model/delta/weakinsertdelta';
@@ -40,6 +42,8 @@ export function getInsertDelta( position, nodes, version ) {
 	const delta = new InsertDelta();
 	delta.addOperation( new InsertOperation( position, nodes, version ) );
 
+	wrapInBatch( delta );
+
 	return delta;
 }
 
@@ -47,12 +51,16 @@ export function getWeakInsertDelta( position, nodes, version ) {
 	const delta = new WeakInsertDelta();
 	delta.addOperation( new InsertOperation( position, nodes, version ) );
 
+	wrapInBatch( delta );
+
 	return delta;
 }
 
 export function getMarkerDelta( name, oldRange, newRange, version ) {
 	const delta = new MarkerDelta();
 	delta.addOperation( new MarkerOperation( name, oldRange, newRange, version ) );
+
+	wrapInBatch( delta );
 
 	return delta;
 }
@@ -77,6 +85,8 @@ export function getMergeDelta( position, howManyInPrev, howManyInNext, version )
 
 	delta.addOperation( new RemoveOperation( position, 1, gyPos, version + 1 ) );
 
+	wrapInBatch( delta );
+
 	return delta;
 }
 
@@ -85,6 +95,8 @@ export function getMoveDelta( sourcePosition, howMany, targetPosition, baseVersi
 
 	const move = new MoveOperation( sourcePosition, howMany, targetPosition, baseVersion );
 	delta.addOperation( move );
+
+	wrapInBatch( delta );
 
 	return delta;
 }
@@ -98,6 +110,8 @@ export function getRemoveDelta( sourcePosition, howMany, baseVersion ) {
 	const remove = new RemoveOperation( sourcePosition, howMany, gyPos, baseVersion );
 	delta.addOperation( remove );
 
+	wrapInBatch( delta );
+
 	return delta;
 }
 
@@ -106,6 +120,8 @@ export function getRenameDelta( position, oldName, newName, baseVersion ) {
 
 	const rename = new RenameOperation( position, oldName, newName, baseVersion );
 	delta.addOperation( rename );
+
+	wrapInBatch( delta );
 
 	return delta;
 }
@@ -127,6 +143,8 @@ export function getSplitDelta( position, nodeCopy, howManyMove, version ) {
 
 	delta.addOperation( move );
 
+	wrapInBatch( delta );
+
 	return delta;
 }
 
@@ -141,6 +159,8 @@ export function getWrapDelta( range, element, version ) {
 
 	delta.addOperation( insert );
 	delta.addOperation( move );
+
+	wrapInBatch( delta );
 
 	return delta;
 }
@@ -164,6 +184,8 @@ export function getUnwrapDelta( positionBefore, howManyChildren, version ) {
 
 	delta.addOperation( move );
 	delta.addOperation( remove );
+
+	wrapInBatch( delta );
 
 	return delta;
 }
@@ -220,4 +242,12 @@ export function getFilledDocument() {
 	] );
 
 	return doc;
+}
+
+function wrapInBatch( delta ) {
+	// Batch() requires the document but only a few lines of code needs batch in `document#changes`
+	// so we may have an invalid batch instance for some tests.
+	const batch = new Batch();
+
+	batch.addDelta( delta );
 }

--- a/tests/model/document/document.js
+++ b/tests/model/document/document.js
@@ -558,6 +558,6 @@ describe( 'Document', () => {
 	} );
 
 	it( 'should be correctly converted to json', () => {
-		expect( jsonParseStringify( doc ).selection ).to.equal( '[engine.model.LiveSelection]' );
+		expect( jsonParseStringify( doc ).selection ).to.equal( '[engine.model.DocumentSelection]' );
 	} );
 } );

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -997,14 +997,15 @@ describe( 'DocumentSelection', () => {
 				expect( emptyP.parent ).to.equal( root ); // Just to be sure we're checking the right element.
 			} );
 
-			it( 'are not removed when containing element is merged with another empty element', () => {
+			it( 'are not removed or merged when containing element is merged with another empty element', () => {
 				const emptyP2 = new Element( 'p', null );
 				root.appendChildren( emptyP2 );
 
 				emptyP.setAttribute( fooStoreAttrKey, 'bar' );
-				emptyP2.setAttribute( fooStoreAttrKey, 'bar' );
+				emptyP2.setAttribute( abcStoreAttrKey, 'bar' );
 
 				expect( emptyP.hasAttribute( fooStoreAttrKey ) ).to.be.true;
+				expect( emptyP.hasAttribute( abcStoreAttrKey ) ).to.be.false;
 
 				// <emptyP>{}<emptyP2>
 				doc.batch().merge( Position.createAfter( emptyP ) );

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -537,6 +537,7 @@ describe( 'DocumentSelection', () => {
 					expect( data.directChange ).to.be.false;
 				} );
 
+				const batch = doc.batch();
 				const splitDelta = new SplitDelta();
 
 				const insertOperation = new InsertOperation(
@@ -551,6 +552,8 @@ describe( 'DocumentSelection', () => {
 					new Position( root, [ 2, 0 ] ),
 					1
 				);
+
+				batch.addDelta( splitDelta );
 
 				splitDelta.addOperation( insertOperation );
 				splitDelta.addOperation( moveOperation );

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -374,10 +374,12 @@ describe( 'DocumentSelection', () => {
 	} );
 
 	describe( 'createFromSelection()', () => {
-		it( 'should return a DocumentSelection instance', () => {
+		it( 'should throw', () => {
 			selection.addRange( range, true );
 
-			expect( DocumentSelection.createFromSelection( selection ) ).to.be.instanceof( DocumentSelection );
+			expect( () => {
+				DocumentSelection.createFromSelection( selection );
+			} ).to.throw( CKEditorError, /^documentselection-cannot-create:/ );
 		} );
 	} );
 
@@ -893,49 +895,37 @@ describe( 'DocumentSelection', () => {
 			it( 'ignores attributes inside an object if selection contains that object', () => {
 				setData( doc, '<p>[<image><$text bold="true">Caption for the image.</$text></image>]</p>' );
 
-				const liveSelection = DocumentSelection.createFromSelection( selection );
-
-				expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
+				expect( selection.hasAttribute( 'bold' ) ).to.equal( false );
 			} );
 
 			it( 'ignores attributes inside an object if selection contains that object (deeper structure)', () => {
 				setData( doc, '<p>[<image><caption><$text bold="true">Caption for the image.</$text></caption></image>]</p>' );
 
-				const liveSelection = DocumentSelection.createFromSelection( selection );
-
-				expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
+				expect( selection.hasAttribute( 'bold' ) ).to.equal( false );
 			} );
 
 			it( 'ignores attributes inside an object if selection contains that object (block level)', () => {
 				setData( doc, '<p>foo</p>[<image><$text bold="true">Caption for the image.</$text></image>]<p>foo</p>' );
 
-				const liveSelection = DocumentSelection.createFromSelection( selection );
-
-				expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
+				expect( selection.hasAttribute( 'bold' ) ).to.equal( false );
 			} );
 
 			it( 'reads attributes from text even if the selection contains an object', () => {
 				setData( doc, '<p>x<$text bold="true">[bar</$text><image></image>foo]</p>' );
 
-				const liveSelection = DocumentSelection.createFromSelection( selection );
-
-				expect( liveSelection.getAttribute( 'bold' ) ).to.equal( true );
+				expect( selection.getAttribute( 'bold' ) ).to.equal( true );
 			} );
 
 			it( 'reads attributes when the entire selection inside an object', () => {
 				setData( doc, '<p><image><caption><$text bold="true">[bar]</$text></caption></image></p>' );
 
-				const liveSelection = DocumentSelection.createFromSelection( selection );
-
-				expect( liveSelection.getAttribute( 'bold' ) ).to.equal( true );
+				expect( selection.getAttribute( 'bold' ) ).to.equal( true );
 			} );
 
 			it( 'stops reading attributes if selection starts with an object', () => {
 				setData( doc, '<p>[<image></image><$text bold="true">bar]</$text></p>' );
 
-				const liveSelection = DocumentSelection.createFromSelection( selection );
-
-				expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
+				expect( selection.hasAttribute( 'bold' ) ).to.equal( false );
 			} );
 		} );
 	} );

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -1048,6 +1048,17 @@ describe( 'DocumentSelection', () => {
 
 				expect( emptyP.getAttribute( fooStoreAttrKey ) ).to.equal( 'bar' );
 			} );
+
+			// Rename and some other deltas don't specify range in doc#change event.
+			// So let's see if there's no crash or something.
+			it( 'are not removed on rename', () => {
+				selection.setRanges( [ rangeInEmptyP ] );
+				selection.setAttribute( 'foo', 'bar' );
+
+				doc.batch().rename( emptyP, 'pnew' );
+
+				expect( emptyP.getAttribute( fooStoreAttrKey ) ).to.equal( 'bar' );
+			} );
 		} );
 	} );
 } );

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -9,7 +9,7 @@ import Text from '../../src/model/text';
 import Range from '../../src/model/range';
 import Position from '../../src/model/position';
 import LiveRange from '../../src/model/liverange';
-import LiveSelection from '../../src/model/liveselection';
+import DocumentSelection from '../../src/model/documentselection';
 import InsertOperation from '../../src/model/operation/insertoperation';
 import MoveOperation from '../../src/model/operation/moveoperation';
 import RemoveOperation from '../../src/model/operation/removeoperation';
@@ -25,7 +25,7 @@ import log from '@ckeditor/ckeditor5-utils/src/log';
 
 testUtils.createSinonSandbox();
 
-describe( 'LiveSelection', () => {
+describe( 'DocumentSelection', () => {
 	let doc, root, selection, liveRange, range;
 
 	beforeEach( () => {
@@ -374,14 +374,14 @@ describe( 'LiveSelection', () => {
 	} );
 
 	describe( 'createFromSelection()', () => {
-		it( 'should return a LiveSelection instance', () => {
+		it( 'should return a DocumentSelection instance', () => {
 			selection.addRange( range, true );
 
-			expect( LiveSelection.createFromSelection( selection ) ).to.be.instanceof( LiveSelection );
+			expect( DocumentSelection.createFromSelection( selection ) ).to.be.instanceof( DocumentSelection );
 		} );
 	} );
 
-	// LiveSelection uses LiveRanges so here are only simple test to see if integration is
+	// DocumentSelection uses LiveRanges so here are only simple test to see if integration is
 	// working well, without getting into complicated corner cases.
 	describe( 'after applying an operation should get updated and fire events', () => {
 		let spyRange;
@@ -698,7 +698,7 @@ describe( 'LiveSelection', () => {
 
 				expect( selection.getAttribute( 'foo' ) ).to.equal( 'bar' );
 
-				expect( emptyP.getAttribute( LiveSelection._getStoreAttributeKey( 'foo' ) ) ).to.equal( 'bar' );
+				expect( emptyP.getAttribute( DocumentSelection._getStoreAttributeKey( 'foo' ) ) ).to.equal( 'bar' );
 			} );
 		} );
 
@@ -735,8 +735,8 @@ describe( 'LiveSelection', () => {
 				expect( selection.getAttribute( 'foo' ) ).to.equal( 'bar' );
 				expect( selection.getAttribute( 'abc' ) ).to.be.undefined;
 
-				expect( emptyP.getAttribute( LiveSelection._getStoreAttributeKey( 'foo' ) ) ).to.equal( 'bar' );
-				expect( emptyP.hasAttribute( LiveSelection._getStoreAttributeKey( 'abc' ) ) ).to.be.false;
+				expect( emptyP.getAttribute( DocumentSelection._getStoreAttributeKey( 'foo' ) ) ).to.equal( 'bar' );
+				expect( emptyP.hasAttribute( DocumentSelection._getStoreAttributeKey( 'abc' ) ) ).to.be.false;
 			} );
 		} );
 
@@ -748,7 +748,7 @@ describe( 'LiveSelection', () => {
 
 				expect( selection.getAttribute( 'foo' ) ).to.be.undefined;
 
-				expect( fullP.hasAttribute( LiveSelection._getStoreAttributeKey( 'foo' ) ) ).to.be.false;
+				expect( fullP.hasAttribute( DocumentSelection._getStoreAttributeKey( 'foo' ) ) ).to.be.false;
 			} );
 
 			it( 'should remove stored attribute if the selection is in empty node', () => {
@@ -758,7 +758,7 @@ describe( 'LiveSelection', () => {
 
 				expect( selection.getAttribute( 'foo' ) ).to.be.undefined;
 
-				expect( emptyP.hasAttribute( LiveSelection._getStoreAttributeKey( 'foo' ) ) ).to.be.false;
+				expect( emptyP.hasAttribute( DocumentSelection._getStoreAttributeKey( 'foo' ) ) ).to.be.false;
 			} );
 		} );
 
@@ -773,8 +773,8 @@ describe( 'LiveSelection', () => {
 				expect( selection.getAttribute( 'foo' ) ).to.be.undefined;
 				expect( selection.getAttribute( 'abc' ) ).to.be.undefined;
 
-				expect( emptyP.hasAttribute( LiveSelection._getStoreAttributeKey( 'foo' ) ) ).to.be.false;
-				expect( emptyP.hasAttribute( LiveSelection._getStoreAttributeKey( 'abc' ) ) ).to.be.false;
+				expect( emptyP.hasAttribute( DocumentSelection._getStoreAttributeKey( 'foo' ) ) ).to.be.false;
+				expect( emptyP.hasAttribute( DocumentSelection._getStoreAttributeKey( 'abc' ) ) ).to.be.false;
 			} );
 		} );
 
@@ -893,7 +893,7 @@ describe( 'LiveSelection', () => {
 			it( 'ignores attributes inside an object if selection contains that object', () => {
 				setData( doc, '<p>[<image><$text bold="true">Caption for the image.</$text></image>]</p>' );
 
-				const liveSelection = LiveSelection.createFromSelection( selection );
+				const liveSelection = DocumentSelection.createFromSelection( selection );
 
 				expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
 			} );
@@ -901,7 +901,7 @@ describe( 'LiveSelection', () => {
 			it( 'ignores attributes inside an object if selection contains that object (deeper structure)', () => {
 				setData( doc, '<p>[<image><caption><$text bold="true">Caption for the image.</$text></caption></image>]</p>' );
 
-				const liveSelection = LiveSelection.createFromSelection( selection );
+				const liveSelection = DocumentSelection.createFromSelection( selection );
 
 				expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
 			} );
@@ -909,7 +909,7 @@ describe( 'LiveSelection', () => {
 			it( 'ignores attributes inside an object if selection contains that object (block level)', () => {
 				setData( doc, '<p>foo</p>[<image><$text bold="true">Caption for the image.</$text></image>]<p>foo</p>' );
 
-				const liveSelection = LiveSelection.createFromSelection( selection );
+				const liveSelection = DocumentSelection.createFromSelection( selection );
 
 				expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
 			} );
@@ -917,7 +917,7 @@ describe( 'LiveSelection', () => {
 			it( 'reads attributes from text even if the selection contains an object', () => {
 				setData( doc, '<p>x<$text bold="true">[bar</$text><image></image>foo]</p>' );
 
-				const liveSelection = LiveSelection.createFromSelection( selection );
+				const liveSelection = DocumentSelection.createFromSelection( selection );
 
 				expect( liveSelection.getAttribute( 'bold' ) ).to.equal( true );
 			} );
@@ -925,7 +925,7 @@ describe( 'LiveSelection', () => {
 			it( 'reads attributes when the entire selection inside an object', () => {
 				setData( doc, '<p><image><caption><$text bold="true">[bar]</$text></caption></image></p>' );
 
-				const liveSelection = LiveSelection.createFromSelection( selection );
+				const liveSelection = DocumentSelection.createFromSelection( selection );
 
 				expect( liveSelection.getAttribute( 'bold' ) ).to.equal( true );
 			} );
@@ -933,7 +933,7 @@ describe( 'LiveSelection', () => {
 			it( 'stops reading attributes if selection starts with an object', () => {
 				setData( doc, '<p>[<image></image><$text bold="true">bar]</$text></p>' );
 
-				const liveSelection = LiveSelection.createFromSelection( selection );
+				const liveSelection = DocumentSelection.createFromSelection( selection );
 
 				expect( liveSelection.hasAttribute( 'bold' ) ).to.equal( false );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Attributes which selection stores in elements should be removed once they are not empty any more. Closes #1001.

---

### Additional information

I marked this change as internal as it should invisible to the developers.

In this PR I also changed `LiveSelection` to `DocumentSelection` which is kinda internal change as well as this class is not meant to be used directly.
