### PR TITLE
T/1055 Selection attributes should be cleared in an enqueueChanges block

### DIFF
--- a/src/model/delta/basic-transformations.js
+++ b/src/model/delta/basic-transformations.js
@@ -409,6 +409,13 @@ addTransformationCase( RemoveDelta, SplitDelta, ( a, b, context ) => {
 	const deltas = defaultTransform( a, b, context );
 	const insertPosition = b._cloneOperation.position;
 
+	const undoMode = context.aWasUndone || context.bWasUndone;
+
+	// Special case applies only if undo is not a context.
+	if ( undoMode ) {
+		return deltas;
+	}
+
 	// In case if `defaultTransform` returned more than one delta.
 	for ( const delta of deltas ) {
 		// "No delta" may be returned in some cases.
@@ -427,6 +434,13 @@ addTransformationCase( RemoveDelta, SplitDelta, ( a, b, context ) => {
 
 // Add special case for SplitDelta x RemoveDelta transformation.
 addTransformationCase( SplitDelta, RemoveDelta, ( a, b, context ) => {
+	const undoMode = context.aWasUndone || context.bWasUndone;
+
+	// Special case applies only if undo is not a context.
+	if ( undoMode ) {
+		return defaultTransform( a, b, context );
+	}
+
 	// This case is very trickily solved.
 	// Instead of fixing `a` delta, we change `b` delta for a while and fire default transformation with fixed `b` delta.
 	// Thanks to that fixing `a` delta will be differently (correctly) transformed.

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -85,7 +85,7 @@ export default class DocumentSelection extends Selection {
 
 			// Whenever element which had selection's attributes stored in it stops being empty,
 			// the attributes need to be removed.
-			clearAttributesStoredInElement( changes, batch );
+			clearAttributesStoredInElement( changes, batch, this._document );
 		} );
 	}
 
@@ -691,7 +691,7 @@ function getAttrsIfCharacter( node ) {
 }
 
 // Removes selection attributes from element which is not empty anymore.
-function clearAttributesStoredInElement( changes, batch ) {
+function clearAttributesStoredInElement( changes, batch, document ) {
 	// Batch may not be passed to the document#change event in some tests.
 	// See https://github.com/ckeditor/ckeditor5-engine/issues/1001#issuecomment-314202352
 	// Ignore also transparent batches because they are... transparent.
@@ -707,9 +707,15 @@ function clearAttributesStoredInElement( changes, batch ) {
 		return;
 	}
 
-	const storedAttributes = Array.from( changeParent.getAttributeKeys() ).filter( key => key.startsWith( storePrefix ) );
+	const anyStoredAttributes = Array.from( changeParent.getAttributeKeys() ).some( key => key.startsWith( storePrefix ) );
 
-	for ( const key of storedAttributes ) {
-		batch.removeAttribute( changeParent, key );
+	if ( anyStoredAttributes ) {
+		document.enqueueChanges( () => {
+			const storedAttributes = Array.from( changeParent.getAttributeKeys() ).filter( key => key.startsWith( storePrefix ) );
+
+			for ( const key of storedAttributes ) {
+				batch.removeAttribute( changeParent, key );
+			}
+		} );
 	}
 }

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -707,15 +707,11 @@ function clearAttributesStoredInElement( changes, batch, document ) {
 		return;
 	}
 
-	const anyStoredAttributes = Array.from( changeParent.getAttributeKeys() ).some( key => key.startsWith( storePrefix ) );
+	document.enqueueChanges( () => {
+		const storedAttributes = Array.from( changeParent.getAttributeKeys() ).filter( key => key.startsWith( storePrefix ) );
 
-	if ( anyStoredAttributes ) {
-		document.enqueueChanges( () => {
-			const storedAttributes = Array.from( changeParent.getAttributeKeys() ).filter( key => key.startsWith( storePrefix ) );
-
-			for ( const key of storedAttributes ) {
-				batch.removeAttribute( changeParent, key );
-			}
-		} );
-	}
+		for ( const key of storedAttributes ) {
+			batch.removeAttribute( changeParent, key );
+		}
+	} );
 }

--- a/tests/model/delta/transform/_utils/utils.js
+++ b/tests/model/delta/transform/_utils/utils.js
@@ -202,14 +202,14 @@ export function expectDelta( delta, expected ) {
 export function expectOperation( op, params ) {
 	for ( const i in params ) {
 		if ( i == 'type' ) {
-			expect( op ).to.be.instanceof( params[ i ] );
+			expect( op, 'operation type' ).to.be.instanceof( params[ i ] );
 		}
 		else if ( i == 'nodes' ) {
-			expect( Array.from( op.nodes ) ).to.deep.equal( params[ i ] );
+			expect( Array.from( op.nodes ), 'nodes' ).to.deep.equal( params[ i ] );
 		} else if ( params[ i ] instanceof Position || params[ i ] instanceof Range ) {
-			expect( op[ i ].isEqual( params[ i ] ) ).to.be.true;
+			expect( op[ i ].isEqual( params[ i ] ), 'property ' + i ).to.be.true;
 		} else {
-			expect( op[ i ] ).to.equal( params[ i ] );
+			expect( op[ i ], 'property ' + 1 ).to.equal( params[ i ] );
 		}
 	}
 }

--- a/tests/model/delta/transform/removedelta.js
+++ b/tests/model/delta/transform/removedelta.js
@@ -184,6 +184,35 @@ describe( 'transform', () => {
 					]
 				} );
 			} );
+
+			it( 'removed node has been split - undo context', () => {
+				const sourcePosition = new Position( root, [ 3, 3, 1 ] );
+				const removeDelta = getRemoveDelta( sourcePosition, 1, baseVersion );
+
+				const splitPosition = new Position( root, [ 3, 3, 1, 2 ] );
+				const nodeCopy = new Element( 'x' );
+				const splitDelta = getSplitDelta( splitPosition, nodeCopy, 2, baseVersion );
+
+				context.bWasUndone = true;
+
+				const transformed = transform( removeDelta, splitDelta, context );
+
+				expect( transformed.length ).to.equal( 1 );
+
+				baseVersion = splitDelta.operations.length;
+
+				expectDelta( transformed[ 0 ], {
+					type: RemoveDelta,
+					operations: [
+						{
+							type: RemoveOperation,
+							sourcePosition,
+							howMany: 1,
+							baseVersion
+						}
+					]
+				} );
+			} );
 		} );
 	} );
 } );

