### PR TITLE
T/1012: Handles with a paragraph when the entire content was removed

### DIFF
--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -206,7 +206,8 @@ function shouldEntireContentBeReplacedWithParagraph( schema, selection ) {
 	const limitStartPosition = Position.createAt( limitElement );
 	const limitEndPosition = Position.createAt( limitElement, 'end' );
 
-	if ( !limitStartPosition.isTouching( selection.getFirstPosition() ) ||
+	if (
+		!limitStartPosition.isTouching( selection.getFirstPosition() ) ||
 		!limitEndPosition.isTouching( selection.getLastPosition() )
 	) {
 		return false;

--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -32,7 +32,7 @@ export default function deleteContent( selection, batch, options = {} ) {
 		return;
 	}
 
-	// 0. Replace the entire content with paragraph.
+	// 1. Replace the entire content with paragraph.
 	// See: https://github.com/ckeditor/ckeditor5-engine/issues/1012#issuecomment-315017594.
 	if ( shouldEntireContentBeReplacedWithParagraph( batch.document.schema, selection ) ) {
 		replaceEntireContentWithParagraph( batch, selection );
@@ -44,12 +44,12 @@ export default function deleteContent( selection, batch, options = {} ) {
 	const startPos = selRange.start;
 	const endPos = LivePosition.createFromPosition( selRange.end );
 
-	// 1. Remove the content if there is any.
+	// 2. Remove the content if there is any.
 	if ( !selRange.start.isTouching( selRange.end ) ) {
 		batch.remove( selRange );
 	}
 
-	// 2. Merge elements in the right branch to the elements in the left branch.
+	// 3. Merge elements in the right branch to the elements in the left branch.
 	// The only reasonable (in terms of data and selection correctness) case in which we need to do that is:
 	//
 	// <heading type=1>Fo[</heading><paragraph>]ar</paragraph> => <heading type=1>Fo^ar</heading>
@@ -63,7 +63,7 @@ export default function deleteContent( selection, batch, options = {} ) {
 
 	selection.collapse( startPos );
 
-	// 3. Autoparagraphing.
+	// 4. Autoparagraphing.
 	// Check if a text is allowed in the new container. If not, try to create a new paragraph (if it's allowed here).
 	if ( shouldAutoparagraph( batch.document, startPos ) ) {
 		insertParagraph( batch, startPos, selection );

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -83,6 +83,8 @@ export default class Schema {
 		this.allow( { name: '$block', inside: '$root' } );
 		this.allow( { name: '$inline', inside: '$block' } );
 
+		this.limits.add( '$root' );
+
 		// TMP!
 		// Create an "all allowed" context in the schema for processing the pasted content.
 		// Read: https://github.com/ckeditor/ckeditor5-engine/issues/638#issuecomment-255086588

--- a/tests/controller/deletecontent.js
+++ b/tests/controller/deletecontent.js
@@ -233,6 +233,12 @@ describe( 'DataController', () => {
 				'<heading1>f[]</heading1><paragraph>x</paragraph>'
 			);
 
+			test(
+				'leaves just one element when all selected',
+				'<heading1>[x</heading1><paragraph>foo</paragraph><paragraph>y]bar</paragraph>',
+				'<heading1>[]bar</heading1>'
+			);
+
 			it( 'uses remove delta instead of merge delta if merged element is empty', () => {
 				setData( doc, '<paragraph>ab[cd</paragraph><paragraph>efgh]</paragraph>' );
 
@@ -696,6 +702,12 @@ describe( 'DataController', () => {
 			test(
 				'when the entire heading and paragraph were selected',
 				'<heading1>[xx</heading1><paragraph>yy]</paragraph>',
+				'<paragraph>[]</paragraph>'
+			);
+
+			test(
+				'when the entire content was selected',
+				'<heading1>[x</heading1><paragraph>foo</paragraph><paragraph>y]</paragraph>',
 				'<paragraph>[]</paragraph>'
 			);
 

--- a/tests/model/schema/schema.js
+++ b/tests/model/schema/schema.js
@@ -49,7 +49,7 @@ describe( 'Schema', () => {
 			expect( schema.limits ).to.be.instanceOf( Set );
 		} );
 
-		it( 'should have defined the limits elements', () => {
+		it( 'should mark $root as a limit element', () => {
 			expect( schema.limits.has( '$root' ) ).to.be.true;
 		} );
 

--- a/tests/model/schema/schema.js
+++ b/tests/model/schema/schema.js
@@ -49,6 +49,10 @@ describe( 'Schema', () => {
 			expect( schema.limits ).to.be.instanceOf( Set );
 		} );
 
+		it( 'should have defined the limits elements', () => {
+			expect( schema.limits.has( '$root' ) ).to.be.true;
+		} );
+
 		describe( '$clipboardHolder', () => {
 			it( 'should allow $block', () => {
 				expect( schema.check( { name: '$block', inside: [ '$clipboardHolder' ] } ) ).to.be.true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `DataController#deleteContent` will leave a paragraph if the entire content was selected and removed. Closes #1012.

On the occasion `$root` element has been as a limit element in Schema in order to simplify the checks.

---

### Additional information

Branch [`t/ckeditor5-engine/1012`](https://github.com/ckeditor/ckeditor5-enter/compare/master...t/ckeditor5-engine/1012) in `ckeditor5-enter` should be merged along with this PR.