### PR TITLE
T/1009: Element#getNodeByPath() should expect offsets not indexes

### DIFF
--- a/src/model/documentfragment.js
+++ b/src/model/documentfragment.js
@@ -186,7 +186,7 @@ export default class DocumentFragment {
 		let node = this; // eslint-disable-line consistent-this
 
 		for ( const index of relativePath ) {
-			node = node.getChild( index );
+			node = node.getChild( node.offsetToIndex( index ) );
 		}
 
 		return node;

--- a/src/model/element.js
+++ b/src/model/element.js
@@ -241,7 +241,7 @@ export default class Element extends Node {
 		let node = this; // eslint-disable-line consistent-this
 
 		for ( const index of relativePath ) {
-			node = node.getChild( index );
+			node = node.getChild( node.offsetToIndex( index ) );
 		}
 
 		return node;

--- a/tests/controller/getselectedcontent.js
+++ b/tests/controller/getselectedcontent.js
@@ -309,6 +309,26 @@ describe( 'Delete utils', () => {
 				expect( content )
 					.to.equal( '<quote><heading1>bc</heading1></quote><heading1>x</heading1><quote><heading1>de</heading1></quote>' );
 			} );
+
+			// See: https://github.com/ckeditor/ckeditor5-engine/pull/1043#issuecomment-318012286
+			it( 'ensures that elements are retrieved by indexes instead of offsets', () => {
+				doc.schema.allow( { name: '$text', inside: '$root' } );
+				doc.schema.allow( { name: '$text', inside: 'quote' } );
+
+				setData( doc,
+					'foo' +
+					'<quote>' +
+						'<paragraph>' +
+							'b[ar' +
+						'</paragraph>' +
+						'bo]m' +
+					'</quote>'
+				);
+
+				const content = stringify( getSelectedContent( doc.selection ) );
+				expect( content )
+					.to.equal( '<paragraph>ar</paragraph>bo' );
+			} );
 		} );
 	} );
 } );

--- a/tests/model/documentfragment.js
+++ b/tests/model/documentfragment.js
@@ -309,16 +309,50 @@ describe( 'DocumentFragment', () => {
 		} );
 
 		it( 'should return a descendant of this node', () => {
+			const foo = new Text( 'foo' );
 			const image = new Element( 'image' );
 			const element = new Element( 'elem', [], [
 				new Element( 'elem', [], [
-					new Text( 'foo' ),
+					foo,
 					image
 				] )
 			] );
 			const frag = new DocumentFragment( element );
 
-			expect( frag.getNodeByPath( [ 0, 0, 1 ] ) ).to.equal( image );
+			expect( frag.getNodeByPath( [ 0, 0, 0 ] ) ).to.equal( foo );
+			expect( frag.getNodeByPath( [ 0, 0, 1 ] ) ).to.equal( foo );
+			expect( frag.getNodeByPath( [ 0, 0, 2 ] ) ).to.equal( foo );
+			expect( frag.getNodeByPath( [ 0, 0, 3 ] ) ).to.equal( image );
+		} );
+
+		it( 'works fine with offsets', () => {
+			const bar = new Text( 'bar' );
+			const foo = new Text( 'foo' );
+			const bom = new Text( 'bom' );
+			const bold = new Element( 'b', [], [
+				bar
+			] );
+			const paragraph = new Element( 'paragraph', [], [
+				foo,
+				bold,
+				bom
+			] );
+			const frag = new DocumentFragment( paragraph );
+
+			// <paragraph>foo<bold>bar</bold>bom</paragraph>
+
+			expect( frag.getNodeByPath( [ 0, 0 ] ) ).to.equal( foo );
+			expect( frag.getNodeByPath( [ 0, 1 ] ) ).to.equal( foo );
+			expect( frag.getNodeByPath( [ 0, 2 ] ) ).to.equal( foo );
+			expect( frag.getNodeByPath( [ 0, 3 ] ) ).to.equal( bold );
+			expect( frag.getNodeByPath( [ 0, 3, 0 ] ) ).to.equal( bar );
+			expect( frag.getNodeByPath( [ 0, 3, 1 ] ) ).to.equal( bar );
+			expect( frag.getNodeByPath( [ 0, 3, 2 ] ) ).to.equal( bar );
+			expect( frag.getNodeByPath( [ 0, 3, 3 ] ) ).to.equal( null );
+			expect( frag.getNodeByPath( [ 0, 4 ] ) ).to.equal( bom );
+			expect( frag.getNodeByPath( [ 0, 5 ] ) ).to.equal( bom );
+			expect( frag.getNodeByPath( [ 0, 6 ] ) ).to.equal( bom );
+			expect( frag.getNodeByPath( [ 0, 7 ] ) ).to.equal( null );
 		} );
 	} );
 } );