--- a/tests/model/delta/transform/renamedelta.js
+++ b/tests/model/delta/transform/renamedelta.js
@@ -76,6 +76,39 @@ describe( 'transform', () => {
 				} );
 			} );
 
+			it( 'split element is renamed but split delta was undone', () => {
+				const renameDelta = new RenameDelta();
+				renameDelta.addOperation( new RenameOperation(
+					new Position( root, [ 3, 3 ] ),
+					'p',
+					'li',
+					baseVersion
+				) );
+
+				const splitPosition = new Position( root, [ 3, 3, 3 ] );
+				const splitDelta = getSplitDelta( splitPosition, new Element( 'p' ), 9, baseVersion );
+
+				context.bWasUndone = true;
+
+				const transformed = transform( renameDelta, splitDelta, context );
+
+				baseVersion = splitDelta.length;
+
+				expect( transformed.length ).to.equal( 1 );
+
+				expectDelta( transformed[ 0 ], {
+					type: RenameDelta,
+					operations: [
+						{
+							type: RenameOperation,
+							oldName: 'p',
+							newName: 'li',
+							position: new Position( root, [ 3, 3 ] )
+						}
+					]
+				} );
+			} );
+
 			it( 'split element is different than renamed element', () => {
 				const renameDelta = new RenameDelta();
 				renameDelta.addOperation( new RenameOperation(

--- a/tests/model/delta/transform/splitdelta.js
+++ b/tests/model/delta/transform/splitdelta.js
@@ -814,6 +814,37 @@ describe( 'transform', () => {
 					]
 				} );
 			} );
+
+			it( 'split node has been removed - undo context', () => {
+				const removePosition = new Position( root, [ 3, 3, 3 ] );
+				const removeDelta = getRemoveDelta( removePosition, 1, baseVersion );
+
+				context.bWasUndone = true;
+
+				const transformed = transform( splitDelta, removeDelta, context );
+
+				expect( transformed.length ).to.equal( 1 );
+
+				baseVersion = removeDelta.operations.length;
+
+				expectDelta( transformed[ 0 ], {
+					type: SplitDelta,
+					operations: [
+						{
+							type: InsertOperation,
+							position: splitDelta.operations[ 0 ].position.getShiftedBy( -1 ),
+							baseVersion
+						},
+						{
+							type: ReinsertOperation,
+							sourcePosition: new Position( gy, [ 0, 3 ] ),
+							howMany: splitDelta.operations[ 1 ].howMany,
+							targetPosition: new Position( root, [ 3, 3, 3, 0 ] ),
+							baseVersion: baseVersion + 1
+						}
+					]
+				} );
+			} );
 		} );
 	} );
 } );

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -990,7 +990,11 @@ describe( 'DocumentSelection', () => {
 					batchTypes.set( batch, batch.type );
 				} );
 
+				sinon.spy( doc, 'enqueueChanges' );
+
 				doc.batch().insert( rangeInEmptyP.start, 'x' );
+
+				expect( doc.enqueueChanges.calledOnce ).to.be.true;
 
 				expect( emptyP.hasAttribute( fooStoreAttrKey ) ).to.be.false;
 				expect( emptyP.hasAttribute( abcStoreAttrKey ) ).to.be.false;
