### PR TITLE
T/1045: Added a `preventReplacingWithParagraph` flag to `DataController#deleteContent()`

### DIFF
--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -19,6 +19,7 @@ import Element from '../model/element';
  * @param {module:engine/model/batch~Batch} batch Batch to which the deltas will be added.
  * @param {Object} [options]
  * @param {Boolean} [options.leaveUnmerged=false] Whether to merge elements after removing the content of the selection.
+ * @param {Boolean} [options.preventReplacingWithParagraph=false] Whether the entire content shouldn't be replaced with the paragraph.
  *
  * For example `<h>x[x</h><p>y]y</p>` will become:
  * * `<h>x^y</h>` with the option disabled (`leaveUnmerged == false`)
@@ -34,7 +35,7 @@ export default function deleteContent( selection, batch, options = {} ) {
 
 	// 1. Replace the entire content with paragraph.
 	// See: https://github.com/ckeditor/ckeditor5-engine/issues/1012#issuecomment-315017594.
-	if ( shouldEntireContentBeReplacedWithParagraph( batch.document.schema, selection ) ) {
+	if ( !options.preventReplacingWithParagraph && shouldEntireContentBeReplacedWithParagraph( batch.document.schema, selection ) ) {
 		replaceEntireContentWithParagraph( batch, selection );
 
 		return;

--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -19,14 +19,22 @@ import Element from '../model/element';
  * @param {module:engine/model/batch~Batch} batch Batch to which the deltas will be added.
  * @param {Object} [options]
  * @param {Boolean} [options.leaveUnmerged=false] Whether to merge elements after removing the content of the selection.
- * @param {Boolean} [options.preventReplacingWithParagraph=false] Whether the entire content shouldn't be replaced with the paragraph.
  *
- * For example `<h>x[x</h><p>y]y</p>` will become:
- * * `<h>x^y</h>` with the option disabled (`leaveUnmerged == false`)
- * * `<h>x^</h><p>y</p>` with enabled (`leaveUnmerged == true`).
+ * For example `<heading>x[x</heading><paragraph>y]y</paragraph>` will become:
+ *
+ * * `<heading>x^y</heading>` with the option disabled (`leaveUnmerged == false`)
+ * * `<heading>x^</heading><paragraph>y</paragraph>` with enabled (`leaveUnmerged == true`).
  *
  * Note: {@link module:engine/model/schema~Schema#objects object} and {@link module:engine/model/schema~Schema#limits limit}
  * elements will not be merged.
+ *
+ * @param {Boolean} [options.doNotResetEntireContent=false] Whether to skip replacing the entire content with a
+ * paragraph when the entire content was selected.
+ *
+ * For example `<heading>[x</heading><paragraph>y]</paragraph> will become:
+ *
+ * * `<paragraph>^</paragraph>` with the option disabled (`doNotResetEntireContent == false`)
+ * * `<heading>^</heading>` with enabled (`doNotResetEntireContent == true`).
  */
 export default function deleteContent( selection, batch, options = {} ) {
 	if ( selection.isCollapsed ) {
@@ -35,7 +43,7 @@ export default function deleteContent( selection, batch, options = {} ) {
 
 	// 1. Replace the entire content with paragraph.
 	// See: https://github.com/ckeditor/ckeditor5-engine/issues/1012#issuecomment-315017594.
-	if ( !options.preventReplacingWithParagraph && shouldEntireContentBeReplacedWithParagraph( batch.document.schema, selection ) ) {
+	if ( !options.doNotResetEntireContent && shouldEntireContentBeReplacedWithParagraph( batch.document.schema, selection ) ) {
 		replaceEntireContentWithParagraph( batch, selection );
 
 		return;

--- a/tests/controller/deletecontent.js
+++ b/tests/controller/deletecontent.js
@@ -751,11 +751,11 @@ describe( 'DataController', () => {
 			} );
 
 			test(
-				'but not if the flag "preventReplacingWithParagraph" is set on true',
+				'but not if the flag "doNotResetEntireContent" is set to true',
 				'<heading1>[</heading1><paragraph>]</paragraph>',
 				'<heading1>[]</heading1>',
 				{
-					preventReplacingWithParagraph: true
+					doNotResetEntireContent: true
 				}
 			);
 		} );

--- a/tests/controller/deletecontent.js
+++ b/tests/controller/deletecontent.js
@@ -749,6 +749,15 @@ describe( 'DataController', () => {
 				expect( getData( doc, { rootName: 'paragraphRoot' } ) )
 					.to.equal( 'x[]z' );
 			} );
+
+			test(
+				'but not if the flag "preventReplacingWithParagraph" is set on true',
+				'<heading1>[</heading1><paragraph>]</paragraph>',
+				'<heading1>[]</heading1>',
+				{
+					preventReplacingWithParagraph: true
+				}
+			);
 		} );
 
 		function test( title, input, output, options ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Added a flag "preventReplacingWithParagraph" to `DataController#deleteContent()` method. Closes #1045.

---

The rest of the ticket:

> After talking with @Reinmar the conclusion is that probably it will be the best to solve this by adding another parameter in `deleteContent` function. As much as I don't like this solution, it is possibly the easiest to implement and maintain, so I propose `preventReplacingWithParagraph` flag.
>
> When this is done, the flag should be set to `true` in `DeleteCommand` if original selection was collapsed.

will be solved in typing repository.