### PR TITLE
Hide caret when an editor is read-only.

### DIFF
--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -23,11 +23,15 @@ import {
 } from '../conversion/model-selection-to-view-converters';
 
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
 /**
  * Controller for the editing pipeline. The editing pipeline controls {@link ~EditingController#model model} rendering,
  * including selection handling. It also creates {@link ~EditingController#view view document} which build a
  * browser-independent virtualization over the DOM elements. Editing controller also attach default converters.
+ *
+ * @mixes module:utils/observablemixin~ObservableMixin
  */
 export default class EditingController {
 	/**
@@ -161,3 +165,5 @@ export default class EditingController {
 		this._listener.stopListening();
 	}
 }
+
+mix( EditingController, ObservableMixin );

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -64,6 +64,20 @@ export default class EditingController {
 		this.mapper = new Mapper();
 
 		/**
+		 * Defines whether controller is in read-only mode.
+		 *
+		 * When controller is read-ony {module:engine/view/document~Document view document} and all view roots
+		 * are read-only as well.
+		 *
+		 * @observable
+		 * @member {Boolean} #isReadOnly
+		 */
+		this.set( 'isReadOnly', false );
+
+		// When controller is read-only the view document is read-only as well.
+		this.view.bind( 'isReadOnly' ).to( this );
+
+		/**
 		 * Model to view conversion dispatcher, which converts changes from the model to
 		 * {@link #view editing view}.
 		 *
@@ -142,6 +156,9 @@ export default class EditingController {
 		const modelRoot = this.model.getRoot( name );
 
 		this.mapper.bindElements( modelRoot, viewRoot );
+
+		// When controller is read-only the all view roots are read-only as well.
+		viewRoot.bind( 'isReadOnly' ).to( this );
 
 		return viewRoot;
 	}

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -66,8 +66,7 @@ export default class EditingController {
 		/**
 		 * Defines whether controller is in read-only mode.
 		 *
-		 * When controller is read-ony {module:engine/view/document~Document view document} and all view roots
-		 * are read-only as well.
+		 * When controller is read-ony then {module:engine/view/document~Document view document} is read-only as well.
 		 *
 		 * @observable
 		 * @member {Boolean} #isReadOnly
@@ -156,9 +155,6 @@ export default class EditingController {
 		const modelRoot = this.model.getRoot( name );
 
 		this.mapper.bindElements( modelRoot, viewRoot );
-
-		// When controller is read-only the all view roots are read-only as well.
-		viewRoot.bind( 'isReadOnly' ).to( this );
 
 		return viewRoot;
 	}

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -22,7 +22,6 @@ import {
 	clearFakeSelection
 } from '../conversion/model-selection-to-view-converters';
 
-import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
@@ -84,22 +83,13 @@ export default class EditingController {
 			viewSelection: this.view.selection
 		} );
 
-		/**
-		 * Property keeping all listenters attached by controller on other objects, so it can
-		 * stop listening on {@link #destroy}.
-		 *
-		 * @private
-		 * @member {utils.EmitterMixin} #_listener
-		 */
-		this._listener = Object.create( EmitterMixin );
-
 		// Convert changes in model to view.
-		this._listener.listenTo( this.model, 'change', ( evt, type, changes ) => {
+		this.listenTo( this.model, 'change', ( evt, type, changes ) => {
 			this.modelToView.convertChange( type, changes );
 		}, { priority: 'low' } );
 
 		// Convert model selection to view.
-		this._listener.listenTo( this.model, 'changesDone', () => {
+		this.listenTo( this.model, 'changesDone', () => {
 			const selection = this.model.selection;
 
 			this.modelToView.convertSelection( selection );
@@ -107,16 +97,16 @@ export default class EditingController {
 		}, { priority: 'low' } );
 
 		// Convert model markers changes.
-		this._listener.listenTo( this.model.markers, 'add', ( evt, marker ) => {
+		this.listenTo( this.model.markers, 'add', ( evt, marker ) => {
 			this.modelToView.convertMarker( 'addMarker', marker.name, marker.getRange() );
 		} );
 
-		this._listener.listenTo( this.model.markers, 'remove', ( evt, marker ) => {
+		this.listenTo( this.model.markers, 'remove', ( evt, marker ) => {
 			this.modelToView.convertMarker( 'removeMarker', marker.name, marker.getRange() );
 		} );
 
 		// Convert view selection to model.
-		this._listener.listenTo( this.view, 'selectionChange', convertSelectionChange( this.model, this.mapper ) );
+		this.listenTo( this.view, 'selectionChange', convertSelectionChange( this.model, this.mapper ) );
 
 		// Attach default content converters.
 		this.modelToView.on( 'insert:$text', insertText(), { priority: 'lowest' } );
@@ -162,7 +152,7 @@ export default class EditingController {
 	 */
 	destroy() {
 		this.view.destroy();
-		this._listener.stopListening();
+		this.stopListening();
 	}
 }
 

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -80,6 +80,16 @@ export default class Document {
 		this.roots = new Map();
 
 		/**
+		 * Defines whether document is in read-only mode.
+		 *
+		 * When document is read-ony then all roots are read-only as well and caret placed inside this root is hidden.
+		 *
+		 * @observable
+		 * @member {Boolean} #isReadOnly
+		 */
+		this.set( 'isReadOnly', false );
+
+		/**
 		 * True if document is focused.
 		 *
 		 * This property is updated by the {@link module:engine/view/observer/focusobserver~FocusObserver}.

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -108,7 +108,7 @@ export default class Document {
 		 * @member {module:engine/view/renderer~Renderer} module:engine/view/document~Document#renderer
 		 */
 		this.renderer = new Renderer( this.domConverter, this.selection );
-		this.renderer.bind( 'isFocused' ).to( this, 'isFocused' );
+		this.renderer.bind( 'isFocused' ).to( this );
 
 		/**
 		 * Map of registered {@link module:engine/view/observer/observer~Observer observers}.

--- a/src/view/editableelement.js
+++ b/src/view/editableelement.js
@@ -74,6 +74,8 @@ export default class EditableElement extends ContainerElement {
 
 		this.setCustomProperty( documentSymbol, document );
 
+		this.bind( 'isReadOnly' ).to( document );
+
 		this.bind( 'isFocused' ).to(
 			document,
 			'isFocused',

--- a/src/view/editableelement.js
+++ b/src/view/editableelement.js
@@ -18,8 +18,10 @@ const documentSymbol = Symbol( 'document' );
  * Editable element which can be a {@link module:engine/view/rooteditableelement~RootEditableElement root}
  * or nested editable area in the editor.
  *
+ * Editable is automatically read-only when its {module:engine/view/document~Document Document} is read-only.
+ *
  * @extends module:engine/view/containerelement~ContainerElement
- * @mixes module:utils/observablemixin~ObservaleMixin
+ * @mixes module:utils/observablemixin~ObservableMixin
  */
 export default class EditableElement extends ContainerElement {
 	/**

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -133,7 +133,7 @@ export default class SelectionObserver extends Observer {
 	 * @param {Document} domDocument DOM document.
 	 */
 	_handleSelectionChange( domDocument ) {
-		if ( !this.isEnabled || !this.document.isFocused ) {
+		if ( !this.isEnabled || ( !this.document.isFocused && !this.document.isReadOnly ) ) {
 			return;
 		}
 

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -133,6 +133,9 @@ export default class SelectionObserver extends Observer {
 	 * @param {Document} domDocument DOM document.
 	 */
 	_handleSelectionChange( domDocument ) {
+		// Selection is handled when document is not focused but is read-only. This is because in read-only
+		// mode contenteditable is set as false and editor won't receive focus but we still need to know
+		// selection position.
 		if ( !this.isEnabled || ( !this.document.isFocused && !this.document.isReadOnly ) ) {
 			return;
 		}

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -53,7 +53,7 @@ describe( 'EditingController', () => {
 		} );
 	} );
 
-	describe( 'createRoot', () => {
+	describe( 'createRoot()', () => {
 		let model, modelRoot, editing;
 
 		beforeEach( () => {
@@ -388,7 +388,7 @@ describe( 'EditingController', () => {
 		} );
 	} );
 
-	describe( 'destroy', () => {
+	describe( 'destroy()', () => {
 		it( 'should remove listenters', () => {
 			const model = new ModelDocument();
 			model.createRoot();

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -29,27 +29,44 @@ import { getData as getViewData } from '../../src/dev-utils/view';
 
 describe( 'EditingController', () => {
 	describe( 'constructor()', () => {
-		it( 'should create controller with properties', () => {
-			const model = new ModelDocument();
-			const editing = new EditingController( model );
+		let model, editing;
 
+		beforeEach( () => {
+			model = new ModelDocument();
+			editing = new EditingController( model );
+		} );
+
+		afterEach( () => {
+			editing.destroy();
+		} );
+
+		it( 'should create controller with properties', () => {
 			expect( editing ).to.have.property( 'model' ).that.equals( model );
 			expect( editing ).to.have.property( 'view' ).that.is.instanceof( ViewDocument );
 			expect( editing ).to.have.property( 'mapper' ).that.is.instanceof( Mapper );
 			expect( editing ).to.have.property( 'modelToView' ).that.is.instanceof( ModelConversionDispatcher );
+			expect( editing ).to.have.property( 'isReadOnly' ).that.is.false;
 
 			editing.destroy();
 		} );
 
 		it( 'should be observable', () => {
-			const model = new ModelDocument();
-			const editing = new EditingController( model );
 			const spy = sinon.spy();
 
 			editing.on( 'change:foo', spy );
 			editing.set( 'foo', 'bar' );
 
 			sinon.assert.calledOnce( spy );
+		} );
+
+		it( 'should bind view#isReadOnly to controller#isReadOnly', () => {
+			editing.isReadOnly = false;
+
+			expect( editing.view.isReadOnly ).to.false;
+
+			editing.isReadOnly = true;
+
+			expect( editing.view.isReadOnly ).to.true;
 		} );
 	} );
 
@@ -116,6 +133,19 @@ describe( 'EditingController', () => {
 
 			expect( editing.mapper.toModelElement( viewRoot ) ).to.equal( modelRoot );
 			expect( editing.mapper.toViewElement( modelRoot ) ).to.equal( viewRoot );
+		} );
+
+		it( 'should bind root#isReadOnly to controller#isReadOnly', () => {
+			const domRoot = createElement( document, 'div', null, createElement( document, 'p' ) );
+			const viewRoot = editing.createRoot( domRoot );
+
+			editing.isReadOnly = false;
+
+			expect( viewRoot.isReadOnly ).to.false;
+
+			editing.isReadOnly = true;
+
+			expect( viewRoot.isReadOnly ).to.true;
 		} );
 	} );
 

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -40,6 +40,17 @@ describe( 'EditingController', () => {
 
 			editing.destroy();
 		} );
+
+		it( 'should be observable', () => {
+			const model = new ModelDocument();
+			const editing = new EditingController( model );
+			const spy = sinon.spy();
+
+			editing.on( 'change:foo', spy );
+			editing.set( 'foo', 'bar' );
+
+			sinon.assert.calledOnce( spy );
+		} );
 	} );
 
 	describe( 'createRoot', () => {

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -134,19 +134,6 @@ describe( 'EditingController', () => {
 			expect( editing.mapper.toModelElement( viewRoot ) ).to.equal( modelRoot );
 			expect( editing.mapper.toViewElement( modelRoot ) ).to.equal( viewRoot );
 		} );
-
-		it( 'should bind root#isReadOnly to controller#isReadOnly', () => {
-			const domRoot = createElement( document, 'div', null, createElement( document, 'p' ) );
-			const viewRoot = editing.createRoot( domRoot );
-
-			editing.isReadOnly = false;
-
-			expect( viewRoot.isReadOnly ).to.false;
-
-			editing.isReadOnly = true;
-
-			expect( viewRoot.isReadOnly ).to.true;
-		} );
 	} );
 
 	describe( 'conversion', () => {

--- a/tests/view/_utils/createdocumentmock.js
+++ b/tests/view/_utils/createdocumentmock.js
@@ -14,6 +14,7 @@ import Selection from '../../../src/view/selection';
 export default function createDocumentMock() {
 	const doc = Object.create( ObservableMixin );
 	doc.set( 'isFocused', false );
+	doc.set( 'isReadOnly', false );
 	doc.selection = new Selection();
 
 	return doc;

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -71,9 +71,10 @@ describe( 'Document', () => {
 		it( 'should create Document with all properties', () => {
 			expect( count( viewDocument.domRoots ) ).to.equal( 0 );
 			expect( count( viewDocument.roots ) ).to.equal( 0 );
-			expect( viewDocument ).to.have.property( 'renderer' ).that.is.instanceOf( Renderer );
-			expect( viewDocument ).to.have.property( 'domConverter' ).that.is.instanceOf( DomConverter );
-			expect( viewDocument ).to.have.property( 'isFocused' ).that.is.false;
+			expect( viewDocument ).to.have.property( 'renderer' ).to.instanceOf( Renderer );
+			expect( viewDocument ).to.have.property( 'domConverter' ).to.instanceOf( DomConverter );
+			expect( viewDocument ).to.have.property( 'isReadOnly' ).to.false;
+			expect( viewDocument ).to.have.property( 'isFocused' ).to.false;
 		} );
 
 		it( 'should add default observers', () => {

--- a/tests/view/editableelement.js
+++ b/tests/view/editableelement.js
@@ -151,6 +151,19 @@ describe( 'EditableElement', () => {
 
 			expect( isReadOnlySpy.calledOnce ).to.be.true;
 		} );
+
+		it( 'should be bound to the document#isReadOnly', () => {
+			const root = new RootEditableElement( 'div' );
+			root.document = createDocumentMock();
+
+			root.document.isReadOnly = false;
+
+			expect( root.isReadOnly ).to.false;
+
+			root.document.isReadOnly = true;
+
+			expect( root.isReadOnly ).to.true;
+		} );
 	} );
 
 	describe( 'getDocument', () => {

--- a/tests/view/observer/selectionobserver.js
+++ b/tests/view/observer/selectionobserver.js
@@ -134,6 +134,26 @@ describe( 'SelectionObserver', () => {
 		changeDomSelection();
 	} );
 
+	it( 'should fired if there is no focus but document is read-only', done => {
+		const spy = sinon.spy();
+
+		viewDocument.isFocused = false;
+		viewDocument.isReadOnly = true;
+
+		// changeDomSelection() may focus the editable element (happens on Chrome)
+		// so cancel this because it sets the isFocused flag.
+		viewDocument.on( 'focus', evt => evt.stop(), { priority: 'highest' } );
+
+		viewDocument.on( 'selectionChange', spy );
+
+		setTimeout( () => {
+			sinon.assert.calledOnce( spy );
+			done();
+		}, 70 );
+
+		changeDomSelection();
+	} );
+
 	it( 'should warn and not enter infinite loop', () => {
 		// Selectionchange event is called twice per `changeDomSelection()` execution.
 		let counter = 35;

--- a/tests/view/utils-tests/createdocumentmock.js
+++ b/tests/view/utils-tests/createdocumentmock.js
@@ -6,19 +6,26 @@
 import createDocumentMock from '../../../tests/view/_utils/createdocumentmock';
 
 describe( 'createDocumentMock', () => {
-	it( 'should create document mock', done => {
+	it( 'should create document mock', () => {
 		const docMock = createDocumentMock();
 		const rootMock = {};
+
+		const isFocusedSpy = sinon.spy();
+		const isReadOnlySpy = sinon.spy();
 
 		docMock.on( 'change:selectedEditable', ( evt, key, value ) => {
 			expect( value ).to.equal( rootMock );
 		} );
 
-		docMock.on( 'change:isFocused', ( evt, key, value ) => {
-			expect( value ).to.be.true;
-			done();
-		} );
+		docMock.on( 'change:isFocused', isFocusedSpy );
+		docMock.on( 'change:isReadOnly', isReadOnlySpy );
 
 		docMock.isFocused = true;
+		docMock.isReadOnly = true;
+
+		sinon.assert.calledOnce( isFocusedSpy );
+		expect( isFocusedSpy.lastCall.args[ 2 ] ).to.true;
+		sinon.assert.calledOnce( isReadOnlySpy );
+		expect( isReadOnlySpy.lastCall.args[ 2 ] ).to.true;
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Hide caret when an editor is read-only. `EditingControler` is observable from now. Observable property `isReadOnly` is added to the `ViewDocument` and `EditingController`. Closes #1024. Closes ckeditor/ckeditor5#503.

---

### Related:
- https://github.com/ckeditor/ckeditor5-widget/pull/8
- https://github.com/ckeditor/ckeditor5-core/pull/99
