### PR TITLE
T/1031: Ignore mutations which lead to no changes

### DIFF
--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -12,7 +12,7 @@
 import Observer from './observer';
 import ViewSelection from '../selection';
 import { startsWithFiller, getDataWithoutFiller } from '../filler';
-import isEqual from '@ckeditor/ckeditor5-utils/src/lib/lodash/isEqual';
+import isEqualWith from '@ckeditor/ckeditor5-utils/src/lib/lodash/isEqualWith';
 
 /**
  * Mutation observer class observes changes in the DOM, fires {@link module:engine/view/document~Document#event:mutations} event, mark view
@@ -210,7 +210,7 @@ export default class MutationObserver extends Observer {
 
 			// It may happen that as a result of many changes (sth was inserted and then removed),
 			// both elements haven't really changed. #1031
-			if ( !isEqual( viewChildren, newViewChildren ) ) {
+			if ( !isEqualWith( viewChildren, newViewChildren, sameNodes ) ) {
 				this.renderer.markToSync( 'children', viewElement );
 
 				viewMutations.push( {
@@ -250,6 +250,25 @@ export default class MutationObserver extends Observer {
 		// If nothing changes on `mutations` event, at this point we have "dirty DOM" (changed) and de-synched
 		// view (which has not been changed). In order to "reset DOM" we render the view again.
 		this.document.render();
+
+		function sameNodes( child1, child2 ) {
+			// First level of comparison (array of children vs array of children) – use the Lodash's default behavior.
+			if ( Array.isArray( child1 ) ) {
+				return;
+			}
+
+			// Elements.
+			if ( child1 === child2 ) {
+				return true;
+			}
+			// Texts.
+			else if ( child1.is( 'text' ) && child2.is( 'text' ) ) {
+				return child1.data === child2.data;
+			}
+
+			// Not matching types.
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Mutation observer will ignore children mutations if as a result of several native mutations the element's children haven't changed. Closes #1031.

---

### Additional information

In https://github.com/ckeditor/ckeditor5-engine/blob/4a4a89aa2ca609e65dadd2f1ff8169e3a8d3c49c/src/view/renderer.js#L508-L525 there's a very similar code to the one I wrote. However, my doesn't handle block fillers. There are no block fillers in the view so that seems to be right, but I'm mentioning just in case.

Also, I've been thinking that perhaps both functions should end up in the `DomConverter`'s public interface one day. But not just yet.