@@ -1002,8 +1006,11 @@ describe( 'DocumentSelection', () => {
 				selection.setRanges( [ rangeInEmptyP ] );
 				selection.setAttribute( 'foo', 'bar' );
 
+				sinon.spy( doc, 'enqueueChanges' );
+
 				doc.batch().move( fullP.getChild( 0 ), rangeInEmptyP.start );
 
+				expect( doc.enqueueChanges.calledOnce ).to.be.true;
 				expect( emptyP.hasAttribute( fooStoreAttrKey ) ).to.be.false;
 			} );
 
@@ -1014,8 +1021,12 @@ describe( 'DocumentSelection', () => {
 				emptyP.setAttribute( fooStoreAttrKey, 'bar' );
 				emptyP2.setAttribute( fooStoreAttrKey, 'bar' );
 
+				sinon.spy( doc, 'enqueueChanges' );
+
 				// <emptyP>{}<emptyP2>
 				doc.batch().merge( Position.createAfter( emptyP ) );
+
+				expect( doc.enqueueChanges.calledOnce ).to.be.true;
 
 				expect( emptyP.hasAttribute( fooStoreAttrKey ) ).to.be.false;
 				expect( emptyP.parent ).to.equal( root ); // Just to be sure we're checking the right element.
@@ -1024,6 +1035,8 @@ describe( 'DocumentSelection', () => {
 			it( 'are not removed or merged when containing element is merged with another empty element', () => {
 				const emptyP2 = new Element( 'p', null );
 				root.appendChildren( emptyP2 );
+
+				sinon.spy( doc, 'enqueueChanges' );
 
 				emptyP.setAttribute( fooStoreAttrKey, 'bar' );
 				emptyP2.setAttribute( abcStoreAttrKey, 'bar' );
@@ -1034,6 +1047,8 @@ describe( 'DocumentSelection', () => {
 				// <emptyP>{}<emptyP2>
 				doc.batch().merge( Position.createAfter( emptyP ) );
 
+				expect( doc.enqueueChanges.called ).to.be.false;
+
 				expect( emptyP.getAttribute( fooStoreAttrKey ) ).to.equal( 'bar' );
 				expect( emptyP.parent ).to.equal( root ); // Just to be sure we're checking the right element.
 			} );
@@ -1043,8 +1058,11 @@ describe( 'DocumentSelection', () => {
 
 				selection.setRanges( [ rangeInFullP ] );
 
+				sinon.spy( doc, 'enqueueChanges' );
+
 				doc.batch().insert( rangeInEmptyP.start, 'x' );
 
+				expect( doc.enqueueChanges.calledOnce ).to.be.true;
 				expect( emptyP.hasAttribute( fooStoreAttrKey ) ).to.be.false;
 			} );
 
@@ -1058,10 +1076,14 @@ describe( 'DocumentSelection', () => {
 				const batch = doc.batch();
 				const spy = sinon.spy( batch, 'removeAttribute' );
 
+				sinon.spy( doc, 'enqueueChanges' );
+
 				// <emptyP>{}<emptyP2>
 				batch.merge( Position.createAfter( emptyP ) );
 
 				expect( emptyP.hasAttribute( fooStoreAttrKey ) ).to.be.false;
+
+				expect( doc.enqueueChanges.calledOnce ).to.be.true;
 				expect( spy.calledOnce ).to.be.true;
 			} );
 
@@ -1069,8 +1091,11 @@ describe( 'DocumentSelection', () => {
 				selection.setRanges( [ rangeInEmptyP ] );
 				selection.setAttribute( 'foo', 'bar' );
 
+				sinon.spy( doc, 'enqueueChanges' );
+
 				doc.batch( 'transparent' ).insert( rangeInEmptyP.start, 'x' );
 
+				expect( doc.enqueueChanges.called ).to.be.false;
 				expect( emptyP.getAttribute( fooStoreAttrKey ) ).to.equal( 'bar' );
 			} );
 
@@ -1080,8 +1105,11 @@ describe( 'DocumentSelection', () => {
 				selection.setRanges( [ rangeInEmptyP ] );
 				selection.setAttribute( 'foo', 'bar' );
 
+				sinon.spy( doc, 'enqueueChanges' );
+
 				doc.batch().rename( emptyP, 'pnew' );
 
+				expect( doc.enqueueChanges.called ).to.be.false;
 				expect( emptyP.getAttribute( fooStoreAttrKey ) ).to.equal( 'bar' );
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fixed: Selection attributes should be cleared in an enqueueChanges block. Closes #1055.

---

### Additional information

When fixing this bug, I found a bug in `AttributeDelta` x `SplitDelta` transformation. It was similar to a bug that I fixed very recently - concerning `RenameDelta` x `SplitDelta` transformation. I also reformatted some code in `delta/transform/basic-transformation.js` to make it more clear.

As with other undo related bugs, tests will come in `ckeditor5-undo`.