### PR TITLE
Virtual selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@ckeditor/ckeditor5-paragraph": "^0.8.0",
     "@ckeditor/ckeditor5-typing": "^0.9.1",
     "@ckeditor/ckeditor5-undo": "^0.8.1",
+    "@ckeditor/ckeditor5-widget": "^0.1.1",
     "eslint-config-ckeditor5": "^1.0.0",
     "gulp": "^3.9.1",
     "guppy-pre-commit": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@ckeditor/ckeditor5-paragraph": "^0.8.0",
     "@ckeditor/ckeditor5-typing": "^0.9.1",
     "@ckeditor/ckeditor5-undo": "^0.8.1",
+    "@ckeditor/ckeditor5-widget": "^0.1.1",
     "eslint-config-ckeditor5": "^1.0.5",
     "gulp": "^3.9.1",
     "guppy-pre-commit": "^0.4.0"

--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -225,7 +225,7 @@ export default class DataController {
 	 * {@link module:engine/view/documentfragment~DocumentFragment view document fragment} converted by the
 	 * {@link #viewToModel view to model converters}.
 	 *
-	 * When marker stamps were converted during conversion process then will be set as DocumentFragment's
+	 * When marker elements were converted during conversion process then will be set as DocumentFragment's
 	 * {@link module:engine/model/documentfragment~DocumentFragment#markers static markers map}.
 	 *
 	 * @param {module:engine/view/element~Element|module:engine/view/documentfragment~DocumentFragment} viewElementOrFragment

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -15,7 +15,7 @@ import {
 	removeUIElement,
 	wrapItem,
 	unwrapItem,
-	virtualSelectionConverter
+	markerToVirtualSelection
 } from './model-to-view-converters';
 
 import { convertSelectionAttribute, convertSelectionMarker } from './model-selection-to-view-converters';
@@ -250,8 +250,8 @@ class ModelConverterBuilder {
 		const priority = this._from.priority === null ? 'normal' : this._from.priority;
 
 		for ( const dispatcher of this._dispatchers ) {
-			dispatcher.on( 'addMarker:' + this._from.name, virtualSelectionConverter( selectionDescriptor ), { priority } );
-			dispatcher.on( 'removeMarker:' + this._from.name, virtualSelectionConverter( selectionDescriptor, false ), { priority } );
+			dispatcher.on( 'addMarker:' + this._from.name, markerToVirtualSelection( selectionDescriptor ), { priority } );
+			dispatcher.on( 'removeMarker:' + this._from.name, markerToVirtualSelection( selectionDescriptor ), { priority } );
 			dispatcher.on( 'selectionMarker:' + this._from.name, convertSelectionMarker( selectionDescriptor ), { priority } );
 		}
 	}

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -437,10 +437,10 @@ export default function buildModelConverter() {
  * can handle virtual selection separately by providing `setVirtualSelection` and `removeVirtualSelection` custom
  * properties.
  *
- * @property {Number} priority {@link module:engine/view/attributeelement~AttributeElement#priority} of the `span`
- * wrapping each text node in the virtual selection.
  * @property {String} class CSS class that will be added to `span`
  * {@link module:engine/view/attributeelement~AttributeElement} wrapping each text node in the virtual selection.
+ * @property {Number} [priority] {@link module:engine/view/attributeelement~AttributeElement#priority} of the `span`
+ * wrapping each text node in the virtual selection. If not provided, default 10 priority will be used.
  * @property {Object} [attributes] Attributes that will be added to `span`
  * {@link module:engine/view/attributeelement~AttributeElement} wrapping each text node it the virtual selection.
  */

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -297,7 +297,7 @@ class ModelConverterBuilder {
 	 * Also, descriptor creator function can be provided:
 	 *
 	 *		buildModelConverter.for( dispatcher ).fromMarker( 'search:blue' ).toVirtualSelection( data => {
-	 *			const color = data.name.split( ':' )[ 1 ];
+	 *			const color = data.markerName.split( ':' )[ 1 ];
 	 *
 	 *			return { class: 'search-' + color };
 	 *		} );
@@ -423,8 +423,8 @@ export default function buildModelConverter() {
 /**
  * @typedef MarkerViewElementCreatorData
  * @param {Object} data Additional information about the change.
- * @param {String} data.name Marker name.
- * @param {module:engine/model/range~Range} data.range Marker range.
+ * @param {String} data.markerName Marker name.
+ * @param {module:engine/model/range~Range} data.markerRange Marker range.
  * @param {Boolean} data.isOpening Defines if currently converted element is a beginning or end of the marker range.
  * @param {module:engine/conversion/modelconsumable~ModelConsumable} consumable Values to consume.
  * @param {Object} conversionApi Conversion interface to be used by callback, passed in `ModelConversionDispatcher` constructor.

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -58,15 +58,16 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  *		buildModelConverter().for( dispatcher ).fromAttribute( 'bold' ).toElement( 'strong' );
  *
  * 4. Model marker to virtual selection converter. This is a converter that converts model markers to virtual
- * selection described by {@link engine/conversion/buildmodelconverter~VirtualSelectionDescriptor} object passed to
- * {@link #toVirtualSelection} method.
+ * selection described by {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor} object passed to
+ * {@link module:engine/conversion/buildmodelconverter~ModelConverterBuilder#toVirtualSelection} method.
  *
  *		buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toVirtualSelection( descriptor );
  *
  * 5. Model marker to element converter. This is a converter that takes model marker and creates separate elements at
- * the beginning and at the end of the marker's range. For more information see {@link #toElement} method.
+ * the beginning and at the end of the marker's range. For more information see
+ * {@link module:engine/conversion/buildmodelconverter~ModelConverterBuilder#toElement} method.
  *
- *		buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toStamp( 'span' );
+ *		buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( 'span' );
  *
  * It is possible to provide various different parameters for
  * {@link module:engine/conversion/buildmodelconverter~ModelConverterBuilder#toElement},
@@ -202,7 +203,7 @@ class ModelConverterBuilder {
 	 * will be used. Keep in mind that when you view element instance or creator function, it has to be/return a
 	 * proper type of view element: {@link module:engine/view/containerelement~ContainerElement ViewContainerElement} if you convert
 	 * from element, {@link module:engine/view/attributeelement~AttributeElement ViewAttributeElement} if you convert
-	 * from attribute and {@link module:engine/view/uielement~UIelement ViewUIElement} if you convert from marker.
+	 * from attribute and {@link module:engine/view/uielement~UIElement ViewUIElement} if you convert from marker.
 	 *
 	 * NOTE: When converting from model's marker, separate elements will be created at the beginning and at the end of the
 	 * marker's range. If range is collapsed then only one element will be created. See how markers
@@ -274,10 +275,10 @@ class ModelConverterBuilder {
 	 * a representation of the model marker in the view:
 	 * * each {@link module:engine/view/text~Text view text node} in the marker's range will be wrapped with `span`
 	 * {@link module:engine/view/attributeelement~AttributeElement},
-	 * * each {@link module:engine/view/element~Element view element} in the marker's range can handle the virtual
-	 * selection individually by providing `setVirtualSelection` and `removeVirtualSelection` methods.
+	 * * each {@link module:engine/view/containerelement~ContainerElement container view element} in the marker's
+	 * range can handle the virtual selection individually by providing `setVirtualSelection` and `removeVirtualSelection` methods.
 	 *
-	 * {@link module:engine/convresion/buildmodelconverter~VirtualSelectionDescriptor Descriptor} will be used to create
+	 * {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor Descriptor} will be used to create
 	 * spans over text nodes and also will be provided to `setVirtualSelection` and `removeVirtualSelection` methods
 	 * each time virtual selection should be set or removed from view elements.
 	 * NOTE: When `setVirtualSelection` and `removeVirtualSelection` methods are present, converter assumes that element
@@ -298,7 +299,7 @@ class ModelConverterBuilder {
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError}
 	 * `build-model-converter-non-marker-to-virtual-selection` when trying to convert not from marker.
 	 *
-	 * @param {function|module:engine/convresion/buildmodelconverter~VirtualSelectionDescriptor} selectionDescriptor
+	 * @param {function|module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor} selectionDescriptor
 	 */
 	toVirtualSelection( selectionDescriptor ) {
 		const priority = this._from.priority === null ? 'normal' : this._from.priority;

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -15,12 +15,12 @@ import {
 	removeUIElement,
 	wrapItem,
 	unwrapItem,
-	wrapRange,
-	unwrapRange
+	eventNameToConsumableType
 } from './model-to-view-converters';
 
 import { convertSelectionAttribute, convertSelectionMarker } from './model-selection-to-view-converters';
 
+import ModelRange from '../model/range';
 import ViewAttributeElement from '../view/attributeelement';
 import ViewContainerElement from '../view/containerelement';
 import ViewUIElement from '../view/uielement';
@@ -243,14 +243,97 @@ class ModelConverterBuilder {
 				dispatcher.on( 'removeAttribute:' + this._from.key, unwrapItem( element ), { priority } );
 
 				dispatcher.on( 'selectionAttribute:' + this._from.key, convertSelectionAttribute( element ), { priority } );
-			} else {
-				element = typeof element == 'string' ? new ViewAttributeElement( element ) : element;
-
-				dispatcher.on( 'addMarker:' + this._from.name, wrapRange( element ), { priority } );
-				dispatcher.on( 'removeMarker:' + this._from.name, unwrapRange( element ), { priority } );
-
-				dispatcher.on( 'selectionMarker:' + this._from.name, convertSelectionMarker( element ), { priority } );
 			}
+		}
+	}
+
+	toVirtualSelection( selectionInfo ) {
+		const priority = this._from.priority === null ? 'normal' : this._from.priority;
+
+		for ( const dispatcher of this._dispatchers ) {
+			dispatcher.on( 'selectionMarker:' + this._from.name, ( evt, data, consumable, api ) => {
+				const info = selectionInfo( data );
+				const wrapElement = new ViewAttributeElement( 'span', info.attributes );
+
+				if ( info.class ) {
+					wrapElement.addClass( info.class );
+				}
+
+				const wrap = convertSelectionMarker( wrapElement );
+
+				wrap( evt, data, consumable, api );
+			}, { priority } );
+
+			dispatcher.on( 'addMarker:' + this._from.name, ( evt, data, consumable, api ) => {
+				const modelItem = data.item;
+				const info = selectionInfo( data );
+
+				if ( modelItem.is( 'textProxy' ) ) {
+					const wrapElement = new ViewAttributeElement( 'span', info.attributes );
+
+					if ( info.class ) {
+						wrapElement.addClass( info.class );
+					}
+
+					const wrap = wrapItem( wrapElement );
+
+					wrap( evt, data, consumable, api );
+				}
+
+				if ( modelItem.is( 'element' ) ) {
+					const consumableType = eventNameToConsumableType( evt.name );
+					const viewElement = api.mapper.toViewElement( modelItem );
+
+					if ( !consumable.consume( modelItem, consumableType ) ) {
+						return;
+					}
+
+					if ( viewElement && viewElement.setVirtualSelection ) {
+						// Virtual selection will be handled by parent element - consume all children.
+						for ( const value of ModelRange.createIn( modelItem ) ) {
+							consumable.consume( value.item, consumableType );
+						}
+
+						viewElement.setVirtualSelection( info );
+					}
+				}
+			}, { priority } );
+
+			dispatcher.on( 'removeMarker:' + this._from.name, ( evt, data, consumable, api ) => {
+				const modelItem = data.item;
+				const info = selectionInfo( data );
+
+				if ( modelItem.is( 'textProxy' ) ) {
+					const info = selectionInfo( data );
+					const wrapElement = new ViewAttributeElement( 'span', info.attributes );
+
+					if ( info.class ) {
+						wrapElement.addClass( info.class );
+					}
+
+					const unwrap = unwrapItem( wrapElement );
+
+					unwrap( evt, data, consumable, api );
+				}
+
+				if ( modelItem.is( 'element' ) ) {
+					const consumableType = eventNameToConsumableType( evt.name );
+					const viewElement = api.mapper.toViewElement( modelItem );
+
+					if ( !consumable.consume( modelItem, consumableType ) ) {
+						return;
+					}
+
+					if ( viewElement && viewElement.setVirtualSelection ) {
+						// Virtual selection will be handled by parent element - consume all children.
+						for ( const value of ModelRange.createIn( modelItem ) ) {
+							consumable.consume( value.item, consumableType );
+						}
+
+						viewElement.removeVirtualSelection( info );
+					}
+				}
+			}, { priority } );
 		}
 	}
 

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -437,10 +437,10 @@ export default function buildModelConverter() {
  * can handle virtual selection separately by providing `setVirtualSelection` and `removeVirtualSelection` custom
  * properties.
  *
- * @property {String} [class] CSS class that will be added to `span`
+ * @property {Number} priority {@link module:engine/view/attributeelement~AttributeElement#priority} of the `span`
+ * wrapping each text node in the virtual selection.
+ * @property {String} class CSS class that will be added to `span`
  * {@link module:engine/view/attributeelement~AttributeElement} wrapping each text node in the virtual selection.
  * @property {Object} [attributes] Attributes that will be added to `span`
  * {@link module:engine/view/attributeelement~AttributeElement} wrapping each text node it the virtual selection.
- * @property {Number} [priority] {@link module:engine/view/attributeelement~AttributeElement#priority} of the `span`
- * wrapping each text node in the virtual selection.
  */

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -242,6 +242,13 @@ class ModelConverterBuilder {
 				dispatcher.on( 'removeAttribute:' + this._from.key, unwrapItem( element ), { priority } );
 
 				dispatcher.on( 'selectionAttribute:' + this._from.key, convertSelectionAttribute( element ), { priority } );
+			} else { // From marker to element.
+				const priority = this._from.priority === null ? 'normal' : this._from.priority;
+
+				element = typeof element == 'string' ? new ViewUIElement( element ) : element;
+
+				dispatcher.on( 'addMarker:' + this._from.name, insertUIElement( element ), { priority } );
+				dispatcher.on( 'removeMarker:' + this._from.name, removeUIElement( element ), { priority } );
 			}
 		}
 	}
@@ -297,27 +304,27 @@ class ModelConverterBuilder {
 	 * @param {String|module:engine/view/uielement~UIElement|Function} element UIElement created by converter or
 	 * a function that returns view element.
 	 */
-	toStamp( element ) {
-		for ( const dispatcher of this._dispatchers ) {
-			if ( this._from.type != 'marker' ) {
-				/**
-				 * To-stamp conversion is supported only for model markers.
-				 *
-				 * @error build-model-converter-element-to-stamp
-				 */
-				throw new CKEditorError(
-					'build-model-converter-non-marker-to-stamp: To-stamp conversion is supported only from model markers.'
-				);
-			}
-
-			const priority = this._from.priority === null ? 'normal' : this._from.priority;
-
-			element = typeof element == 'string' ? new ViewUIElement( element ) : element;
-
-			dispatcher.on( 'addMarker:' + this._from.name, insertUIElement( element ), { priority } );
-			dispatcher.on( 'removeMarker:' + this._from.name, removeUIElement( element ), { priority } );
-		}
-	}
+	// toStamp( element ) {
+	// 	for ( const dispatcher of this._dispatchers ) {
+	// 		if ( this._from.type != 'marker' ) {
+	// 			/**
+	// 			 * To-stamp conversion is supported only for model markers.
+	// 			 *
+	// 			 * @error build-model-converter-element-to-stamp
+	// 			 */
+	// 			throw new CKEditorError(
+	// 				'build-model-converter-non-marker-to-stamp: To-stamp conversion is supported only from model markers.'
+	// 			);
+	// 		}
+    //
+	// 		const priority = this._from.priority === null ? 'normal' : this._from.priority;
+    //
+	// 		element = typeof element == 'string' ? new ViewUIElement( element ) : element;
+    //
+	// 		dispatcher.on( 'addMarker:' + this._from.name, insertUIElement( element ), { priority } );
+	// 		dispatcher.on( 'removeMarker:' + this._from.name, removeUIElement( element ), { priority } );
+	// 	}
+	// }
 
 	/**
 	 * Registers what view attribute will be created by converter. Keep in mind, that only model attribute to

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -62,7 +62,10 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  * selection described by {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor} object passed to
  * {@link module:engine/conversion/buildmodelconverter~ModelConverterBuilder#toVirtualSelection} method.
  *
- *		buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toVirtualSelection( descriptor );
+ *		buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toVirtualSelection( {
+ *			class: 'search',
+ *			priority: 20
+ *		} );
  *
  * 5. Model marker to element converter. This is a converter that takes model marker and creates separate elements at
  * the beginning and at the end of the marker's range. For more information see

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -15,7 +15,8 @@ import {
 	removeUIElement,
 	wrapItem,
 	unwrapItem,
-	markerToVirtualSelection
+	convertTextsInsideMarker,
+	convertElementsInsideMarker
 } from './model-to-view-converters';
 
 import { convertSelectionAttribute, convertSelectionMarker } from './model-selection-to-view-converters';
@@ -322,8 +323,13 @@ class ModelConverterBuilder {
 		}
 
 		for ( const dispatcher of this._dispatchers ) {
-			dispatcher.on( 'addMarker:' + this._from.name, markerToVirtualSelection( selectionDescriptor ), { priority } );
-			dispatcher.on( 'removeMarker:' + this._from.name, markerToVirtualSelection( selectionDescriptor ), { priority } );
+			// Separate converters for converting texts and elements inside marker's range.
+			dispatcher.on( 'addMarker:' + this._from.name, convertTextsInsideMarker( selectionDescriptor ), { priority } );
+			dispatcher.on( 'addMarker:' + this._from.name, convertElementsInsideMarker( selectionDescriptor ), { priority } );
+
+			dispatcher.on( 'removeMarker:' + this._from.name, convertTextsInsideMarker( selectionDescriptor ), { priority } );
+			dispatcher.on( 'removeMarker:' + this._from.name, convertElementsInsideMarker( selectionDescriptor ), { priority } );
+
 			dispatcher.on( 'selectionMarker:' + this._from.name, convertSelectionMarker( selectionDescriptor ), { priority } );
 		}
 	}

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -276,13 +276,18 @@ class ModelConverterBuilder {
 	 * * each {@link module:engine/view/text~Text view text node} in the marker's range will be wrapped with `span`
 	 * {@link module:engine/view/attributeelement~AttributeElement},
 	 * * each {@link module:engine/view/containerelement~ContainerElement container view element} in the marker's
-	 * range can handle the virtual selection individually by providing `setVirtualSelection` and `removeVirtualSelection` methods.
+	 * range can handle the virtual selection individually by providing `setVirtualSelection` and `removeVirtualSelection`
+	 * custom properties:
+	 *
+	 *		viewElement.setCustomProperty( 'setVirtualSelection', ( element, descriptor ) => {} );
+	 *		viewElement.setCustomProperty( 'removeVirtualSelection', ( element, descriptor ) => {} );
 	 *
 	 * {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor Descriptor} will be used to create
 	 * spans over text nodes and also will be provided to `setVirtualSelection` and `removeVirtualSelection` methods
 	 * each time virtual selection should be set or removed from view elements.
-	 * NOTE: When `setVirtualSelection` and `removeVirtualSelection` methods are present, converter assumes that element
-	 * is taking care of presenting virtual selection on its child nodes, so it won't convert virtual selection on them.
+	 * NOTE: When `setVirtualSelection` and `removeVirtualSelection` custom properties are present, converter assumes
+	 * that element itself is taking care of presenting virtual selection on its child nodes, so it won't convert virtual
+	 * selection on them.
 	 *
 	 * Virtual selection descriptor can be provided as plain object:
 	 *
@@ -423,7 +428,8 @@ export default function buildModelConverter() {
  * @typedef VirtualSelectionDescriptor
  * Object describing how virtual selection should be created in the view. Each text node in virtual selection
  * will be wrapped with `span` element with CSS class, attributes and priority described by this object. Each element
- * can handle virtual selection separately by providing `setVirtualSelection` and `removeVirtualSelection` methods.
+ * can handle virtual selection separately by providing `setVirtualSelection` and `removeVirtualSelection` custom
+ * properties.
  *
  * @property {String} [class] CSS class that will be added to `span`
  * {@link module:engine/view/attributeelement~AttributeElement} wrapping each text node in the virtual selection.

--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -36,7 +36,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  * {@link module:engine/conversion/model-to-view-converters}, {@link module:engine/conversion/modelconsumable~ModelConsumable},
  * {@link module:engine/conversion/mapper~Mapper}.
  *
- * Using this API it is possible to create four kinds of converters:
+ * Using this API it is possible to create five kinds of converters:
  *
  * 1. Model element to view element converter. This is a converter that takes the model element and represents it
  * in the view.

--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -6,6 +6,7 @@
 import ViewElement from '../view/element';
 import ViewRange from '../view/range';
 import viewWriter from '../view/writer';
+import { virtualSelectionDescriptorToAttribute } from './model-to-view-converters';
 
 /**
  * Contains {@link module:engine/model/selection~Selection model selection} to
@@ -173,16 +174,13 @@ export function convertSelectionAttribute( elementCreator ) {
  * or function returning a view element, which will be used for wrapping.
  * @returns {Function} Selection converter.
  */
-export function convertSelectionMarker( elementCreator ) {
+export function convertSelectionMarker( selectionDescriptor ) {
 	return ( evt, data, consumable, conversionApi ) => {
-		const viewElement = elementCreator instanceof ViewElement ?
-			elementCreator.clone( true ) :
-			elementCreator( data, consumable, conversionApi );
+		const descriptor = typeof selectionDescriptor == 'function' ?
+			selectionDescriptor( data, consumable, conversionApi ) :
+			selectionDescriptor;
 
-		if ( !viewElement ) {
-			return;
-		}
-
+		const viewElement = virtualSelectionDescriptorToAttribute( descriptor );
 		const consumableName = 'selectionMarker:' + data.name;
 
 		wrapCollapsedSelectionPosition( data.selection, conversionApi.viewSelection, viewElement, consumable, consumableName );

--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -6,7 +6,7 @@
 import ViewElement from '../view/element';
 import ViewRange from '../view/range';
 import viewWriter from '../view/writer';
-import { virtualSelectionDescriptorToAttribute } from './model-to-view-converters';
+import { virtualSelectionDescriptorToAttributeElement } from './model-to-view-converters';
 
 /**
  * Contains {@link module:engine/model/selection~Selection model selection} to
@@ -176,7 +176,7 @@ export function convertSelectionMarker( selectionDescriptor ) {
 			return;
 		}
 
-		const viewElement = virtualSelectionDescriptorToAttribute( descriptor );
+		const viewElement = virtualSelectionDescriptorToAttributeElement( descriptor );
 		const consumableName = 'selectionMarker:' + data.name;
 
 		wrapCollapsedSelectionPosition( data.selection, conversionApi.viewSelection, viewElement, consumable, consumableName );

--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -164,14 +164,11 @@ export function convertSelectionAttribute( elementCreator ) {
  * Performs similar conversion as {@link ~convertSelectionAttribute}, but depends on a marker name of a marker in which
  * collapsed selection is placed.
  *
- *		modelDispatcher.on( 'selectionMarker:searchResult', wrapRange( new ViewAttributeElement( 'span', { class: 'searchResult' } ) ) );
- *
- * **Note:** You can use the same `elementCreator` function for this converter factory
- * and {@link module:engine/conversion/model-to-view-converters~wrapRange}.
+ *		modelDispatcher.on( 'selectionMarker:searchResult', convertSelectionMarker( { class: 'search' } ) );
  *
  * @see module:engine/conversion/model-selection-to-view-converters~convertSelectionAttribute
- * @param {module:engine/view/attributeelement~AttributeElement|Function} elementCreator View element,
- * or function returning a view element, which will be used for wrapping.
+ * @param {module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor|Function} selectionDescriptor Virtual
+ * selection descriptor object or function returning a descriptor object.
  * @returns {Function} Selection converter.
  */
 export function convertSelectionMarker( selectionDescriptor ) {

--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -180,6 +180,10 @@ export function convertSelectionMarker( selectionDescriptor ) {
 			selectionDescriptor( data, consumable, conversionApi ) :
 			selectionDescriptor;
 
+		if ( !descriptor ) {
+			return;
+		}
+
 		const viewElement = virtualSelectionDescriptorToAttribute( descriptor );
 		const consumableName = 'selectionMarker:' + data.name;
 

--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -113,11 +113,6 @@ export function convertCollapsedSelection() {
  *			}
  *		}
  *		modelDispatcher.on( 'selectionAttribute:style', convertSelectionAttribute( styleCreator ) );
- *
- * **Note:** You can use the same `elementCreator` function for this converter factory
- * and {@link module:engine/conversion/model-to-view-converters~wrapRange}
- * model to view converter, as long as the `elementCreator` function uses only the first parameter (attribute value).
- *
  *		modelDispatcher.on( 'selection', convertCollapsedSelection() );
  *		modelDispatcher.on( 'selectionAttribute:italic', convertSelectionAttribute( new ViewAttributeElement( 'em' ) ) );
  *		modelDispatcher.on( 'selectionAttribute:bold', convertSelectionAttribute( new ViewAttributeElement( 'strong' ) ) );

--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -177,7 +177,7 @@ export function convertSelectionMarker( selectionDescriptor ) {
 		}
 
 		const viewElement = virtualSelectionDescriptorToAttributeElement( descriptor );
-		const consumableName = 'selectionMarker:' + data.name;
+		const consumableName = 'selectionMarker:' + data.markerName;
 
 		wrapCollapsedSelectionPosition( data.selection, conversionApi.viewSelection, viewElement, consumable, consumableName );
 	};

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -431,7 +431,10 @@ export function convertTextsInsideMarker( selectionDescriptor ) {
  * Function factory, creates converter that converts all elements inside marker's range. Converter checks if element has
  * functions stored under `setVirtualSelection` and `removeVirtualSelection` custom properties and calls them passing
  * {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor. In such case converter will consume
- * all element's children, assuming that they were handled by element itself.
+ * all element's children, assuming that they were handled by element itself. If selection descriptor will not provide
+ * priority, priority 10 will be used as default, to be compliant with
+ * {@link module:engine/conversion/model-to-view-converters~convertTextsInsideMarker} method which uses default priority of
+ * {@link module:engine/view/attributeelement~AttributeElement}.
  *
  * @param {module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor|Function} selectionDescriptor
  * @return {Function}
@@ -450,6 +453,10 @@ export function convertElementsInsideMarker( selectionDescriptor ) {
 
 		if ( !consumable.consume( data.item, evt.name ) ) {
 			return;
+		}
+
+		if ( !descriptor.priority ) {
+			descriptor.priority = 10;
 		}
 
 		const viewElement = conversionApi.mapper.toViewElement( modelItem );
@@ -535,9 +542,10 @@ export function eventNameToConsumableType( evtName ) {
 
 /**
  * Creates `span` {@link module:engine/view/attributeelement~AttributeElement view attribute element} from information
- * provided by {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor} object.
+ * provided by {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor} object. If priority
+ * is not provided in selection descriptor - default priority will be used.
  *
- * @param {module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor }descriptor
+ * @param {module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor } descriptor
  * @return {module:engine/view/attributeelement~AttributeElement}
  */
 export function virtualSelectionDescriptorToAttributeElement( descriptor ) {

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -254,6 +254,8 @@ export function removeAttribute( attributeCreator ) {
  *
  * @param {module:engine/view/element~Element|Function} elementCreator View element, or function returning a view element, which will
  * be used for wrapping.
+ * @param {Function} [nameToConsumable] Optional function used to map conversion event name to consumable name. By default it
+ * uses {engine/conversion/model-to-view-converters~eventNameToConsumableType} function.
  * @returns {Function} Set/change attribute converter.
  */
 export function wrapItem( elementCreator, nameToConsumable = eventNameToConsumableType ) {
@@ -304,6 +306,8 @@ export function wrapItem( elementCreator, nameToConsumable = eventNameToConsumab
  * @see module:engine/conversion/model-to-view-converters~wrapItem
  * @param {module:engine/view/element~Element|Function} elementCreator View element, or function returning a view element, which will
  * be used for unwrapping.
+ * @param {Function} [nameToConsumable] Optional function used to map conversion event name to consumable name. By default it
+ * uses {engine/conversion/model-to-view-converters~eventNameToConsumableType} function.
  * @returns {Function} Remove attribute converter.
  */
 export function unwrapItem( elementCreator, nameToConsumable = eventNameToConsumableType ) {

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -405,7 +405,7 @@ export function remove() {
 /**
  * Function factory, creates converter that converts all texts inside marker's range. Converter wraps each text with
  * {@link module:engine/view/attributeelement~AttributeElement} created from provided descriptor.
- * See {@link engine/conversion/model-to-view-converters~virtualSelectionDescriptorToAttributeElement}.
+ * See {link module:engine/conversion/model-to-view-converters~virtualSelectionDescriptorToAttributeElement}.
  *
  * @param {module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor|Function} selectionDescriptor
  * @return {Function}

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -413,14 +413,13 @@ export function markerToVirtualSelection( selectionDescriptor ) {
 			return;
 		}
 
-		const addMarker = evt.name.split( ':' )[ 0 ] == 'addMarker';
-		const modelItem = data.item;
-
-		// Return if model item is not present. This happens when whole marker conversion is fired before converting
-		// children of marker's range.
-		if ( !modelItem ) {
+		// Do not convert if marker's range is collapsed.
+		if ( data.markerRange.isCollapsed ) {
 			return;
 		}
+
+		const addMarker = evt.name.split( ':' )[ 0 ] == 'addMarker';
+		const modelItem = data.item;
 
 		if ( modelItem.is( 'textProxy' ) ) {
 			const viewElement = virtualSelectionDescriptorToAttributeElement( descriptor );

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -385,6 +385,13 @@ export function remove() {
 	};
 }
 
+/**
+ * Function factory, crates marker to virtual selection converter.
+ * For more information see {@link module:engine/conversion/buildmodelconverter~ModelConverterBuilder#toVirtualSelection}.
+ *
+ * @param {module:engine/conversion/modelconversiondispatcher~VirtualSelectionDescriptor|Function} selectionDescriptor
+ * @return {Function} Marker to virtual selection converter.
+ */
 export function markerToVirtualSelection( selectionDescriptor ) {
 	return ( evt, data, consumable, conversionApi ) =>	{
 		const descriptor = typeof selectionDescriptor == 'function' ?
@@ -510,6 +517,13 @@ export function eventNameToConsumableType( evtName ) {
 	return parts[ 0 ] + ':' + parts[ 1 ];
 }
 
+/**
+ * Creates `span` {@link module:engine/view/attributeelement~AttributeElement view attribute element} from information
+ * provided by {@link module:engine/conversion/modelconversiondispatcher~VirtualSelectionDescriptor} object.
+ *
+ * @param {module:engine/conversion/modelconversiondispatcher~VirtualSelectionDescriptor }descriptor
+ * @return {module:engine/view/attributeelement~AttributeElement}
+ */
 export function virtualSelectionDescriptorToAttribute( descriptor ) {
 	const attributeElement = new ViewAttributeElement( 'span', descriptor.attributes );
 

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -122,16 +122,27 @@ export function insertUIElement( elementCreator ) {
 			return;
 		}
 
-		if ( !consumable.consume( data.range, evt.name ) ) {
+		const markerRange = data.markerRange;
+		const eventName = evt.name;
+
+		// If marker's range is collapsed - check if it can be consumed.
+		if ( markerRange.isCollapsed && !consumable.consume( markerRange, eventName ) ) {
 			return;
+		}
+
+		// if marker's range is not collapsed - consume all items inside.
+		for ( const value of markerRange ) {
+			if ( !consumable.consume( value.item, eventName ) ) {
+				return;
+			}
 		}
 
 		const mapper = conversionApi.mapper;
 
-		viewWriter.insert( mapper.toViewPosition( data.range.start ), viewStartElement );
+		viewWriter.insert( mapper.toViewPosition( markerRange.start ), viewStartElement );
 
-		if ( !data.range.isCollapsed ) {
-			viewWriter.insert( mapper.toViewPosition( data.range.end ), viewEndElement );
+		if ( !markerRange.isCollapsed ) {
+			viewWriter.insert( mapper.toViewPosition( markerRange.end ), viewEndElement );
 		}
 	};
 }
@@ -489,11 +500,22 @@ export function removeUIElement( elementCreator ) {
 			return;
 		}
 
-		if ( !consumable.consume( data.range, evt.name ) ) {
+		const markerRange = data.markerRange;
+		const eventName = evt.name;
+
+		// If marker's range is collapsed - check if it can be consumed.
+		if ( markerRange.isCollapsed && !consumable.consume( markerRange, eventName ) ) {
 			return;
 		}
 
-		const viewRange = conversionApi.mapper.toViewRange( data.range );
+		// Check if all items in the range can be consumed, and consume them.
+		for ( const value of markerRange ) {
+			if ( !consumable.consume( value.item, eventName ) ) {
+				return;
+			}
+		}
+
+		const viewRange = conversionApi.mapper.toViewRange( markerRange );
 
 		// First remove closing element.
 		viewWriter.clear( viewRange.getEnlarged(), viewEndElement );

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -442,11 +442,13 @@ export function convertTextsInsideMarker( selectionDescriptor ) {
 /**
  * Function factory, creates converter that converts all elements inside marker's range. Converter checks if element has
  * functions stored under `setVirtualSelection` and `removeVirtualSelection` custom properties and calls them passing
- * {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor. In such case converter will consume
+ * {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor}. In such case converter will consume
  * all element's children, assuming that they were handled by element itself. If selection descriptor will not provide
  * priority, priority 10 will be used as default, to be compliant with
  * {@link module:engine/conversion/model-to-view-converters~convertTextsInsideMarker} method which uses default priority of
  * {@link module:engine/view/attributeelement~AttributeElement}.
+ * When `setVirtualSelection` and `removeVirtualSelection` custom properties are not present, element is not converted
+ * in any special way. This means that converters will proceed to convert element's child nodes.
  *
  * @param {module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor|Function} selectionDescriptor
  * @return {Function}
@@ -463,7 +465,7 @@ export function convertElementsInsideMarker( selectionDescriptor ) {
 			return;
 		}
 
-		if ( !consumable.consume( data.item, evt.name ) ) {
+		if ( !consumable.test( data.item, evt.name ) ) {
 			return;
 		}
 
@@ -476,7 +478,10 @@ export function convertElementsInsideMarker( selectionDescriptor ) {
 		const selectionHandlingMethod = addMarker ? 'setVirtualSelection' : 'removeVirtualSelection';
 
 		if ( viewElement && viewElement.getCustomProperty( selectionHandlingMethod ) ) {
-			// Virtual selection will be handled by parent element - consume all children.
+			// Consume element itself.
+			consumable.consume( data.item, evt.name );
+
+			// Consume all children nodes.
 			for ( const value of ModelRange.createIn( modelItem ) ) {
 				consumable.consume( value.item, evt.name );
 			}

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -430,13 +430,13 @@ export function markerToVirtualSelection( selectionDescriptor ) {
 
 			const selectionHandlingMethod = addMarker ? 'setVirtualSelection' : 'removeVirtualSelection';
 
-			if ( viewElement && viewElement[ selectionHandlingMethod ] ) {
+			if ( viewElement && viewElement.getCustomProperty( selectionHandlingMethod ) ) {
 				// Virtual selection will be handled by parent element - consume all children.
 				for ( const value of ModelRange.createIn( modelItem ) ) {
 					consumable.consume( value.item, consumableType );
 				}
 
-				viewElement[ selectionHandlingMethod ]( descriptor );
+				viewElement.getCustomProperty( selectionHandlingMethod )( viewElement, descriptor );
 			}
 		}
 	};

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -412,7 +412,7 @@ export function markerToVirtualSelection( selectionDescriptor ) {
 		}
 
 		if ( modelItem.is( 'textProxy' ) ) {
-			const viewElement = virtualSelectionDescriptorToAttribute( descriptor );
+			const viewElement = virtualSelectionDescriptorToAttributeElement( descriptor );
 			const converter = addMarker ?
 				wrapItem( viewElement, eventName => eventName ) :
 				unwrapItem( viewElement, eventName => eventName );
@@ -524,7 +524,7 @@ export function eventNameToConsumableType( evtName ) {
  * @param {module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor }descriptor
  * @return {module:engine/view/attributeelement~AttributeElement}
  */
-export function virtualSelectionDescriptorToAttribute( descriptor ) {
+export function virtualSelectionDescriptorToAttributeElement( descriptor ) {
 	const attributeElement = new ViewAttributeElement( 'span', descriptor.attributes );
 
 	if ( descriptor.class ) {

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -126,12 +126,14 @@ export function insertUIElement( elementCreator ) {
 		const markerRange = data.markerRange;
 		const eventName = evt.name;
 
+		// Marker that is collapsed has consumable build differently that non-collapsed one.
+		// For more information see `addMarker` and `removeMarker` events description.
 		// If marker's range is collapsed - check if it can be consumed.
 		if ( markerRange.isCollapsed && !consumable.consume( markerRange, eventName ) ) {
 			return;
 		}
 
-		// if marker's range is not collapsed - consume all items inside.
+		// If marker's range is not collapsed - consume all items inside.
 		for ( const value of markerRange ) {
 			if ( !consumable.consume( value.item, eventName ) ) {
 				return;

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -256,7 +256,7 @@ export function removeAttribute( attributeCreator ) {
  * be used for wrapping.
  * @returns {Function} Set/change attribute converter.
  */
-export function wrapItem( elementCreator ) {
+export function wrapItem( elementCreator, nameToConsumable = eventNameToConsumableType ) {
 	return ( evt, data, consumable, conversionApi ) => {
 		const viewElement = ( elementCreator instanceof ViewElement ) ?
 			elementCreator.clone( true ) :
@@ -266,7 +266,7 @@ export function wrapItem( elementCreator ) {
 			return;
 		}
 
-		if ( !consumable.consume( data.item, eventNameToConsumableType( evt.name ) ) ) {
+		if ( !consumable.consume( data.item, nameToConsumable( evt.name ) ) ) {
 			return;
 		}
 
@@ -306,7 +306,7 @@ export function wrapItem( elementCreator ) {
  * be used for unwrapping.
  * @returns {Function} Remove attribute converter.
  */
-export function unwrapItem( elementCreator ) {
+export function unwrapItem( elementCreator, nameToConsumable = eventNameToConsumableType ) {
 	return ( evt, data, consumable, conversionApi ) => {
 		const viewElement = ( elementCreator instanceof ViewElement ) ?
 			elementCreator.clone( true ) :
@@ -316,7 +316,7 @@ export function unwrapItem( elementCreator ) {
 			return;
 		}
 
-		if ( !consumable.consume( data.item, eventNameToConsumableType( evt.name ) ) ) {
+		if ( !consumable.consume( data.item, nameToConsumable( evt.name ) ) ) {
 			return;
 		}
 
@@ -402,7 +402,9 @@ export function markerToVirtualSelection( selectionDescriptor ) {
 
 		if ( modelItem.is( 'textProxy' ) ) {
 			const viewElement = virtualSelectionDescriptorToAttribute( descriptor );
-			const converter = addMarker ? wrapItem( viewElement ) : unwrapItem( viewElement );
+			const converter = addMarker ?
+				wrapItem( viewElement, eventName => eventName ) :
+				unwrapItem( viewElement, eventName => eventName );
 
 			converter( evt, data, consumable, conversionApi );
 		}

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -389,7 +389,7 @@ export function remove() {
  * Function factory, crates marker to virtual selection converter.
  * For more information see {@link module:engine/conversion/buildmodelconverter~ModelConverterBuilder#toVirtualSelection}.
  *
- * @param {module:engine/conversion/modelconversiondispatcher~VirtualSelectionDescriptor|Function} selectionDescriptor
+ * @param {module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor|Function} selectionDescriptor
  * @return {Function} Marker to virtual selection converter.
  */
 export function markerToVirtualSelection( selectionDescriptor ) {
@@ -519,9 +519,9 @@ export function eventNameToConsumableType( evtName ) {
 
 /**
  * Creates `span` {@link module:engine/view/attributeelement~AttributeElement view attribute element} from information
- * provided by {@link module:engine/conversion/modelconversiondispatcher~VirtualSelectionDescriptor} object.
+ * provided by {@link module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor} object.
  *
- * @param {module:engine/conversion/modelconversiondispatcher~VirtualSelectionDescriptor }descriptor
+ * @param {module:engine/conversion/buildmodelconverter~VirtualSelectionDescriptor }descriptor
  * @return {module:engine/view/attributeelement~AttributeElement}
  */
 export function virtualSelectionDescriptorToAttribute( descriptor ) {

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -657,9 +657,9 @@ export default class ModelConversionDispatcher {
 
 	/**
 	 * Fired when a new marker is added to the model.
-	 * * If marker's range is not collapsed then event is fired separately for each item contained in that range. Consumable
-	 * contains all items from that range.
-	 * * If marker's range is collapsed then single event is fired. Consumable contains collapsed range.
+	 * * If marker's range is not collapsed, event is fired separately for each item contained in that range. In this
+	 * situation, consumable contains all items from that range.
+	 * * If marker's range is collapsed, single event is fired. In this situation, consumable contains only the collapsed range.
 	 *
 	 * `addMarker` is a namespace for a class of events. Names of actually called events follow this pattern:
 	 * `addMarker:<markerName>`. By specifying certain marker names, you can make the events even more gradual. For example,
@@ -673,7 +673,7 @@ export default class ModelConversionDispatcher {
 	 * @param {module:engine/model/range~Range} [data.range] Range spanning over item. Not present if collapsed range
 	 * is being converted.
 	 * @param {String} data.markerName Name of the marker.
-	 * @param {module:engine/model/range~Range} data.markerRange Whole marker's range.
+	 * @param {module:engine/model/range~Range} data.markerRange Marker's range spanning on all items.
 	 * @param {module:engine/conversion/modelconsumable~ModelConsumable} consumable Values to consume. When non-collapsed
 	 * marker is being converted then consumable contains all items in marker's range. For collapsed markers it contains
 	 * only marker's range to consume.
@@ -682,9 +682,9 @@ export default class ModelConversionDispatcher {
 
 	/**
 	 * Fired when marker is removed from the model.
-	 * * If marker's range is not collapsed then event is fired separately for each item contained in that range. Consumable
-	 * contains all items from that range.
-	 * * If marker's range is collapsed then single event is fired. Consumable contains collapsed range.
+	 * * If marker's range is not collapsed, event is fired separately for each item contained in that range. In this
+	 * situation, consumable contains all items from that range.
+	 * * If marker's range is collapsed, single event is fired. In this situation, consumable contains only the collapsed range.
 	 *
 	 * `removeMarker` is a namespace for a class of events. Names of actually called events follow this pattern:
 	 * `removeMarker:<markerName>`. By specifying certain marker names, you can make the events even more gradual. For example,

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -359,7 +359,8 @@ export default class ModelConversionDispatcher {
 		for ( const marker of markers ) {
 			const data = {
 				selection,
-				name: marker.name
+				markerName: marker.name,
+				markerRange: marker.getRange()
 			};
 
 			if ( consumable.test( selection, 'selectionMarker:' + marker.name ) ) {

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -400,7 +400,6 @@ export default class ModelConversionDispatcher {
 		}
 
 		// Create consumable for each item in range.
-		// TODO: better consumable name handling.
 		const consumable = this._createConsumableForRange( range, type + ':' + name.split( ':' )[ 0 ] );
 
 		// Create separate event for each node in the range.
@@ -480,22 +479,6 @@ export default class ModelConversionDispatcher {
 		for ( const key of selection.getAttributeKeys() ) {
 			consumable.add( selection, 'selectionAttribute:' + key );
 		}
-
-		return consumable;
-	}
-
-	/**
-	 * Creates {@link module:engine/conversion/modelconsumable~ModelConsumable} for adding or removing marker on given `range`.
-	 *
-	 * @private
-	 * @param {'addMarker'|'removeMarker'} type Change type.
-	 * @param {module:engine/model/range~Range} range Range on which marker was added or removed.
-	 * @returns {module:engine/conversion/modelconsumable~ModelConsumable} Values to consume.
-	 */
-	_createMarkerConsumable( type, range ) {
-		const consumable = new Consumable();
-
-		consumable.add( range, type );
 
 		return consumable;
 	}

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -387,6 +387,11 @@ export default class ModelConversionDispatcher {
 	 * Fires {@link ~#event:addMarker addMarker event} or {@link ~#event:removeMarker removeMarker event} based on
 	 * given `type` with data based on passed parameters.
 	 *
+	 * Marker conversion is performed in two steps. In the first step, event containing marker's whole range is fired. If
+	 * consumable passed with that event is consumed - no further events are dispatched. In the second step, event for each
+	 * item in the marker's range is fired. This way marker can be converted as a whole or each item in the marker's
+	 * range can be converted separately.
+	 *
 	 * @fires addMarker
 	 * @fires removeMarker
 	 * @param {'addMarker'|'removeMarker'} type Change type.

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -399,8 +399,20 @@ export default class ModelConversionDispatcher {
 			return;
 		}
 
+		// In markers case, event name == consumable name.
+		const eventName = type + ':' + name;
+
+		// Fire event for whole marker. This can be used to convert whole marker to element.
+		const markerConsumable = this._createMarkerConsumable( eventName, range );
+		this.fire( eventName, { name, range }, markerConsumable, this.conversionApi );
+
+		// Return if whole marker was consumed - do not perform conversion of each node in marker's range.
+		if ( !markerConsumable.test( range, eventName ) ) {
+			return;
+		}
+
 		// Create consumable for each item in range.
-		const consumable = this._createConsumableForRange( range, type + ':' + name.split( ':' )[ 0 ] );
+		const consumable = this._createConsumableForRange( range, eventName );
 
 		// Create separate event for each node in the range.
 		for ( const value of range ) {
@@ -412,7 +424,7 @@ export default class ModelConversionDispatcher {
 				range: itemRange
 			};
 
-			this.fire( type + ':' + name, data, consumable, this.conversionApi );
+			this.fire( eventName, data, consumable, this.conversionApi );
 		}
 	}
 
@@ -479,6 +491,22 @@ export default class ModelConversionDispatcher {
 		for ( const key of selection.getAttributeKeys() ) {
 			consumable.add( selection, 'selectionAttribute:' + key );
 		}
+
+		return consumable;
+	}
+
+	/**
+	 * Creates {@link module:engine/conversion/modelconsumable~ModelConsumable} for adding or removing marker on given `range`.
+	 *
+	 * @private
+	 * @param {'addMarker'|'removeMarker'} type Change type.
+	 * @param {module:engine/model/range~Range} range Range on which marker was added or removed.
+	 * @returns {module:engine/conversion/modelconsumable~ModelConsumable} Values to consume.
+	 */
+	_createMarkerConsumable( type, range ) {
+		const consumable = new Consumable();
+
+		consumable.add( range, type );
 
 		return consumable;
 	}

--- a/src/conversion/modelconversiondispatcher.js
+++ b/src/conversion/modelconversiondispatcher.js
@@ -399,10 +399,22 @@ export default class ModelConversionDispatcher {
 			return;
 		}
 
-		const consumable = this._createMarkerConsumable( type, range );
-		const data = { name, range };
+		// Create consumable for each item in range.
+		// TODO: better consumable name handling.
+		const consumable = this._createConsumableForRange( range, type + ':' + name.split( ':' )[ 0 ] );
 
-		this.fire( type + ':' + name, data, consumable, this.conversionApi );
+		// Create separate event for each node in the range.
+		for ( const value of range ) {
+			const item = value.item;
+			const itemRange = Range.createFromPositionAndShift( value.previousPosition, value.length );
+			const data = {
+				item,
+				name,
+				range: itemRange
+			};
+
+			this.fire( type + ':' + name, data, consumable, this.conversionApi );
+		}
 	}
 
 	/**

--- a/src/conversion/viewconversiondispatcher.js
+++ b/src/conversion/viewconversiondispatcher.js
@@ -137,7 +137,7 @@ export default class ViewConversionDispatcher {
 	 * @param {Object} [additionalData] Additional data to be passed in `data` argument when firing `ViewConversionDispatcher`
 	 * events. See also {@link ~ViewConversionDispatcher#event:element element event}.
 	 * @returns {module:engine/model/documentfragment~DocumentFragment} Model data that is a result of the conversion process
-	 * wrapped in `DocumentFragment`. Converted marker stamps will be set as that document fragment's
+	 * wrapped in `DocumentFragment`. Converted marker elements will be set as that document fragment's
 	 * {@link module:engine/model/documentfragment~DocumentFragment#markers static markers map}.
 	 */
 	convert( viewItem, additionalData = {} ) {
@@ -157,7 +157,7 @@ export default class ViewConversionDispatcher {
 			conversionResult = new ModelDocumentFragment( [ conversionResult ] );
 		}
 
-		// Extract temporary markers stamp from model and set as static markers collection.
+		// Extract temporary markers elements from model and set as static markers collection.
 		conversionResult.markers = extractMarkersFromModelFragment( conversionResult );
 
 		return conversionResult;
@@ -279,7 +279,7 @@ mix( ViewConversionDispatcher, EmitterMixin );
 // @param {module:engine/view/documentfragment~DocumentFragment|module:engine/view/node~Node} modelItem Fragment of model.
 // @returns {Map<String, module:engine/model/range~Range>} List of static markers.
 function extractMarkersFromModelFragment( modelItem ) {
-	const markerStamps = new Set();
+	const markerElements = new Set();
 	const markers = new Map();
 
 	// Create ModelTreeWalker.
@@ -290,16 +290,16 @@ function extractMarkersFromModelFragment( modelItem ) {
 
 	// Walk through DocumentFragment and collect marker elements.
 	for ( const value of walker ) {
-		// Check if current element is a marker stamp.
+		// Check if current element is a marker.
 		if ( value.item.name == '$marker' ) {
-			markerStamps.add( value.item );
+			markerElements.add( value.item );
 		}
 	}
 
 	// Walk through collected marker elements store its path and remove its from the DocumentFragment.
-	for ( const stamp of markerStamps ) {
-		const markerName = stamp.getAttribute( 'data-name' );
-		const currentPosition = ModelPosition.createBefore( stamp );
+	for ( const markerElement of markerElements ) {
+		const markerName = markerElement.getAttribute( 'data-name' );
+		const currentPosition = ModelPosition.createBefore( markerElement );
 
 		// When marker of given name is not stored it means that we have found the beginning of the range.
 		if ( !markers.has( markerName ) ) {
@@ -309,8 +309,8 @@ function extractMarkersFromModelFragment( modelItem ) {
 			markers.get( markerName ).end = ModelPosition.createFromPosition( currentPosition );
 		}
 
-		// Remove marker stamp element from DocumentFragment.
-		remove( ModelRange.createOn( stamp ) );
+		// Remove marker element from DocumentFragment.
+		remove( ModelRange.createOn( markerElement ) );
 	}
 
 	return markers;

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -14,7 +14,6 @@ import EmptyElement from './emptyelement';
 import UIElement from './uielement';
 import Text from './text';
 import Range from './range';
-import TreeWalker from './treewalker';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import DocumentFragment from './documentfragment';
 import isIterable from '@ckeditor/ckeditor5-utils/src/isiterable';
@@ -37,8 +36,7 @@ const writer = {
 	wrap,
 	wrapPosition,
 	unwrap,
-	rename,
-	breakViewRangePerContainer
+	rename
 };
 
 export default writer;
@@ -265,37 +263,6 @@ export function mergeContainers( position ) {
 	remove( Range.createOn( next ) );
 
 	return newPosition;
-}
-
-/**
- * Breaks given `range` on a set of {@link module:engine/view/range~Range ranges}, that each are contained within a
- * {@link module:engine/view/containerelement~ContainerElement container element}. After `range` is broken, it's "pieces" can
- * be used by other {@link module:engine/view/writer~writer} methods (which expect that passed ranges are contained within
- * one container element).
- *
- * @function module:engine/view/writer~writer.breakViewRangePerContainer
- * @param {module:engine/view/range~Range} range Range to break.
- * @returns {Array.<module:engine/view/range~Range>} Ranges that combine into passed `viewRange`.
- */
-export function breakViewRangePerContainer( range ) {
-	const ranges = [];
-	const walker = new TreeWalker( { boundaries: range } );
-
-	let start = range.start;
-
-	for ( const value of walker ) {
-		if ( value.item.is( 'containerElement' ) ) {
-			if ( !start.isEqual( value.previousPosition ) ) {
-				ranges.push( new Range( start, value.previousPosition ) );
-			}
-
-			start = value.nextPosition;
-		}
-	}
-
-	ranges.push( new Range( start, range.end ) );
-
-	return ranges;
 }
 
 /**

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -293,7 +293,7 @@ describe( 'EditingController', () => {
 			let element, outerRange;
 
 			beforeEach( () => {
-				element = new ModelElement( new ModelText( 'foo' ) );
+				element = new ModelElement( 'paragraph', null, new ModelText( 'foo' ) );
 				modelRoot.appendChildren( element );
 
 				outerRange = ModelRange.createOn( element );
@@ -308,6 +308,7 @@ describe( 'EditingController', () => {
 			it( 'marker strictly contained', () => {
 				const markerRange = ModelRange.createFromParentsAndOffsets( element, 1, element, 2 );
 				model.markers.set( 'name', markerRange );
+
 				editing.modelToView.convertInsertion( outerRange );
 				expect( editing.modelToView.convertMarker.calledWithExactly( 'addMarker', 'name', markerRange ) ).to.be.true;
 			} );

--- a/tests/conversion/buildmodelconverter.js
+++ b/tests/conversion/buildmodelconverter.js
@@ -450,7 +450,7 @@ describe( 'Model converter builder', () => {
 		} );
 	} );
 
-	describe( 'model marker to view stamp conversion', () => {
+	describe( 'model marker to view element conversion', () => {
 		let modelText, modelElement, range;
 
 		beforeEach( () => {
@@ -471,7 +471,7 @@ describe( 'Model converter builder', () => {
 			} );
 
 			it( 'using passed view element name', () => {
-				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toStamp( 'span' );
+				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( 'span' );
 
 				dispatcher.convertMarker( 'addMarker', 'search', range );
 
@@ -484,7 +484,7 @@ describe( 'Model converter builder', () => {
 
 			it( 'using passed view element', () => {
 				const viewElement = new ViewUIElement( 'span', { class: 'search' } );
-				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toStamp( viewElement );
+				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( viewElement );
 
 				dispatcher.convertMarker( 'addMarker', 'search', range );
 
@@ -496,7 +496,7 @@ describe( 'Model converter builder', () => {
 			} );
 
 			it( 'using passed creator function', () => {
-				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toStamp( data => {
+				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( data => {
 					const className = 'search search-color-' + data.name.split( ':' )[ 1 ];
 
 					return new ViewUIElement( 'span', { class: className } );
@@ -518,7 +518,7 @@ describe( 'Model converter builder', () => {
 			} );
 
 			it( 'using passed view element name', () => {
-				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toStamp( 'span' );
+				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( 'span' );
 
 				dispatcher.convertMarker( 'addMarker', 'search', range );
 
@@ -531,7 +531,7 @@ describe( 'Model converter builder', () => {
 
 			it( 'using passed view element', () => {
 				const viewElement = new ViewUIElement( 'span', { class: 'search' } );
-				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toStamp( viewElement );
+				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( viewElement );
 
 				dispatcher.convertMarker( 'addMarker', 'search', range );
 
@@ -545,7 +545,7 @@ describe( 'Model converter builder', () => {
 			} );
 
 			it( 'using passed creator function', () => {
-				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toStamp( data => {
+				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( data => {
 					const className = 'search search-color-' + data.name.split( ':' )[ 1 ];
 
 					return new ViewUIElement( 'span', { class: className } );
@@ -566,8 +566,8 @@ describe( 'Model converter builder', () => {
 		it( 'should overwrite default priority', () => {
 			range = ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 2 );
 
-			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toStamp( 'normal' );
-			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).withPriority( 'high' ).toStamp( 'high' );
+			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( 'normal' );
+			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).withPriority( 'high' ).toElement( 'high' );
 
 			dispatcher.convertMarker( 'addMarker', 'search', range );
 
@@ -593,17 +593,5 @@ describe( 'Model converter builder', () => {
 		expect( () => {
 			buildModelConverter().for( dispatcher ).fromElement( 'paragraph' ).toAttribute( 'paragraph', true );
 		} ).to.throw( CKEditorError, /^build-model-converter-non-attribute-to-attribute/ );
-	} );
-
-	it( 'should throw when trying to build model element to view stamp converter', () => {
-		expect( () => {
-			buildModelConverter().for( dispatcher ).fromElement( 'paragraph' ).toStamp( 'span' );
-		} ).to.throw( CKEditorError, /^build-model-converter-non-marker-to-stamp/ );
-	} );
-
-	it( 'should throw when trying to build model attribute to view stamp converter', () => {
-		expect( () => {
-			buildModelConverter().for( dispatcher ).fromAttribute( 'class' ).toStamp( 'span' );
-		} ).to.throw( CKEditorError, /^build-model-converter-non-marker-to-stamp/ );
 	} );
 } );

--- a/tests/conversion/buildmodelconverter.js
+++ b/tests/conversion/buildmodelconverter.js
@@ -343,7 +343,7 @@ describe( 'Model converter builder', () => {
 		} );
 	} );
 
-	describe( 'model marker to view element conversion', () => {
+	describe( 'model marker to virtual selection converter', () => {
 		let modelText, modelElement;
 
 		beforeEach( () => {
@@ -358,57 +358,51 @@ describe( 'Model converter builder', () => {
 			mapper.bindElements( modelElement, viewElement );
 		} );
 
-		it( 'using passed view element name', () => {
-			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( 'strong' );
-
-			dispatcher.convertMarker( 'addMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 ) );
-
-			expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<strong>ob</strong>ar</p></div>' );
-
-			dispatcher.convertMarker(
-				'removeMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 )
-			);
-
-			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
-		} );
-
-		it( 'using passed view element', () => {
-			const viewElement = new ViewAttributeElement( 'span', { class: 'search' } );
-			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( viewElement );
-
-			dispatcher.convertMarker( 'addMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 ) );
-
-			expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="search">ob</span>ar</p></div>' );
-
-			dispatcher.convertMarker(
-				'removeMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 )
-			);
-
-			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
-		} );
-
-		it( 'using passed creator function', () => {
-			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( data => {
-				const className = 'search search-color-' + data.name.split( ':' )[ 1 ];
-
-				return new ViewAttributeElement( 'span', { class: className } );
+		it( 'using passed virtual selection descriptor object', () => {
+			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toVirtualSelection( {
+				class: 'virtual-selection',
+				priority: 1,
+				attributes: { title: 'marker' }
 			} );
 
+			dispatcher.convertMarker( 'addMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 ) );
+
+			expect( viewToString( viewRoot ) ).to.equal(
+				'<div>' +
+					'<p>' +
+						'fo' +
+						'<span class="virtual-selection" title="marker">ob</span>' +
+						'ar' +
+					'</p>' +
+				'</div>' );
+
 			dispatcher.convertMarker(
-				'addMarker', 'search:red', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 )
+				'removeMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 )
 			);
 
-			expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="search search-color-red">ob</span>ar</p></div>' );
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+		} );
+
+		it( 'using passed virtual selection descriptor object creator', () => {
+			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toVirtualSelection( () => ( {
+				class: 'virtual-selection',
+				priority: 12,
+				attributes: { title: 'marker' }
+			} ) );
+
+			dispatcher.convertMarker( 'addMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 ) );
+
+			expect( viewToString( viewRoot ) ).to.equal(
+				'<div>' +
+					'<p>' +
+						'fo' +
+						'<span class="virtual-selection" title="marker">ob</span>' +
+						'ar' +
+					'</p>' +
+				'</div>' );
 
 			dispatcher.convertMarker(
-				'removeMarker', 'search:blue', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 )
-			);
-
-			// Nothing should change as we remove a marker with different name, which should generate different view attribute element.
-			expect( viewToString( viewRoot ) ).to.equal( '<div><p>fo<span class="search search-color-red">ob</span>ar</p></div>' );
-
-			dispatcher.convertMarker(
-				'removeMarker', 'search:red', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 )
+				'removeMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 )
 			);
 
 			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );

--- a/tests/conversion/buildmodelconverter.js
+++ b/tests/conversion/buildmodelconverter.js
@@ -509,7 +509,7 @@ describe( 'Model converter builder', () => {
 
 			it( 'using passed creator function', () => {
 				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( data => {
-					const className = 'search search-color-' + data.name.split( ':' )[ 1 ];
+					const className = 'search search-color-' + data.markerName.split( ':' )[ 1 ];
 
 					return new ViewUIElement( 'span', { class: className } );
 				} );
@@ -558,7 +558,7 @@ describe( 'Model converter builder', () => {
 
 			it( 'using passed creator function', () => {
 				buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( data => {
-					const className = 'search search-color-' + data.name.split( ':' )[ 1 ];
+					const className = 'search search-color-' + data.markerName.split( ':' )[ 1 ];
 
 					return new ViewUIElement( 'span', { class: className } );
 				} );

--- a/tests/conversion/buildmodelconverter.js
+++ b/tests/conversion/buildmodelconverter.js
@@ -361,7 +361,7 @@ describe( 'Model converter builder', () => {
 		it( 'using passed virtual selection descriptor object', () => {
 			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toVirtualSelection( {
 				class: 'virtual-selection',
-				priority: 1,
+				priority: 3,
 				attributes: { title: 'marker' }
 			} );
 
@@ -375,6 +375,8 @@ describe( 'Model converter builder', () => {
 						'ar' +
 					'</p>' +
 				'</div>' );
+
+			expect( viewRoot.getChild( 0 ).getChild( 1 ).priority ).to.equal( 3 );
 
 			dispatcher.convertMarker(
 				'removeMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 )
@@ -401,6 +403,8 @@ describe( 'Model converter builder', () => {
 					'</p>' +
 				'</div>' );
 
+			expect( viewRoot.getChild( 0 ).getChild( 1 ).priority ).to.equal( 12 );
+
 			dispatcher.convertMarker(
 				'removeMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 )
 			);
@@ -409,7 +413,9 @@ describe( 'Model converter builder', () => {
 		} );
 
 		it( 'should do nothing when marker range is collapsed', () => {
-			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toElement( 'strong' );
+			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toVirtualSelection( {
+				class: 'virtual-selection'
+			} );
 
 			dispatcher.convertMarker( 'addMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 2 ) );
 
@@ -420,6 +426,27 @@ describe( 'Model converter builder', () => {
 			);
 
 			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+		} );
+
+		it( 'should create converters with provided priority', () => {
+			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).toVirtualSelection( {
+				class: 'virtual-selection'
+			} );
+
+			buildModelConverter().for( dispatcher ).fromMarker( 'search' ).withPriority( 'high' ).toVirtualSelection( {
+				class: 'override'
+			} );
+
+			dispatcher.convertMarker( 'addMarker', 'search', ModelRange.createFromParentsAndOffsets( modelElement, 2, modelElement, 4 ) );
+
+			expect( viewToString( viewRoot ) ).to.equal(
+				'<div>' +
+					'<p>' +
+						'fo' +
+						'<span class="override">ob</span>' +
+						'ar' +
+					'</p>' +
+				'</div>' );
 		} );
 	} );
 

--- a/tests/conversion/buildmodelconverter.js
+++ b/tests/conversion/buildmodelconverter.js
@@ -448,6 +448,18 @@ describe( 'Model converter builder', () => {
 					'</p>' +
 				'</div>' );
 		} );
+
+		it( 'should throw if trying to convert from attribute', () => {
+			expect( () => {
+				buildModelConverter().for( dispatcher ).fromAttribute( 'bold' ).toVirtualSelection( { class: 'foo' } );
+			} ).to.throw( CKEditorError, /^build-model-converter-non-marker-to-virtual-selection/ );
+		} );
+
+		it( 'should throw if trying to convert from element', () => {
+			expect( () => {
+				buildModelConverter().for( dispatcher ).fromElement( 'paragraph' ).toVirtualSelection( { class: 'foo' } );
+			} ).to.throw( CKEditorError, /^build-model-converter-non-marker-to-virtual-selection/ );
+		} );
 	} );
 
 	describe( 'model marker to view element conversion', () => {

--- a/tests/conversion/model-selection-to-view-converters.js
+++ b/tests/conversion/model-selection-to-view-converters.js
@@ -269,7 +269,7 @@ describe( 'model-selection-to-view-converters', () => {
 
 			it( 'in marker - using virtual selection descriptor creator', () => {
 				dispatcher.on( 'selectionMarker:marker2', convertSelectionMarker(
-					data => ( { 'class': data.name } )
+					data => ( { 'class': data.markerName } )
 				) );
 
 				setModelData( modelDoc, 'foobar' );

--- a/tests/conversion/model-selection-to-view-converters.js
+++ b/tests/conversion/model-selection-to-view-converters.js
@@ -28,7 +28,8 @@ import {
 	insertElement,
 	insertText,
 	wrapItem,
-	markerToVirtualSelection
+	convertTextsInsideMarker,
+	convertElementsInsideMarker
 } from '../../src/conversion/model-to-view-converters';
 
 import { stringify as stringifyView } from '../../src/dev-utils/view';
@@ -58,8 +59,10 @@ describe( 'model-selection-to-view-converters', () => {
 		dispatcher.on( 'insert:$text', insertText() );
 		dispatcher.on( 'addAttribute:bold', wrapItem( new ViewAttributeElement( 'strong' ) ) );
 
-		dispatcher.on( 'addMarker:marker', markerToVirtualSelection( virtualSelectionDescriptor ) );
-		dispatcher.on( 'removeMarker:marker', markerToVirtualSelection( virtualSelectionDescriptor ) );
+		dispatcher.on( 'addMarker:marker', convertTextsInsideMarker( virtualSelectionDescriptor ) );
+		dispatcher.on( 'addMarker:marker', convertElementsInsideMarker( virtualSelectionDescriptor ) );
+		dispatcher.on( 'removeMarker:marker', convertTextsInsideMarker( virtualSelectionDescriptor ) );
+		dispatcher.on( 'removeMarker:marker', convertElementsInsideMarker( virtualSelectionDescriptor ) );
 
 		// Default selection converters.
 		dispatcher.on( 'selection', clearAttributes(), { priority: 'low' } );
@@ -228,7 +231,7 @@ describe( 'model-selection-to-view-converters', () => {
 				// Convert model to view.
 				dispatcher.convertInsertion( ModelRange.createIn( modelRoot ) );
 				dispatcher.convertMarker( 'addMarker', marker.name, marker.getRange() );
-                //
+
 				const markers = Array.from( modelDoc.markers.getMarkersAtPosition( modelSelection.getFirstPosition() ) );
 				dispatcher.convertSelection( modelSelection, markers );
 

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -131,21 +131,21 @@ describe( 'model-to-view-converters', () => {
 			dispatcher.on( 'addMarker:marker', markerToVirtualSelection( virtualSelectionDescriptor ) );
 			dispatcher.on( 'removeMarker:marker', markerToVirtualSelection( virtualSelectionDescriptor ) );
 			dispatcher.on( 'insert:paragraph', insertElement( () => {
-				const element = new ViewContainerElement( 'p' );
+				const viewContainer = new ViewContainerElement( 'p' );
 
-				element.setVirtualSelection = descriptor => {
+				viewContainer.setCustomProperty( 'setVirtualSelection', ( element, descriptor ) => {
 					element.addClass( 'virtual-selection-own-class' );
 
 					expect( descriptor ).to.equal( virtualSelectionDescriptor );
-				};
+				} );
 
-				element.removeVirtualSelection = descriptor => {
+				viewContainer.setCustomProperty( 'removeVirtualSelection', ( element, descriptor ) => {
 					element.removeClass( 'virtual-selection-own-class' );
 
 					expect( descriptor ).to.equal( virtualSelectionDescriptor );
-				};
+				} );
 
-				return element;
+				return viewContainer;
 			} ), { priority: 'high' } );
 
 			dispatcher.convertInsertion( markerRange );
@@ -179,8 +179,8 @@ describe( 'model-to-view-converters', () => {
 
 			dispatcher.on( 'insert:paragraph', insertElement( () => {
 				const element = new ViewContainerElement( 'p' );
-				element.setVirtualSelection = data => element.addClass( data.class );
-				element.removeVirtualSelection = data => element.removeClass( data.class );
+				element.setCustomProperty( 'setVirtualSelection', ( element, data ) => element.addClass( data.class ) );
+				element.setCustomProperty( 'removeVirtualSelection', ( element, data ) => element.removeClass( data.class ) );
 
 				return element;
 			} ), { priority: 'high' } );

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -629,7 +629,7 @@ describe( 'model-to-view-converters', () => {
 		} );
 
 		it( 'should insert and remove ui element - function as a creator', () => {
-			const viewUi = data => new ViewUIElement( 'span', { 'class': data.name } );
+			const viewUi = data => new ViewUIElement( 'span', { 'class': data.markerName } );
 
 			dispatcher.on( 'addMarker:marker', insertUIElement( viewUi ) );
 			dispatcher.on( 'removeMarker:marker', removeUIElement( viewUi ) );
@@ -652,11 +652,11 @@ describe( 'model-to-view-converters', () => {
 			dispatcher.on( 'removeMarker:marker', removeUIElement( viewUi ) );
 
 			dispatcher.on( 'addMarker:marker', ( evt, data, consumable ) => {
-				expect( consumable.test( data.range, 'addMarker:marker' ) ).to.be.true;
+				expect( consumable.test( data.markerRange, 'addMarker:marker' ) ).to.be.true;
 			} );
 
 			dispatcher.on( 'removeMarker:marker', ( evt, data, consumable ) => {
-				expect( consumable.test( data.range, 'removeMarker:marker' ) ).to.be.true;
+				expect( consumable.test( data.markerRange, 'removeMarker:marker' ) ).to.be.true;
 			} );
 
 			dispatcher.convertMarker( 'addMarker', 'marker', range );
@@ -679,11 +679,11 @@ describe( 'model-to-view-converters', () => {
 			dispatcher.on( 'removeMarker:marker', removeUIElement( viewUi ) );
 
 			dispatcher.on( 'addMarker:marker', ( evt, data, consumable ) => {
-				consumable.consume( data.range, 'addMarker:marker' );
+				consumable.consume( data.markerRange, 'addMarker:marker' );
 			}, { priority: 'high' } );
 
 			dispatcher.on( 'removeMarker:marker', ( evt, data, consumable ) => {
-				consumable.consume( data.range, 'removeMarker:marker' );
+				consumable.consume( data.markerRange, 'removeMarker:marker' );
 			}, { priority: 'high' } );
 
 			dispatcher.convertMarker( 'addMarker', 'marker', range );
@@ -706,11 +706,11 @@ describe( 'model-to-view-converters', () => {
 			dispatcher.on( 'removeMarker:marker', removeUIElement( viewUi ) );
 
 			dispatcher.on( 'addMarker:marker', ( evt, data, consumable ) => {
-				expect( consumable.test( data.range, 'addMarker:marker' ) ).to.be.true;
+				expect( consumable.test( data.markerRange, 'addMarker:marker' ) ).to.be.true;
 			} );
 
 			dispatcher.on( 'removeMarker:marker', ( evt, data, consumable ) => {
-				expect( consumable.test( data.range, 'removeMarker:marker' ) ).to.be.true;
+				expect( consumable.test( data.markerRange, 'removeMarker:marker' ) ).to.be.true;
 			} );
 
 			dispatcher.convertMarker( 'addMarker', 'marker', range );
@@ -733,11 +733,11 @@ describe( 'model-to-view-converters', () => {
 			dispatcher.on( 'removeMarker:marker', removeUIElement( viewUi ) );
 
 			dispatcher.on( 'addMarker:marker', ( evt, data, consumable ) => {
-				consumable.consume( data.range, 'addMarker:marker' );
+				consumable.consume( data.markerRange, 'addMarker:marker' );
 			}, { priority: 'high' } );
 
 			dispatcher.on( 'removeMarker:marker', ( evt, data, consumable ) => {
-				consumable.consume( data.range, 'removeMarker:marker' );
+				consumable.consume( data.markerRange, 'removeMarker:marker' );
 			}, { priority: 'high' } );
 
 			dispatcher.convertMarker( 'addMarker', 'marker', range );
@@ -773,7 +773,7 @@ describe( 'model-to-view-converters', () => {
 			} );
 
 			it( 'should insert and remove ui element - function as a creator', () => {
-				const viewUi = data => new ViewUIElement( 'span', { 'class': data.name } );
+				const viewUi = data => new ViewUIElement( 'span', { 'class': data.markerName } );
 
 				dispatcher.on( 'addMarker:marker', insertUIElement( viewUi ) );
 				dispatcher.on( 'removeMarker:marker', removeUIElement( viewUi ) );
@@ -791,10 +791,10 @@ describe( 'model-to-view-converters', () => {
 			it( 'should insert and remove different opening and ending element', () => {
 				function creator( data ) {
 					if ( data.isOpening ) {
-						return new ViewUIElement( 'span', { 'class': data.name, 'data-start': true } );
+						return new ViewUIElement( 'span', { 'class': data.markerName, 'data-start': true } );
 					}
 
-					return new ViewUIElement( 'span', { 'class': data.name, 'data-end': true } );
+					return new ViewUIElement( 'span', { 'class': data.markerName, 'data-end': true } );
 				}
 
 				dispatcher.on( 'addMarker:marker', insertUIElement( creator ) );

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -29,7 +29,7 @@ import {
 	remove,
 	removeUIElement,
 	markerToVirtualSelection,
-	virtualSelectionDescriptorToAttribute
+	virtualSelectionDescriptorToAttributeElement
 } from '../../src/conversion/model-to-view-converters';
 
 import { createRangeOnElementOnly } from '../../tests/model/_utils/utils';
@@ -1037,14 +1037,14 @@ describe( 'model-to-view-converters', () => {
 		} );
 	} );
 
-	describe( 'virtualSelectionDescriptorToAttribute()', () => {
+	describe( 'virtualSelectionDescriptorToAttributeElement()', () => {
 		it( 'should return attribute element from descriptor object', () => {
 			const descriptor = {
 				class: 'foo-class',
 				attributes: { one: 1, two: 2 },
 				priority: 7,
 			};
-			const element = virtualSelectionDescriptorToAttribute( descriptor );
+			const element = virtualSelectionDescriptorToAttributeElement( descriptor );
 
 			expect( element.is( 'attributeElement' ) ).to.be.true;
 			expect( element.name ).to.equal( 'span' );
@@ -1061,7 +1061,7 @@ describe( 'model-to-view-converters', () => {
 				attributes: { one: 1, two: 2 },
 				priority: 7,
 			};
-			const element = virtualSelectionDescriptorToAttribute( descriptor );
+			const element = virtualSelectionDescriptorToAttributeElement( descriptor );
 
 			expect( element.is( 'attributeElement' ) ).to.be.true;
 			expect( element.name ).to.equal( 'span' );
@@ -1077,7 +1077,7 @@ describe( 'model-to-view-converters', () => {
 				class: 'foo-class',
 				attributes: { one: 1, two: 2 },
 			};
-			const element = virtualSelectionDescriptorToAttribute( descriptor );
+			const element = virtualSelectionDescriptorToAttributeElement( descriptor );
 
 			expect( element.is( 'attributeElement' ) ).to.be.true;
 			expect( element.name ).to.equal( 'span' );
@@ -1094,7 +1094,7 @@ describe( 'model-to-view-converters', () => {
 				class: 'foo-class',
 				priority: 7
 			};
-			const element = virtualSelectionDescriptorToAttribute( descriptor );
+			const element = virtualSelectionDescriptorToAttributeElement( descriptor );
 
 			expect( element.is( 'attributeElement' ) ).to.be.true;
 			expect( element.name ).to.equal( 'span' );

--- a/tests/conversion/modelconversiondispatcher.js
+++ b/tests/conversion/modelconversiondispatcher.js
@@ -654,8 +654,47 @@ describe( 'ModelConversionDispatcher', () => {
 			dispatcher.convertMarker( 'removeMarker', 'name', range );
 		} );
 
-		it( 'should fire conversion for each item in the range', () => {
-			expect( true ).to.be.false;
+		it( 'should fire conversion for whole range and each item in the range', () => {
+			const element = new ModelElement( 'paragraph', null, [ new ModelText( 'foo bar baz' ) ] );
+			root.appendChildren( [ element ] );
+			range = ModelRange.createIn( root );
+
+			const addMarkerItems = [];
+			const removeMarkerItems = [];
+
+			dispatcher.on( 'addMarker:name', ( evt, data ) => {
+				// Called for whole marker.
+				if ( !data.item ) {
+					expect( data.range.isEqual( range ) ).to.be.true;
+				} else {
+					addMarkerItems.push( data.item );
+				}
+			} );
+			dispatcher.on( 'removeMarker:name', ( evt, data ) => {
+				// Called for whole marker.
+				if ( !data.item ) {
+					expect( data.range.isEqual( range ) ).to.be.true;
+				} else {
+					removeMarkerItems.push( data.item );
+				}
+			} );
+
+			dispatcher.convertMarker( 'addMarker', 'name', range );
+			dispatcher.convertMarker( 'removeMarker', 'name', range );
+
+			let i = 0;
+			for ( const val of range ) {
+				const item = val.item;
+
+				if ( item.is( 'textProxy' ) ) {
+					expect( item.data ).to.equal( addMarkerItems[ i ].data );
+					expect( item.data ).to.equal( removeMarkerItems[ i ].data );
+				} else {
+					expect( removeMarkerItems[ i ] ).to.equal( item );
+				}
+
+				i++;
+			}
 		} );
 
 		it( 'should not fire conversion for each item in marker\'s range if whole marker conversion was performed', () => {

--- a/tests/conversion/modelconversiondispatcher.js
+++ b/tests/conversion/modelconversiondispatcher.js
@@ -654,6 +654,10 @@ describe( 'ModelConversionDispatcher', () => {
 			dispatcher.convertMarker( 'removeMarker', 'name', range );
 		} );
 
+		it( 'should fire conversion for each item in the range', () => {
+			expect( true ).to.be.false;
+		} );
+
 		it( 'should not fire conversion for each item in marker\'s range if whole marker conversion was performed', () => {
 			const spy = sinon.spy( ( evt, data, consumable ) => {
 				if ( !data.item ) {

--- a/tests/conversion/modelconversiondispatcher.js
+++ b/tests/conversion/modelconversiondispatcher.js
@@ -550,7 +550,10 @@ describe( 'ModelConversionDispatcher', () => {
 		let range;
 
 		beforeEach( () => {
-			range = ModelRange.createFromParentsAndOffsets( root, 0, root, 4 );
+			const element = new ModelElement( 'paragraph', null, [ new ModelText( 'foo bar baz' ) ] );
+			root.appendChildren( [ element ] );
+
+			range = ModelRange.createFromParentsAndOffsets( element, 0, element, 4 );
 		} );
 
 		it( 'should fire event based on passed parameters', () => {
@@ -594,11 +597,19 @@ describe( 'ModelConversionDispatcher', () => {
 
 		it( 'should prepare consumable values', () => {
 			dispatcher.on( 'addMarker:name', ( evt, data, consumable ) => {
-				expect( consumable.test( data.range, 'addMarker' ) ).to.be.true;
+				if ( data.item ) {
+					expect( consumable.test( data.item, 'addMarker:name' ) ).to.be.true;
+				} else {
+					expect( consumable.test( data.range, 'addMarker:name' ) ).to.be.true;
+				}
 			} );
 
 			dispatcher.on( 'removeMarker:name', ( evt, data, consumable ) => {
-				expect( consumable.test( data.range, 'removeMarker' ) ).to.be.true;
+				if ( data.item ) {
+					expect( consumable.test( data.item, 'removeMarker:name' ) ).to.be.true;
+				} else {
+					expect( consumable.test( data.range, 'removeMarker:name' ) ).to.be.true;
+				}
 			} );
 
 			dispatcher.convertMarker( 'addMarker', 'name', range );

--- a/tests/conversion/viewconversiondispatcher.js
+++ b/tests/conversion/viewconversiondispatcher.js
@@ -172,7 +172,7 @@ describe( 'ViewConversionDispatcher', () => {
 			expect( spy.calledOnce ).to.be.true;
 		} );
 
-		it( 'should extract temporary markers stamps from converter element and create static markers list', () => {
+		it( 'should extract temporary markers elements from converter element and create static markers list', () => {
 			const viewFragment = new ViewDocumentFragment();
 
 			dispatcher.on( 'documentFragment', ( evt, data ) => {

--- a/tests/manual/markers.js
+++ b/tests/manual/markers.js
@@ -38,8 +38,7 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 
 			return {
 				class: 'h-' + color,
-				attributes: { 'data-id': 100 },
-				priority: 1000
+				priority: 1
 			};
 		} );
 

--- a/tests/manual/markers.js
+++ b/tests/manual/markers.js
@@ -27,63 +27,63 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 	plugins: [ Enter, Typing, Paragraph, Bold, Italic, List, Heading, Undo ],
 	toolbar: [ 'headings', 'bold', 'italic', 'bulletedList', 'numberedList', 'undo', 'redo' ]
 } )
-.then( editor => {
-	window.editor = editor;
-	model = window.editor.editing.model;
+	.then( editor => {
+		window.editor = editor;
+		model = window.editor.editing.model;
 
-	buildModelConverter().for( editor.editing.modelToView )
-		.fromMarker( 'highlight' )
-		.toVirtualSelection( data => {
-			const color = data.name.split( ':' )[ 1 ];
+		buildModelConverter().for( editor.editing.modelToView )
+			.fromMarker( 'highlight' )
+			.toVirtualSelection( data => {
+				const color = data.markerName.split( ':' )[ 1 ];
 
-			return {
-				class: 'h-' + color,
-				priority: 1
-			};
+				return {
+					class: 'h-' + color,
+					priority: 1
+				};
+			} );
+
+		window.document.getElementById( 'add-yellow' ).addEventListener( 'mousedown', e => {
+			e.preventDefault();
+			addHighlight( 'yellow' );
 		} );
 
-	window.document.getElementById( 'add-yellow' ).addEventListener( 'mousedown', e => {
-		e.preventDefault();
-		addHighlight( 'yellow' );
-	} );
+		window.document.getElementById( 'add-red' ).addEventListener( 'mousedown', e => {
+			e.preventDefault();
+			addHighlight( 'red' );
+		} );
 
-	window.document.getElementById( 'add-red' ).addEventListener( 'mousedown', e => {
-		e.preventDefault();
-		addHighlight( 'red' );
-	} );
+		window.document.getElementById( 'remove-marker' ).addEventListener( 'mousedown', e => {
+			e.preventDefault();
+			removeHighlight();
+		} );
 
-	window.document.getElementById( 'remove-marker' ).addEventListener( 'mousedown', e => {
-		e.preventDefault();
-		removeHighlight();
-	} );
+		window.document.getElementById( 'move-to-start' ).addEventListener( 'mousedown', e => {
+			e.preventDefault();
+			moveSelectionToStart();
+		} );
 
-	window.document.getElementById( 'move-to-start' ).addEventListener( 'mousedown', e => {
-		e.preventDefault();
-		moveSelectionToStart();
-	} );
+		window.document.getElementById( 'move-left' ).addEventListener( 'mousedown', e => {
+			e.preventDefault();
+			moveSelectionByOffset( -1 );
+		} );
 
-	window.document.getElementById( 'move-left' ).addEventListener( 'mousedown', e => {
-		e.preventDefault();
-		moveSelectionByOffset( -1 );
-	} );
+		window.document.getElementById( 'move-right' ).addEventListener( 'mousedown', e => {
+			e.preventDefault();
+			moveSelectionByOffset( 1 );
+		} );
 
-	window.document.getElementById( 'move-right' ).addEventListener( 'mousedown', e => {
-		e.preventDefault();
-		moveSelectionByOffset( 1 );
-	} );
+		model.enqueueChanges( () => {
+			const root = model.getRoot();
+			const range = new Range( new Position( root, [ 0, 10 ] ), new Position( root, [ 1, 5 ] ) );
+			const name = 'highlight:yellow:' + uid();
 
-	model.enqueueChanges( () => {
-		const root = model.getRoot();
-		const range = new Range( new Position( root, [ 0, 10 ] ), new Position( root, [ 1, 5 ] ) );
-		const name = 'highlight:yellow:' + uid();
-
-		markerNames.push( name );
-		model.markers.set( name, range );
+			markerNames.push( name );
+			model.markers.set( name, range );
+		} );
+	} )
+	.catch( err => {
+		console.error( err.stack );
 	} );
-} )
-.catch( err => {
-	console.error( err.stack );
-} );
 
 function uid() {
 	return _uid++;

--- a/tests/manual/markers.js
+++ b/tests/manual/markers.js
@@ -18,7 +18,6 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import buildModelConverter from '../../src/conversion/buildmodelconverter';
 import Position from '../../src/model/position';
 import Range from '../../src/model/range';
-import ViewAttributeElement from '../../src/view/attributeelement';
 
 const markerNames = [];
 let model = null;
@@ -34,10 +33,14 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 
 	buildModelConverter().for( editor.editing.modelToView )
 		.fromMarker( 'highlight' )
-		.toElement( data => {
+		.toVirtualSelection( data => {
 			const color = data.name.split( ':' )[ 1 ];
 
-			return new ViewAttributeElement( 'span', { class: 'h-' + color } );
+			return {
+				class: 'h-' + color,
+				attributes: { 'data-id': 100 },
+				priority: 1000
+			};
 		} );
 
 	window.document.getElementById( 'add-yellow' ).addEventListener( 'mousedown', e => {
@@ -72,7 +75,7 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 
 	model.enqueueChanges( () => {
 		const root = model.getRoot();
-		const range = new Range( new Position( root, [ 0, 10 ] ), new Position( root, [ 0, 16 ] ) );
+		const range = new Range( new Position( root, [ 0, 10 ] ), new Position( root, [ 1, 5 ] ) );
 		const name = 'highlight:yellow:' + uid();
 
 		markerNames.push( name );

--- a/tests/manual/virtualselection.html
+++ b/tests/manual/virtualselection.html
@@ -1,6 +1,14 @@
 <style>
-	span.virtual-selection {
+	span.virtual-selection-yellow {
 		background-color: yellow;
+	}
+
+	span.virtual-selection-blue {
+		background-color: blue;
+	}
+
+	span.virtual-selection-red {
+		background-color: red;
 	}
 
 	.ck-widget.fancy-widget {
@@ -11,8 +19,18 @@
 		line-height: 40px;
 	}
 
-	.ck-widget.fancy-widget.virtual-selection {
+	.ck-widget.fancy-widget.virtual-selection-yellow {
 		background-color: yellow;
+		color: black;
+	}
+
+	.ck-widget.fancy-widget.virtual-selection-blue {
+		background-color: blue;
+		color: black;
+	}
+
+	.ck-widget.fancy-widget.virtual-selection-red {
+		background-color: red;
 		color: black;
 	}
 </style>
@@ -22,4 +40,6 @@
 	<figure></figure>
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas at diam quis justo imperdiet posuere non eu tortor. Mauris vel magna eu sem hendrerit varius. Ut imperdiet velit ut ante interdum convallis. Vestibulum vitae lacinia mi. </p>
 </div>
-<button id="add-marker">Set marker</button>
+<button id="add-marker-yellow">Set yellow marker</button>
+<button id="add-marker-blue">Set blue marker</button>
+<button id="add-marker-red">Set red marker</button>

--- a/tests/manual/virtualselection.html
+++ b/tests/manual/virtualselection.html
@@ -33,6 +33,10 @@
 		background-color: red;
 		color: black;
 	}
+
+	button {
+		width: 200px;
+	}
 </style>
 
 <div id="editor">
@@ -40,6 +44,11 @@
 	<figure></figure>
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas at diam quis justo imperdiet posuere non eu tortor. Mauris vel magna eu sem hendrerit varius. Ut imperdiet velit ut ante interdum convallis. Vestibulum vitae lacinia mi. </p>
 </div>
-<button id="add-marker-yellow">Set yellow marker</button>
-<button id="add-marker-blue">Set blue marker</button>
-<button id="add-marker-red">Set red marker</button>
+<h2>Markers</h2>
+<button id="add-marker-yellow">Set yellow marker</button><button id="remove-marker-yellow">Remove yellow marker</button>
+<br />
+<button id="add-marker-red">Set red marker</button><button id="remove-marker-red">Remove red marker</button>
+<br />
+<button id="add-marker-blue">Set blue marker</button><button id="remove-marker-blue">Remove blue marker</button>
+<br />
+<button id="remove-markers">Remove all markers</button>

--- a/tests/manual/virtualselection.html
+++ b/tests/manual/virtualselection.html
@@ -1,0 +1,25 @@
+<style>
+	span.virtual-selection {
+		background-color: yellow;
+	}
+
+	.ck-widget.fancy-widget {
+		background-color: black;
+		color: white;
+		text-align: center;
+		height: 40px;
+		line-height: 40px;
+	}
+
+	.ck-widget.fancy-widget.virtual-selection {
+		background-color: yellow;
+		color: black;
+	}
+</style>
+
+<div id="editor">
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas at diam quis justo imperdiet posuere non eu tortor. Mauris vel magna eu sem hendrerit varius. Ut imperdiet velit ut ante interdum convallis. Vestibulum vitae lacinia mi. </p>
+	<figure></figure>
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas at diam quis justo imperdiet posuere non eu tortor. Mauris vel magna eu sem hendrerit varius. Ut imperdiet velit ut ante interdum convallis. Vestibulum vitae lacinia mi. </p>
+</div>
+<button id="add-marker">Set marker</button>

--- a/tests/manual/virtualselection.js
+++ b/tests/manual/virtualselection.js
@@ -69,24 +69,24 @@ ClassicEditor.create( global.document.querySelector( '#editor' ), {
 	plugins: [ Enter, Typing, Paragraph, Undo, Heading, FancyWidget ],
 	toolbar: [ 'headings', 'undo', 'redo' ]
 } )
-.then( editor => {
-	window.editor = editor;
-	const model = editor.document;
+	.then( editor => {
+		window.editor = editor;
+		const model = editor.document;
 
-	buildModelConverter()
-		.for( editor.editing.modelToView )
-		.fromMarker( 'marker' )
-		.toVirtualSelection( { class: 'virtual-selection' } );
+		buildModelConverter()
+			.for( editor.editing.modelToView )
+			.fromMarker( 'marker' )
+			.toVirtualSelection( { class: 'virtual-selection' } );
 
-	document.getElementById( 'add-marker' ).addEventListener( 'mousedown', evt => {
-		editor.document.enqueueChanges( () => {
-			const range = ModelRange.createFromRange( model.selection.getFirstRange() );
-			model.markers.set( 'marker', range );
+		document.getElementById( 'add-marker' ).addEventListener( 'mousedown', evt => {
+			editor.document.enqueueChanges( () => {
+				const range = ModelRange.createFromRange( model.selection.getFirstRange() );
+				model.markers.set( 'marker', range );
+			} );
+
+			evt.preventDefault();
 		} );
-
-		evt.preventDefault();
+	} )
+	.catch( err => {
+		console.error( err.stack );
 	} );
-} )
-.catch( err => {
-	console.error( err.stack );
-} );

--- a/tests/manual/virtualselection.js
+++ b/tests/manual/virtualselection.js
@@ -43,20 +43,19 @@ class FancyWidget extends Plugin {
 		buildModelConverter().for( editing.modelToView )
 			.fromElement( 'fancywidget' )
 			.toElement( () => {
-				const text = new ViewText( 'widget' );
-				const fancyView = new ViewContainerElement( 'figure', { class: 'fancy-widget' }, text );
+				const widgetElement = new ViewContainerElement( 'figure', { class: 'fancy-widget' }, new ViewText( 'widget' ) );
 
-				fancyView.setVirtualSelection = data => {
-					text.data = 'widget - with virtual selection';
-					fancyView.addClass( data.class );
-				};
+				widgetElement.setCustomProperty( 'setVirtualSelection', ( element, data ) => {
+					element.getChild( 0 ).data = 'widget - with virtual selection';
+					element.addClass( data.class );
+				} );
 
-				fancyView.removeVirtualSelection = data => {
-					text.data = 'widget';
-					fancyView.removeClass( data.class );
-				};
+				widgetElement.setCustomProperty( 'removeVirtualSelection', ( element, data ) => {
+					element.getChild( 0 ).data = 'widget';
+					element.removeClass( data.class );
+				} );
 
-				return toWidget( fancyView );
+				return toWidget( widgetElement );
 			} );
 
 		// Build converter from view element to model element for data pipeline.

--- a/tests/manual/virtualselection.js
+++ b/tests/manual/virtualselection.js
@@ -11,6 +11,9 @@ import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import List from '@ckeditor/ckeditor5-list/src/list';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import buildModelConverter from '../../src/conversion/buildmodelconverter';
 import buildViewConverter from '../../src/conversion/buildviewconverter';
@@ -56,8 +59,8 @@ class FancyWidget extends Plugin {
 }
 
 ClassicEditor.create( global.document.querySelector( '#editor' ), {
-	plugins: [ Enter, Typing, Paragraph, Undo, Heading, FancyWidget ],
-	toolbar: [ 'headings', 'undo', 'redo' ]
+	plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic, List, FancyWidget ],
+	toolbar: [ 'headings', 'undo', 'redo', 'bold', 'italic', 'numberedList', 'bulletedList' ]
 } )
 	.then( editor => {
 		window.editor = editor;

--- a/tests/manual/virtualselection.js
+++ b/tests/manual/virtualselection.js
@@ -45,16 +45,6 @@ class FancyWidget extends Plugin {
 			.toElement( () => {
 				const widgetElement = new ViewContainerElement( 'figure', { class: 'fancy-widget' }, new ViewText( 'widget' ) );
 
-				widgetElement.setCustomProperty( 'setVirtualSelection', ( element, data ) => {
-					element.getChild( 0 ).data = 'widget - with virtual selection';
-					element.addClass( data.class );
-				} );
-
-				widgetElement.setCustomProperty( 'removeVirtualSelection', ( element, data ) => {
-					element.getChild( 0 ).data = 'widget';
-					element.removeClass( data.class );
-				} );
-
 				return toWidget( widgetElement );
 			} );
 
@@ -71,22 +61,36 @@ ClassicEditor.create( global.document.querySelector( '#editor' ), {
 } )
 	.then( editor => {
 		window.editor = editor;
-		const model = editor.document;
 
 		buildModelConverter()
 			.for( editor.editing.modelToView )
 			.fromMarker( 'marker' )
-			.toVirtualSelection( { class: 'virtual-selection' } );
+			.toVirtualSelection( data => ( { class: 'virtual-selection-' + data.markerName.split( ':' )[ 1 ] } ) );
 
-		document.getElementById( 'add-marker' ).addEventListener( 'mousedown', evt => {
-			editor.document.enqueueChanges( () => {
-				const range = ModelRange.createFromRange( model.selection.getFirstRange() );
-				model.markers.set( 'marker', range );
-			} );
+		document.getElementById( 'add-marker-yellow' ).addEventListener( 'mousedown', evt => {
+			addMarker( editor, 'yellow' );
+			evt.preventDefault();
+		} );
 
+		document.getElementById( 'add-marker-blue' ).addEventListener( 'mousedown', evt => {
+			addMarker( editor, 'blue' );
+			evt.preventDefault();
+		} );
+
+		document.getElementById( 'add-marker-red' ).addEventListener( 'mousedown', evt => {
+			addMarker( editor, 'red' );
 			evt.preventDefault();
 		} );
 	} )
 	.catch( err => {
 		console.error( err.stack );
 	} );
+
+function addMarker( editor, color ) {
+	const model = editor.document;
+
+	editor.document.enqueueChanges( () => {
+		const range = ModelRange.createFromRange( model.selection.getFirstRange() );
+		model.markers.set( 'marker:' + color, range );
+	} );
+}

--- a/tests/manual/virtualselection.js
+++ b/tests/manual/virtualselection.js
@@ -81,6 +81,33 @@ ClassicEditor.create( global.document.querySelector( '#editor' ), {
 			addMarker( editor, 'red' );
 			evt.preventDefault();
 		} );
+
+		document.getElementById( 'remove-marker-yellow' ).addEventListener( 'mousedown', evt => {
+			removeMarker( editor, 'yellow' );
+			evt.preventDefault();
+		} );
+
+		document.getElementById( 'remove-marker-blue' ).addEventListener( 'mousedown', evt => {
+			removeMarker( editor, 'blue' );
+			evt.preventDefault();
+		} );
+
+		document.getElementById( 'remove-marker-red' ).addEventListener( 'mousedown', evt => {
+			removeMarker( editor, 'red' );
+			evt.preventDefault();
+		} );
+
+		document.getElementById( 'remove-markers' ).addEventListener( 'mousedown', evt => {
+			const markers = editor.document.markers;
+
+			editor.document.enqueueChanges( () => {
+				for ( const marker of markers ) {
+					markers.remove( marker );
+				}
+			} );
+
+			evt.preventDefault();
+		} );
 	} )
 	.catch( err => {
 		console.error( err.stack );
@@ -92,5 +119,13 @@ function addMarker( editor, color ) {
 	editor.document.enqueueChanges( () => {
 		const range = ModelRange.createFromRange( model.selection.getFirstRange() );
 		model.markers.set( 'marker:' + color, range );
+	} );
+}
+
+function removeMarker( editor, color ) {
+	const model = editor.document;
+
+	editor.document.enqueueChanges( () => {
+		model.markers.remove( 'marker:' + color );
 	} );
 }

--- a/tests/manual/virtualselection.js
+++ b/tests/manual/virtualselection.js
@@ -1,0 +1,93 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Undo from '@ckeditor/ckeditor5-undo/src/undo';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import global from '@ckeditor/ckeditor5-utils/src/dom/global';
+import buildModelConverter from '../../src/conversion/buildmodelconverter';
+import buildViewConverter from '../../src/conversion/buildviewconverter';
+import ModelRange from '../../src/model/range';
+import ModelElement from '../../src/model/element';
+import ViewContainerElement from '../../src/view/containerelement';
+import ViewText from '../../src/view/text';
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
+import { toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
+
+class FancyWidget extends Plugin {
+	static get requires() {
+		return [ Widget ];
+	}
+
+	init() {
+		const editor = this.editor;
+		const doc = editor.document;
+		const schema = doc.schema;
+		const data = editor.data;
+		const editing = editor.editing;
+
+		// Configure schema.
+		schema.registerItem( 'fancywidget' );
+		schema.allow( { name: 'fancywidget', inside: '$root' } );
+		schema.objects.add( 'fancywidget' );
+
+		// Build converter from model to view for editing pipeline.
+		buildModelConverter().for( editing.modelToView )
+			.fromElement( 'fancywidget' )
+			.toElement( () => {
+				const text = new ViewText( 'widget' );
+				const fancyView = new ViewContainerElement( 'figure', { class: 'fancy-widget' }, text );
+
+				fancyView.setVirtualSelection = data => {
+					text.data = 'widget - with virtual selection';
+					fancyView.addClass( data.class );
+				};
+
+				fancyView.removeVirtualSelection = data => {
+					text.data = 'widget';
+					fancyView.removeClass( data.class );
+				};
+
+				return toWidget( fancyView );
+			} );
+
+		// Build converter from view element to model element for data pipeline.
+		buildViewConverter().for( data.viewToModel )
+			.fromElement( 'figure' )
+			.toElement( () => new ModelElement( 'fancywidget' ) );
+	}
+}
+
+ClassicEditor.create( global.document.querySelector( '#editor' ), {
+	plugins: [ Enter, Typing, Paragraph, Undo, Heading, FancyWidget ],
+	toolbar: [ 'headings', 'undo', 'redo' ]
+} )
+.then( editor => {
+	window.editor = editor;
+	const model = editor.document;
+
+	buildModelConverter()
+		.for( editor.editing.modelToView )
+		.fromMarker( 'marker' )
+		.toVirtualSelection( { class: 'virtual-selection' } );
+
+	document.getElementById( 'add-marker' ).addEventListener( 'mousedown', evt => {
+		editor.document.enqueueChanges( () => {
+			const range = ModelRange.createFromRange( model.selection.getFirstRange() );
+			model.markers.set( 'marker', range );
+		} );
+
+		evt.preventDefault();
+	} );
+} )
+.catch( err => {
+	console.error( err.stack );
+} );

--- a/tests/manual/virtualselection.md
+++ b/tests/manual/virtualselection.md
@@ -1,7 +1,14 @@
 ### Virtual selection manual test
 
-1. Select widget and press `Set marker` button - widget's background color should change.
-1. Select part of the text in the first paragraph and press `Set marker` - widget's should return to its initial state, 
-text should be highlighted.
-1. Create selection that starts in the first paragraph and ends in second one. Press `Set marker`. Selected text
-should be highlighted and widget should have virtual selection applied.
+1. Create selection that starts before the last word of the first paragraph and ends after first
+word of the second paragraph and press `Set yellow marker`.
+1. Yellow marker should be visible on text and widget.
+1. Select whole contents of the editor and press `Set red marker`.
+1. Yellow marker should be visible as before, red marker should be visible on ranges where yellow marker is not
+applied.
+1. Click `Remove yellow marker`.
+1. Red marker should be visible on the whole content, including the widget.
+1. Play with markers, add and remove them, check if they are applied correctly.
+
+NOTE: Yellow marker should be visible over red and blue one. Red marker should be visible over blue one. 
+

--- a/tests/manual/virtualselection.md
+++ b/tests/manual/virtualselection.md
@@ -1,7 +1,6 @@
 ### Virtual selection manual test
 
-1. Select widget and press `Set marker` button - widget's background color should change and text should change 
-to `widget - with virtual selection`.
+1. Select widget and press `Set marker` button - widget's background color should change.
 1. Select part of the text in the first paragraph and press `Set marker` - widget's should return to its initial state, 
 text should be highlighted.
 1. Create selection that starts in the first paragraph and ends in second one. Press `Set marker`. Selected text

--- a/tests/manual/virtualselection.md
+++ b/tests/manual/virtualselection.md
@@ -1,0 +1,8 @@
+### Virtual selection manual test
+
+1. Select widget and press `Set marker` button - widget's background color should change and text should change 
+to `widget - with virtual selection`.
+1. Select part of the text in the first paragraph and press `Set marker` - widget's should return to its initial state, 
+text should be highlighted.
+1. Create selection that starts in the first paragraph and ends in second one. Press `Set marker`. Selected text
+should be highlighted and widget should have virtual selection applied.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Created virtual selection handling in model to view converters. Closes #1015. 

BREAKING CHANGE: `ModelConverterBuilder#toStamp()` functionality is moved to `ModelConverterBuilder#toElement`. Introduced `ModelConverterBuilder#toVirtualSelection` which replaces current marker to element conversion.
BREAKING CHANGE: Parameter change for `convertSelectionMarker()` function from `model-selection-to-view-converters.js`.
BREAKING CHANGE: Removed `wrapRange()` and `unwrapRange()` functions from `model-to-view-converters.js` as they're no longer used.
BREAKING CHANGE: Removed `breakViewRangePerContainer()` from view writer as it's no longer used.
BREAKING CHANGE: Renamed `StampCreatorData` to `MarkerViewElementCreatorData` and renamed its fields.