--- a/tests/model/documentfragment.js
+++ b/tests/model/documentfragment.js
@@ -326,6 +326,8 @@ describe( 'DocumentFragment', () => {
 		} );
 
 		it( 'works fine with offsets', () => {
+			const abc = new Text( 'abc' );
+			const xyz = new Text( 'xyz' );
 			const bar = new Text( 'bar' );
 			const foo = new Text( 'foo' );
 			const bom = new Text( 'bom' );
@@ -337,22 +339,34 @@ describe( 'DocumentFragment', () => {
 				bold,
 				bom
 			] );
-			const frag = new DocumentFragment( paragraph );
+			const frag = new DocumentFragment( [
+				abc,
+				paragraph,
+				xyz
+			] );
 
-			// <paragraph>foo<bold>bar</bold>bom</paragraph>
+			// abc<paragraph>foo<bold>bar</bold>bom</paragraph>xyz
 
-			expect( frag.getNodeByPath( [ 0, 0 ] ) ).to.equal( foo );
-			expect( frag.getNodeByPath( [ 0, 1 ] ) ).to.equal( foo );
-			expect( frag.getNodeByPath( [ 0, 2 ] ) ).to.equal( foo );
-			expect( frag.getNodeByPath( [ 0, 3 ] ) ).to.equal( bold );
-			expect( frag.getNodeByPath( [ 0, 3, 0 ] ) ).to.equal( bar );
-			expect( frag.getNodeByPath( [ 0, 3, 1 ] ) ).to.equal( bar );
-			expect( frag.getNodeByPath( [ 0, 3, 2 ] ) ).to.equal( bar );
-			expect( frag.getNodeByPath( [ 0, 3, 3 ] ) ).to.equal( null );
-			expect( frag.getNodeByPath( [ 0, 4 ] ) ).to.equal( bom );
-			expect( frag.getNodeByPath( [ 0, 5 ] ) ).to.equal( bom );
-			expect( frag.getNodeByPath( [ 0, 6 ] ) ).to.equal( bom );
-			expect( frag.getNodeByPath( [ 0, 7 ] ) ).to.equal( null );
+			expect( frag.getNodeByPath( [ 0 ] ), 1 ).to.equal( abc );
+			expect( frag.getNodeByPath( [ 1 ] ), 2 ).to.equal( abc );
+			expect( frag.getNodeByPath( [ 2 ] ), 3 ).to.equal( abc );
+			expect( frag.getNodeByPath( [ 3 ] ), 4 ).to.equal( paragraph );
+			expect( frag.getNodeByPath( [ 3, 0 ] ), 5 ).to.equal( foo );
+			expect( frag.getNodeByPath( [ 3, 1 ] ), 6 ).to.equal( foo );
+			expect( frag.getNodeByPath( [ 3, 2 ] ), 7 ).to.equal( foo );
+			expect( frag.getNodeByPath( [ 3, 3 ] ), 8 ).to.equal( bold );
+			expect( frag.getNodeByPath( [ 3, 3, 0 ] ), 9 ).to.equal( bar );
+			expect( frag.getNodeByPath( [ 3, 3, 1 ] ), 10 ).to.equal( bar );
+			expect( frag.getNodeByPath( [ 3, 3, 2 ] ), 11 ).to.equal( bar );
+			expect( frag.getNodeByPath( [ 3, 3, 3 ] ), 12 ).to.equal( null );
+			expect( frag.getNodeByPath( [ 3, 4 ] ), 13 ).to.equal( bom );
+			expect( frag.getNodeByPath( [ 3, 5 ] ), 14 ).to.equal( bom );
+			expect( frag.getNodeByPath( [ 3, 6 ] ), 15 ).to.equal( bom );
+			expect( frag.getNodeByPath( [ 3, 7 ] ), 16 ).to.equal( null );
+			expect( frag.getNodeByPath( [ 4 ] ), 17 ).to.equal( xyz );
+			expect( frag.getNodeByPath( [ 5 ] ), 18 ).to.equal( xyz );
+			expect( frag.getNodeByPath( [ 6 ] ), 19 ).to.equal( xyz );
+			expect( frag.getNodeByPath( [ 7 ] ), 20 ).to.equal( null );
 		} );
 	} );
 } );

