### PR TITLE
Removed isReadOnly state from EditingController.

### DIFF
--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -64,19 +64,6 @@ export default class EditingController {
 		this.mapper = new Mapper();
 
 		/**
-		 * Defines whether controller is in read-only mode.
-		 *
-		 * When controller is read-ony then {module:engine/view/document~Document view document} is read-only as well.
-		 *
-		 * @observable
-		 * @member {Boolean} #isReadOnly
-		 */
-		this.set( 'isReadOnly', false );
-
-		// When controller is read-only the view document is read-only as well.
-		this.view.bind( 'isReadOnly' ).to( this );
-
-		/**
 		 * Model to view conversion dispatcher, which converts changes from the model to
 		 * {@link #view editing view}.
 		 *

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -45,7 +45,6 @@ describe( 'EditingController', () => {
 			expect( editing ).to.have.property( 'view' ).that.is.instanceof( ViewDocument );
 			expect( editing ).to.have.property( 'mapper' ).that.is.instanceof( Mapper );
 			expect( editing ).to.have.property( 'modelToView' ).that.is.instanceof( ModelConversionDispatcher );
-			expect( editing ).to.have.property( 'isReadOnly' ).that.is.false;
 
 			editing.destroy();
 		} );
@@ -57,16 +56,6 @@ describe( 'EditingController', () => {
 			editing.set( 'foo', 'bar' );
 
 			sinon.assert.calledOnce( spy );
-		} );
-
-		it( 'should bind view#isReadOnly to controller#isReadOnly', () => {
-			editing.isReadOnly = false;
-
-			expect( editing.view.isReadOnly ).to.false;
-
-			editing.isReadOnly = true;
-
-			expect( editing.view.isReadOnly ).to.true;
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Removed `isReadOnly` state from `EditingController`. Closes #1028.

---

Related https://github.com/ckeditor/ckeditor5-core/pull/100.