### PR TITLE
T/1020 Fixes for placeholder with UI element and selection.

### DIFF
--- a/src/conversion/view-selection-to-model-converters.js
+++ b/src/conversion/view-selection-to-model-converters.js
@@ -39,10 +39,8 @@ export function convertSelectionChange( modelDocument, mapper ) {
 
 		modelSelection.setRanges( ranges, viewSelection.isBackward );
 
-		if ( !modelSelection.isEqual( modelDocument.selection ) ) {
-			modelDocument.enqueueChanges( () => {
-				modelDocument.selection.setTo( modelSelection );
-			} );
-		}
+		modelDocument.enqueueChanges( () => {
+			modelDocument.selection.setTo( modelSelection );
+		} );
 	};
 }

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -148,7 +148,7 @@ export default class SelectionObserver extends Observer {
 		const domSelection = domDocument.defaultView.getSelection();
 		const newViewSelection = this.domConverter.domSelectionToView( domSelection );
 
-		if ( this.selection.isEqual( newViewSelection ) ) {
+		if ( this.selection.isEqual( newViewSelection ) && this.domConverter.isCorrectDomSelection( domSelection ) ) {
 			return;
 		}
 

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -602,24 +602,27 @@ export default class Renderer {
 	 */
 	_updateDomSelection( domRoot ) {
 		const domSelection = domRoot.ownerDocument.defaultView.getSelection();
-		const oldViewSelection = domSelection && this.domConverter.domSelectionToView( domSelection );
 
-		if ( oldViewSelection && this.selection.isEqual( oldViewSelection ) ) {
-			return;
-		}
+		// Check whether dom selection needs fixing. If it does not need fixing maybe w don't have to update it at all.
+		if ( this.domConverter.isCorrectDomSelection( domSelection ) ) {
+			const viewSelectionFromDom = this.domConverter.domSelectionToView( domSelection );
 
-		if ( oldViewSelection && areSimilarSelections( oldViewSelection, this.selection ) ) {
-			const data = {
-				oldSelection: oldViewSelection,
-				currentSelection: this.selection
-			};
+			// Compare view selection assumed from dom with current view selection.
+			if ( this.selection.isCollapsed && this.selection.isEqual( viewSelectionFromDom ) ) {
+				return;
+			} else if ( areSimilarSelections( viewSelectionFromDom, this.selection ) ) {
+				const data = {
+					oldSelection: viewSelectionFromDom,
+					currentSelection: this.selection
+				};
 
-			log.warn(
-				'renderer-skipped-selection-rendering: The selection was not rendered due to its similarity to the current one.',
-				data
-			);
+				log.warn(
+					'renderer-skipped-selection-rendering: The selection was not rendered due to its similarity to the current one.',
+					data
+				);
 
-			return;
+				return;
+			}
 		}
 
 		// Multi-range selection is not available in most browsers, and, at least in Chrome, trying to

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -603,12 +603,17 @@ export default class Renderer {
 	_updateDomSelection( domRoot ) {
 		const domSelection = domRoot.ownerDocument.defaultView.getSelection();
 
-		// Check whether dom selection needs fixing. If it does not need fixing maybe w don't have to update it at all.
+		// Below we will check whether DOM Selection needs updating at all.
+		// We need to update DOM Selection if either:
+		// * it is at incorrect position, or
+		// * it has changed (when compared to view selection).
 		if ( this.domConverter.isCorrectDomSelection( domSelection ) ) {
+			// DOM Selection is at correct position. Check whether it has changed.
 			const viewSelectionFromDom = this.domConverter.domSelectionToView( domSelection );
 
 			// Compare view selection assumed from dom with current view selection.
 			if ( this.selection.isCollapsed && this.selection.isEqual( viewSelectionFromDom ) ) {
+				// Selection did not changed and is correct, do not update.
 				return;
 			} else if ( areSimilarSelections( viewSelectionFromDom, this.selection ) ) {
 				const data = {
@@ -621,6 +626,7 @@ export default class Renderer {
 					data
 				);
 
+				// Selection did not changed and is correct, do not update.
 				return;
 			}
 		}

--- a/tests/conversion/view-selection-to-model-converters.js
+++ b/tests/conversion/view-selection-to-model-converters.js
@@ -109,7 +109,8 @@ describe( 'convertSelectionChange', () => {
 		expect( model.selection.isBackward ).to.true;
 	} );
 
-	it( 'should not enqueue changes if selection has not changed', () => {
+	it( 'should re-convert selection even if it has not changed in model', () => {
+		// Selection might not have changed in model but it needs to be reconverted because it ended up in incorrect place in DOM.
 		const viewSelection = new ViewSelection();
 		viewSelection.addRange( ViewRange.createFromParentsAndOffsets(
 			viewRoot.getChild( 0 ).getChild( 0 ), 1, viewRoot.getChild( 0 ).getChild( 0 ), 1 ) );
@@ -122,6 +123,6 @@ describe( 'convertSelectionChange', () => {
 
 		convertSelection( null, { newSelection: viewSelection } );
 
-		expect( spy.called ).to.be.false;
+		expect( spy.called ).to.be.true;
 	} );
 } );

--- a/tests/manual/placeholder.html
+++ b/tests/manual/placeholder.html
@@ -1,1 +1,5 @@
+<style type="text/css">
+	.myUi { display: inline-block; width: 6px; height: 6px; position: relative; top: -16px; background: #AA0000; pointer-events: none; }
+</style>
+
 <div id="editor"><h2></h2><p></p></div>

--- a/tests/manual/placeholder.js
+++ b/tests/manual/placeholder.js
@@ -13,19 +13,30 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import { attachPlaceholder } from '../../src/view/placeholder';
+import ViewUIElement from '../../src/view/uielement';
+import buildModelConverter from '../../src/conversion/buildmodelconverter';
+import ModelRange from '../../src/model/range';
 
 ClassicEditor.create( global.document.querySelector( '#editor' ), {
 	plugins: [ Enter, Typing, Paragraph, Undo, Heading ],
 	toolbar: [ 'headings', 'undo', 'redo' ]
 } )
 .then( editor => {
+	const modelDoc = editor.document;
 	const viewDoc = editor.editing.view;
 	const header = viewDoc.getRoot().getChild( 0 );
 	const paragraph = viewDoc.getRoot().getChild( 1 );
 
-	attachPlaceholder( header, 'Type some header text...' );
-	attachPlaceholder( paragraph, 'Type some paragraph text...' );
-	viewDoc.render();
+	const viewStamp = new ViewUIElement( 'span', { class: 'myUi' } );
+	buildModelConverter().for( editor.editing.modelToView ).fromMarker( 'myMarker' ).toStamp( viewStamp );
+
+	modelDoc.enqueueChanges( () => {
+		attachPlaceholder( header, 'Type some header text...' );
+		attachPlaceholder( paragraph, 'Type some paragraph text...' );
+
+		const modelHeader = modelDoc.getRoot().getChild( 0 );
+		modelDoc.markers.set( 'myMarker', ModelRange.createFromParentsAndOffsets( modelHeader, 0, modelHeader, 0 ) );
+	} );
 } )
 .catch( err => {
 	console.error( err.stack );

--- a/tests/manual/placeholder.md
+++ b/tests/manual/placeholder.md
@@ -7,3 +7,4 @@
 * Clicking outside the editor should show both placeholders.
 * Type some text into paragraph, and click outside. Paragraph placeholder should be hidden.
 * Remove added text and click outside - paragraph placeholder should now be visible again.
+* UIElement (red square) should behave correctly.

--- a/tests/view/domconverter/domconverter.js
+++ b/tests/view/domconverter/domconverter.js
@@ -8,7 +8,8 @@
 import DomConverter from '../../../src/view/domconverter';
 import ViewEditable from '../../../src/view/editableelement';
 import ViewDocument from '../../../src/view/document';
-import { BR_FILLER, NBSP_FILLER } from '../../../src/view/filler';
+import ViewUIElement from '../../../src/view/uielement';
+import { BR_FILLER, NBSP_FILLER, INLINE_FILLER, INLINE_FILLER_LENGTH } from '../../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
@@ -187,6 +188,91 @@ describe( 'DomConverter', () => {
 				expect( converter.isComment( element ) ).to.be.false;
 				expect( converter.isComment( documentFragment ) ).to.be.false;
 				expect( converter.isComment( {} ) ).to.be.false;
+			} );
+		} );
+	} );
+
+	describe( 'isCorrectDomSelection', () => {
+		function domSelection( anchorParent, anchorOffset, focusParent, focusOffset ) {
+			const sel = document.getSelection();
+
+			sel.collapse( anchorParent, anchorOffset );
+			sel.extend( focusParent, focusOffset );
+
+			return sel;
+		}
+
+		let domP, domFillerTextNode, domUiSpan;
+
+		beforeEach( () => {
+			// <p>INLINE_FILLERfoo<span></span></p>.
+			domP = document.createElement( 'p' );
+			domFillerTextNode = document.createTextNode( INLINE_FILLER + 'foo' );
+			domUiSpan = document.createElement( 'span' );
+
+			const viewUiSpan = new ViewUIElement( 'span' );
+
+			domP.appendChild( domFillerTextNode );
+			domP.appendChild( domUiSpan );
+
+			converter.bindElements( domUiSpan, viewUiSpan );
+
+			document.body.appendChild( domP );
+		} );
+
+		it( 'should return true for correct dom selection', () => {
+			// <p>INLINE_FILLER{foo}<span></span></p>.
+			const sel1 = domSelection( domFillerTextNode, INLINE_FILLER_LENGTH, domFillerTextNode, INLINE_FILLER_LENGTH + 3 );
+			expect( converter.isCorrectDomSelection( sel1 ) ).to.be.true;
+
+			// <p>INLINE_FILLERfoo[]<span></span></p>.
+			const sel2 = domSelection( domP, 1, domP, 1 );
+			expect( converter.isCorrectDomSelection( sel2 ) ).to.be.true;
+
+			// <p>INLINE_FILLERfoo<span></span>[]</p>.
+			const sel3 = domSelection( domP, 2, domP, 2 );
+			expect( converter.isCorrectDomSelection( sel3 ) ).to.be.true;
+		} );
+
+		describe( 'should return false', () => {
+			it( 'if anchor or focus is before filler node', () => {
+				// Tests forward and backward selection.
+				// <p>[INLINE_FILLERfoo]<span></span></p>.
+				const sel1 = domSelection( domP, 0, domP, 1 );
+				expect( converter.isCorrectDomSelection( sel1 ) ).to.be.false;
+
+				const sel2 = domSelection( domP, 1, domP, 0 );
+				expect( converter.isCorrectDomSelection( sel2 ) ).to.be.false;
+			} );
+
+			it( 'if anchor or focus is before filler sequence', () => {
+				// Tests forward and backward selection.
+				// <p>{INLINE_FILLERfoo}<span></span></p>.
+				const sel1 = domSelection( domFillerTextNode, 0, domFillerTextNode, INLINE_FILLER_LENGTH + 3 );
+				expect( converter.isCorrectDomSelection( sel1 ) ).to.be.false;
+
+				const sel2 = domSelection( domFillerTextNode, INLINE_FILLER_LENGTH + 3, domFillerTextNode, 0 );
+				expect( converter.isCorrectDomSelection( sel2 ) ).to.be.false;
+			} );
+
+			it( 'if anchor or focus is in the middle of filler sequence', () => {
+				// Tests forward and backward selection.
+				// <p>I{NLINE_FILLERfoo}<span></span></p>.
+				const sel1 = domSelection( domFillerTextNode, 1, domFillerTextNode, INLINE_FILLER_LENGTH + 3 );
+				expect( converter.isCorrectDomSelection( sel1 ) ).to.be.false;
+
+				const sel2 = domSelection( domFillerTextNode, INLINE_FILLER_LENGTH + 3, domFillerTextNode, 1 );
+				expect( converter.isCorrectDomSelection( sel2 ) ).to.be.false;
+			} );
+
+			it( 'if anchor or focus is inside dom element that represents view ui element', () => {
+				// Tests forward and backward selection.
+				// <p>INLINE_FILLER{foo<span>]</span></p>.
+				const sel1 = domSelection( domFillerTextNode, INLINE_FILLER_LENGTH + 3, domUiSpan, 0 );
+				expect( converter.isCorrectDomSelection( sel1 ) ).to.be.false;
+
+				const sel2 = domSelection( domUiSpan, 0, domFillerTextNode, INLINE_FILLER_LENGTH + 3 );
+				expect( converter.isCorrectDomSelection( sel2 ) ).to.be.false;
 			} );
 		} );
 	} );

--- a/theme/placeholder.scss
+++ b/theme/placeholder.scss
@@ -2,8 +2,15 @@
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
 .ck-placeholder::before {
+	position: absolute;
+	top: 0;
+	left: 0;
 	content: attr( data-placeholder );
 	cursor: text;
 	color: #c2c2c2;
 	pointer-events: none; // See ckeditor/ckeditor5#469.
+}
+
+.ck-placeholder {
+	position: relative;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Placeholder text pseudo-element has now `position: absolute;` to not interfere with other elements that might be in "emptyish" element (for example UI elements). Closes #1020.
Fix: DOM Selection is now re-rendered and fixed when it is placed in DOM representation of `view.UIElement` or before/inside inline filler. Closes #797. Closes #613.