### PR TITLE
T/1014 view.Renderer does not create inline filler in newly created DOM elements

### DIFF
--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -252,7 +252,6 @@ export default class DomConverter {
 		let offset = 0;
 
 		for ( const childView of viewElement.getChildren() ) {
-			// debugger;
 			if ( blockFillerOffset === offset ) {
 				yield this.blockFiller( domDocument );
 			}

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -16,7 +16,10 @@ import ViewRange from './range';
 import ViewSelection from './selection';
 import ViewDocumentFragment from './documentfragment';
 import ViewTreeWalker from './treewalker';
-import { BR_FILLER, INLINE_FILLER_LENGTH, isBlockFiller, isInlineFiller, startsWithFiller, getDataWithoutFiller } from './filler';
+import {
+	BR_FILLER, INLINE_FILLER, INLINE_FILLER_LENGTH, isBlockFiller,
+	isInlineFiller, startsWithFiller, getDataWithoutFiller
+} from './filler';
 
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import indexOf from '@ckeditor/ckeditor5-utils/src/dom/indexof';
@@ -177,7 +180,8 @@ export default class DomConverter {
 	 * @param {Document} domDocument Document which will be used to create DOM nodes.
 	 * @param {Object} [options] Conversion options.
 	 * @param {Boolean} [options.bind=false] Determines whether new elements will be bound.
-	 * @param {Boolean} [options.withChildren=true] If true node's and document fragment's children  will be converted too.
+	 * @param {Boolean} [options.withChildren=true] If true node's and document fragment's children will be converted too.
+	 * @param {module:engine/view/position~Position|null} [options.inlineFiller=null] Position where inline filler should be inserted.
 	 * @returns {Node|DocumentFragment} Converted node or DocumentFragment.
 	 */
 	viewToDom( viewNode, domDocument, options = {} ) {
@@ -243,21 +247,41 @@ export default class DomConverter {
 	 * @returns {Iterable.<Node>} DOM nodes.
 	 */
 	* viewChildrenToDom( viewElement, domDocument, options = {} ) {
-		const fillerPositionOffset = viewElement.getFillerOffset && viewElement.getFillerOffset();
+		const blockFillerOffset = viewElement.getFillerOffset && viewElement.getFillerOffset();
+		const inlineFillerOffset = options.inlineFiller && options.inlineFiller.parent == viewElement ? options.inlineFiller.offset : null;
 		let offset = 0;
 
 		for ( const childView of viewElement.getChildren() ) {
-			if ( fillerPositionOffset === offset ) {
+			// debugger;
+			if ( blockFillerOffset === offset ) {
 				yield this.blockFiller( domDocument );
 			}
 
-			yield this.viewToDom( childView, domDocument, options );
+			const domNode = this.viewToDom( childView, domDocument, options );
+
+			// We need to insert inline filler before the dom node.
+			if ( inlineFillerOffset === offset ) {
+				// If dom node that was about to return is a text node, just add inline filler to that text node.
+				if ( this.isText( domNode ) ) {
+					domNode.data = INLINE_FILLER + domNode.data;
+				}
+				// Otherwise, return text node with inline filler.
+				else {
+					yield domDocument.createTextNode( INLINE_FILLER );
+				}
+			}
+
+			yield domNode;
 
 			offset++;
 		}
 
-		if ( fillerPositionOffset === offset ) {
+		if ( blockFillerOffset === offset ) {
 			yield this.blockFiller( domDocument );
+		}
+
+		if ( inlineFillerOffset === offset ) {
+			yield domDocument.createTextNode( INLINE_FILLER );
 		}
 	}
 

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -445,19 +445,10 @@ export default class Renderer {
 		}
 
 		const domDocument = domElement.ownerDocument;
-		const filler = options.inlineFillerPosition;
 		const actualDomChildren = domElement.childNodes;
-		const expectedDomChildren = Array.from( domConverter.viewChildrenToDom( viewElement, domDocument, { bind: true } ) );
-
-		if ( filler && filler.parent == viewElement ) {
-			const expectedNodeAfterFiller = expectedDomChildren[ filler.offset ];
-
-			if ( this.domConverter.isText( expectedNodeAfterFiller ) ) {
-				expectedNodeAfterFiller.data = INLINE_FILLER + expectedNodeAfterFiller.data;
-			} else {
-				expectedDomChildren.splice( filler.offset, 0, domDocument.createTextNode( INLINE_FILLER ) );
-			}
-		}
+		const expectedDomChildren = Array.from(
+			domConverter.viewChildrenToDom( viewElement, domDocument, { bind: true, inlineFiller: options.inlineFillerPosition } )
+		);
 
 		const actions = diff( actualDomChildren, expectedDomChildren, sameNodes );
 

--- a/tests/view/domconverter/view-to-dom.js
+++ b/tests/view/domconverter/view-to-dom.js
@@ -366,7 +366,7 @@ describe( 'DomConverter', () => {
 			expect( domChildren[ 1 ].childNodes.length ).to.equal( 1 );
 		} );
 
-		it( 'should add filler', () => {
+		it( 'should add block filler', () => {
 			const viewP = parse( '<container:p></container:p>' );
 
 			const domChildren = Array.from( converter.viewChildrenToDom( viewP, document ) );
@@ -375,7 +375,7 @@ describe( 'DomConverter', () => {
 			expect( isBlockFiller( domChildren[ 0 ], converter.blockFiller ) ).to.be.true;
 		} );
 
-		it( 'should add filler according to fillerPositionOffset', () => {
+		it( 'should add block filler according to fillerPositionOffset', () => {
 			const viewP = parse( '<container:p>foo</container:p>' );
 			viewP.getFillerOffset = () => 0;
 
@@ -384,6 +384,20 @@ describe( 'DomConverter', () => {
 			expect( domChildren.length ).to.equal( 2 );
 			expect( isBlockFiller( domChildren[ 0 ], converter.blockFiller ) ).to.be.true;
 			expect( domChildren[ 1 ].data ).to.equal( 'foo' );
+		} );
+
+		it( 'should add inline filler according to options.inlineFiller', () => {
+			const view = parse(
+				'<container:div><container:p>Foo</container:p><container:p><attribute:b></attribute:b>foo</container:p></container:div>'
+			);
+
+			const viewB = view.getChild( 1 ).getChild( 0 );
+			const inlineFiller = new ViewPosition( viewB, 0 );
+
+			const domChildren = Array.from( converter.viewChildrenToDom( view, document, { inlineFiller } ) );
+			const domFiller = domChildren[ 1 ].childNodes[ 0 ].childNodes[ 0 ];
+
+			expect( domFiller.data ).to.equal( INLINE_FILLER );
 		} );
 
 		it( 'should pass options', () => {

--- a/tests/view/position.js
+++ b/tests/view/position.js
@@ -594,6 +594,14 @@ describe( 'Position', () => {
 			test( firstPosition, secondPosition, section );
 		} );
 
+		it( 'for two positions in different trees returns null', () => {
+			const div = new Element( 'div' );
+			const posInDiv = new Position( div, 0 );
+			const firstPosition = new Position( liOl2, 10 );
+
+			test( posInDiv, firstPosition, null );
+		} );
+
 		function test( positionA, positionB, lca ) {
 			expect( positionA.getCommonAncestor( positionB ) ).to.equal( lca );
 			expect( positionB.getCommonAncestor( positionA ) ).to.equal( lca );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -7,6 +7,7 @@
 
 import ViewDocument from '../../src/view/document';
 import ViewElement from '../../src/view/element';
+import ViewContainerElement from '../../src/view/containerelement';
 import ViewAttributeElement from '../../src/view/attributeelement';
 import ViewText from '../../src/view/text';
 import ViewRange from '../../src/view/range';
@@ -1214,6 +1215,40 @@ describe( 'Renderer', () => {
 			expect( () => {
 				renderer.render();
 			} ).to.throw( CKEditorError, /^view-renderer-filler-was-lost/ );
+		} );
+
+		// #1014.
+		it( 'should create inline filler in newly created dom nodes', () => {
+			// 1. Create the view structure which needs inline filler.
+			const inputView =
+				'<container:ul>' +
+					'<container:li>Foobar.</container:li>' +
+					'<container:li>[]<container:div></container:div></container:li>' +
+				'</container:ul>';
+
+			const { view: view, selection: newSelection } = parse( inputView );
+
+			viewRoot.appendChildren( view );
+			selection.setTo( newSelection );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			// 2. Check if filler element has been (correctly) created.
+			expect( domRoot.innerHTML.indexOf( INLINE_FILLER ) ).not.to.equal( -1 );
+
+			// 3. Move the inline filler parent to a newly created element.
+			const viewLi = view.getChild( 0 );
+			const viewLiIndented = view.removeChildren( 1, 1 ); // Array with one element.
+			const viewUl = new ViewContainerElement( 'ul', null, viewLiIndented );
+			viewLi.appendChildren( viewUl );
+
+			// 4. Mark changed items and render the view.
+			renderer.markToSync( 'children', view );
+			renderer.markToSync( 'children', viewLi );
+			renderer.render();
+
+			expect( domRoot.innerHTML.indexOf( INLINE_FILLER ) ).not.to.equal( -1 );
 		} );
 
 		it( 'should handle focusing element', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Inline filler will be correctly inserted if it is deep in a newly created view structure that is just converted to DOM. Closes #1014.