--- a/tests/model/element.js
+++ b/tests/model/element.js
@@ -176,15 +176,48 @@ describe( 'Element', () => {
 		} );
 
 		it( 'should return a descendant of this node', () => {
+			const foo = new Text( 'foo' );
 			const image = new Element( 'image' );
 			const element = new Element( 'elem', [], [
 				new Element( 'elem', [], [
-					new Text( 'foo' ),
+					foo,
 					image
 				] )
 			] );
 
-			expect( element.getNodeByPath( [ 0, 1 ] ) ).to.equal( image );
+			expect( element.getNodeByPath( [ 0, 0 ] ) ).to.equal( foo );
+			expect( element.getNodeByPath( [ 0, 1 ] ) ).to.equal( foo );
+			expect( element.getNodeByPath( [ 0, 2 ] ) ).to.equal( foo );
+			expect( element.getNodeByPath( [ 0, 3 ] ) ).to.equal( image );
+		} );
+
+		it( 'works fine with offsets', () => {
+			const bar = new Text( 'bar' );
+			const foo = new Text( 'foo' );
+			const bom = new Text( 'bom' );
+			const bold = new Element( 'b', [], [
+				bar
+			] );
+			const paragraph = new Element( 'paragraph', [], [
+				foo,
+				bold,
+				bom
+			] );
+
+			// <paragraph>foo<bold>bar</bold>bom</paragraph>
+
+			expect( paragraph.getNodeByPath( [ 0 ] ) ).to.equal( foo );
+			expect( paragraph.getNodeByPath( [ 1 ] ) ).to.equal( foo );
+			expect( paragraph.getNodeByPath( [ 2 ] ) ).to.equal( foo );
+			expect( paragraph.getNodeByPath( [ 3 ] ) ).to.equal( bold );
+			expect( paragraph.getNodeByPath( [ 3, 0 ] ) ).to.equal( bar );
+			expect( paragraph.getNodeByPath( [ 3, 1 ] ) ).to.equal( bar );
+			expect( paragraph.getNodeByPath( [ 3, 2 ] ) ).to.equal( bar );
+			expect( paragraph.getNodeByPath( [ 3, 3 ] ) ).to.equal( null );
+			expect( paragraph.getNodeByPath( [ 4 ] ) ).to.equal( bom );
+			expect( paragraph.getNodeByPath( [ 5 ] ) ).to.equal( bom );
+			expect( paragraph.getNodeByPath( [ 6 ] ) ).to.equal( bom );
+			expect( paragraph.getNodeByPath( [ 7 ] ) ).to.equal( null );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `model.Element#getNodeByPath()` and `model.DocumentFragment#getNodeByPath()` work with offsets instead of indexes. Closes #1009.
