### PR TITLE
t/660: Implemented ViewDocument#scrollToTheSelection method

### DIFF
--- a/src/view/document.js
+++ b/src/view/document.js
@@ -307,10 +307,12 @@ export default class Document {
 	scrollToTheSelection() {
 		const range = this.selection.getFirstRange();
 
-		scrollUtils.scrollViewportToShowTarget( {
-			target: this.domConverter.viewRangeToDom( range ),
-			viewportOffset: 20
-		} );
+		if ( range ) {
+			scrollUtils.scrollViewportToShowTarget( {
+				target: this.domConverter.viewRangeToDom( range ),
+				viewportOffset: 20
+			} );
+		}
 	}
 
 	/**

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -20,6 +20,7 @@ import KeyObserver from './observer/keyobserver';
 import FakeSelectionObserver from './observer/fakeselectionobserver';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import scrollUtils from '@ckeditor/ckeditor5-utils/src/dom/scroll';
 
 /**
  * Document class creates an abstract layer over the content editable area.
@@ -297,6 +298,19 @@ export default class Document {
 				log.warn( 'view-focus-no-selection: There is no selection in any editable to focus.' );
 			}
 		}
+	}
+
+	/**
+	 * Scrolls the page viewport and {@link #domRoots} with their ancestors to reveal the
+	 * caret, if not already visible to the user.
+	 */
+	scrollToTheSelection() {
+		const range = this.selection.getFirstRange();
+
+		scrollUtils.scrollViewportToShowTarget( {
+			target: this.domConverter.viewRangeToDom( range ),
+			viewportOffset: 20
+		} );
 	}
 
 	/**

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -20,7 +20,7 @@ import KeyObserver from './observer/keyobserver';
 import FakeSelectionObserver from './observer/fakeselectionobserver';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import scrollUtils from '@ckeditor/ckeditor5-utils/src/dom/scroll';
+import { scrollViewportToShowTarget } from '@ckeditor/ckeditor5-utils/src/dom/scroll';
 
 /**
  * Document class creates an abstract layer over the content editable area.
@@ -308,7 +308,7 @@ export default class Document {
 		const range = this.selection.getFirstRange();
 
 		if ( range ) {
-			scrollUtils.scrollViewportToShowTarget( {
+			scrollViewportToShowTarget( {
 				target: this.domConverter.viewRangeToDom( range ),
 				viewportOffset: 20
 			} );

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -19,7 +19,7 @@ import DomConverter from '../../../src/view/domconverter';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import count from '@ckeditor/ckeditor5-utils/src/count';
 import log from '@ckeditor/ckeditor5-utils/src/log';
-import scrollUtils from '@ckeditor/ckeditor5-utils/src/dom/scroll';
+import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
 testUtils.createSinonSandbox();
 
@@ -326,24 +326,21 @@ describe( 'Document', () => {
 
 	describe( 'scrollToTheSelection()', () => {
 		it( 'does nothing when there are no ranges in the selection', () => {
-			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget' );
+			const stub = testUtils.sinon.stub( global.window, 'scrollTo' );
 
 			viewDocument.scrollToTheSelection();
 			sinon.assert.notCalled( stub );
 		} );
 
 		it( 'scrolls to the first range in selection with an offset', () => {
-			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget' );
+			const stub = testUtils.sinon.stub( global.window, 'scrollTo' );
 			const root = viewDocument.createRoot( document.createElement( 'div' ) );
 			const range = ViewRange.createIn( root );
 
 			viewDocument.selection.addRange( range );
 
 			viewDocument.scrollToTheSelection();
-			sinon.assert.calledWithMatch( stub, {
-				target: viewDocument.domConverter.viewRangeToDom( range ),
-				viewportOffset: 20
-			} );
+			sinon.assert.calledWithMatch( stub, sinon.match.number, sinon.match.number );
 		} );
 	} );
 

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -326,14 +326,14 @@ describe( 'Document', () => {
 
 	describe( 'scrollToTheSelection()', () => {
 		it( 'does nothing when there are no ranges in the selection', () => {
-			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget', () => {} );
+			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget' ).callsFake( () => {} );
 
 			viewDocument.scrollToTheSelection();
 			sinon.assert.notCalled( stub );
 		} );
 
 		it( 'scrolls to the first range in selection with an offset', () => {
-			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget', () => {} );
+			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget' ).callsFake( () => {} );
 			const root = viewDocument.createRoot( document.createElement( 'div' ) );
 			const range = ViewRange.createIn( root );
 

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -19,6 +19,7 @@ import DomConverter from '../../../src/view/domconverter';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import count from '@ckeditor/ckeditor5-utils/src/count';
 import log from '@ckeditor/ckeditor5-utils/src/log';
+import scrollUtils from '@ckeditor/ckeditor5-utils/src/dom/scroll';
 
 testUtils.createSinonSandbox();
 
@@ -320,6 +321,22 @@ describe( 'Document', () => {
 			const getObserverMock = viewDocument.getObserver( ObserverMock );
 
 			expect( getObserverMock ).to.be.undefined;
+		} );
+	} );
+
+	describe( 'scrollToTheSelection()', () => {
+		it( 'scrolls to the first range in selection with an offset', () => {
+			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget', () => {} );
+			const root = viewDocument.createRoot( document.createElement( 'div' ) );
+			const range = ViewRange.createIn( root );
+
+			viewDocument.selection.addRange( range );
+
+			viewDocument.scrollToTheSelection();
+			sinon.assert.calledWithMatch( stub, {
+				target: viewDocument.domConverter.viewRangeToDom( range ),
+				viewportOffset: 20
+			} );
 		} );
 	} );
 

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -326,14 +326,14 @@ describe( 'Document', () => {
 
 	describe( 'scrollToTheSelection()', () => {
 		it( 'does nothing when there are no ranges in the selection', () => {
-			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget' ).callsFake( () => {} );
+			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget' );
 
 			viewDocument.scrollToTheSelection();
 			sinon.assert.notCalled( stub );
 		} );
 
 		it( 'scrolls to the first range in selection with an offset', () => {
-			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget' ).callsFake( () => {} );
+			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget' );
 			const root = viewDocument.createRoot( document.createElement( 'div' ) );
 			const range = ViewRange.createIn( root );
 

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -325,6 +325,13 @@ describe( 'Document', () => {
 	} );
 
 	describe( 'scrollToTheSelection()', () => {
+		it( 'does nothing when there are no ranges in the selection', () => {
+			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget', () => {} );
+
+			viewDocument.scrollToTheSelection();
+			sinon.assert.notCalled( stub );
+		} );
+
 		it( 'scrolls to the first range in selection with an offset', () => {
 			const stub = testUtils.sinon.stub( scrollUtils, 'scrollViewportToShowTarget', () => {} );
 			const root = viewDocument.createRoot( document.createElement( 'div' ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Implemented ViewDocument#scrollToTheSelection method. Closes #660.

#### Commit message for integration branches:

Feature: View Document should scroll to the selection upon user input (see: ckeditor/ckeditor5-engine#660).

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-utils/pull/174.

Global mgit configuration (branch constellation): https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-engine/660.

Integration branches:
* https://github.com/ckeditor/ckeditor5-block-quote/tree/t/ckeditor5-engine/660
* https://github.com/ckeditor/ckeditor5-clipboard/tree/t/ckeditor5-engine/660
* https://github.com/ckeditor/ckeditor5-enter/tree/t/ckeditor5-engine/660
* https://github.com/ckeditor/ckeditor5-typing/tree/t/ckeditor5-engine/660

Issues:
* [Integration in the `ImageUploadEngine`](https://github.com/ckeditor/ckeditor5-upload/blob/master/src/imageuploadengine.js#L47-L54) – do we need to duplicate the code from the clipboard? Maybe we can use some other event which also fires on user input (paste) and it will handle scrolling once, in the clipboard?
* More integrations? List, link, etc. They're not critical but presumably, depending on the styling of the web page, they also may require scrolling after command execution.