### PR TITLE
Fixed: view.Range#getTrimmed() was returning incorrect ranges in some cases

### DIFF
--- a/src/view/range.js
+++ b/src/view/range.js
@@ -98,8 +98,8 @@ export default class Range {
 	 * @returns {module:engine/view/range~Range} Enlarged range.
 	 */
 	getEnlarged() {
-		let start = this.start.getLastMatchingPosition( enlargeShrinkSkip, { direction: 'backward' } );
-		let end = this.end.getLastMatchingPosition( enlargeShrinkSkip );
+		let start = this.start.getLastMatchingPosition( enlargeTrimSkip, { direction: 'backward' } );
+		let end = this.end.getLastMatchingPosition( enlargeTrimSkip );
 
 		// Fix positions, in case if they are in Text node.
 		if ( start.parent.is( 'text' ) && start.isAtStart ) {
@@ -130,8 +130,8 @@ export default class Range {
 	 * @returns {module:engine/view/range~Range} Shrink range.
 	 */
 	getTrimmed() {
-		let start = this.start.getLastMatchingPosition( enlargeShrinkSkip );
-		let end = this.end.getLastMatchingPosition( enlargeShrinkSkip, { direction: 'backward' } );
+		let start = this.start.getLastMatchingPosition( enlargeTrimSkip, { boundaries: new Range( this.start, this.end ) } );
+		let end = this.end.getLastMatchingPosition( enlargeTrimSkip, { boundaries: new Range( start, this.end ), direction: 'backward' } );
 		const nodeAfterStart = start.nodeAfter;
 		const nodeBeforeEnd = end.nodeBefore;
 
@@ -438,7 +438,7 @@ export default class Range {
 }
 
 // Function used by getEnlagred and getShrinked methods.
-function enlargeShrinkSkip( value ) {
+function enlargeTrimSkip( value ) {
 	if ( value.item.is( 'attributeElement' ) || value.item.is( 'uiElement' ) ) {
 		return true;
 	}

--- a/tests/view/range.js
+++ b/tests/view/range.js
@@ -172,6 +172,16 @@ describe( 'Range', () => {
 				.to.equal( '<p>foo<b>[<img></img>]</b>bom</p>' );
 		} );
 
+		it( 'case8', () => {
+			expect( trim( '<p>[<b></b>]</p>' ) )
+				.to.equal( '<p><b></b>[]</p>' );
+		} );
+
+		it( 'case9', () => {
+			expect( trim( '<p><b></b>[<b></b>]<b></b></p>' ) )
+				.to.equal( '<p><b></b><b></b>[]<b></b></p>' );
+		} );
+
 		function trim( data ) {
 			data = data
 				.replace( /<p>/g, '<container:p>' )

--- a/tests/view/range.js
+++ b/tests/view/range.js
@@ -162,24 +162,29 @@ describe( 'Range', () => {
 				.to.equal( '<p><b>f</b>{oo}<b><span></span>bar</b></p>' );
 		} );
 
-		it( 'case6', () => {
+		it( 'case 6', () => {
 			expect( trim( '<p>foo[</p><p>bar</p><p>]bom</p>' ) )
 				.to.equal( '<p>foo[</p><p>bar</p><p>]bom</p>' );
 		} );
 
-		it( 'case7', () => {
+		it( 'case 7', () => {
 			expect( trim( '<p>foo[<b><img></img></b>]bom</p>' ) )
 				.to.equal( '<p>foo<b>[<img></img>]</b>bom</p>' );
 		} );
 
-		it( 'case8', () => {
+		it( 'case 8', () => {
 			expect( trim( '<p>[<b></b>]</p>' ) )
 				.to.equal( '<p><b></b>[]</p>' );
 		} );
 
-		it( 'case9', () => {
+		it( 'case 9', () => {
 			expect( trim( '<p><b></b>[<b></b>]<b></b></p>' ) )
 				.to.equal( '<p><b></b><b></b>[]<b></b></p>' );
+		} );
+
+		it( 'case 10', () => {
+			expect( trim( '<p>[<b></b><b></b>]</p>' ) )
+				.to.equal( '<p><b></b><b></b>[]</p>' );
 		} );
 
 		function trim( data ) {

--- a/tests/view/range.js
+++ b/tests/view/range.js
@@ -172,16 +172,21 @@ describe( 'Range', () => {
 				.to.equal( '<p>foo<b>[<img></img>]</b>bom</p>' );
 		} );
 
+		// Other results may theoretically be correct too. It is not decided whether the trimmed range should
+		// be collapsed in attribute element, at its start or its end. This is one of possible correct results
+		// and we won't know for sure unless we have more cases. See #1058.
 		it( 'case 8', () => {
 			expect( trim( '<p>[<b></b>]</p>' ) )
 				.to.equal( '<p><b></b>[]</p>' );
 		} );
 
+		// As above.
 		it( 'case 9', () => {
 			expect( trim( '<p><b></b>[<b></b>]<b></b></p>' ) )
 				.to.equal( '<p><b></b><b></b>[]<b></b></p>' );
 		} );
 
+		// As above.
 		it( 'case 10', () => {
 			expect( trim( '<p>[<b></b><b></b>]</p>' ) )
 				.to.equal( '<p><b></b><b></b>[]</p>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `view.Range#getTrimmed()` was returning incorrect ranges in some cases. Fixes #1058.

---

### Additional information

For now I've gone with the easy solution because it seems safer and was easy to implement.

Such range: `<p>[<span></span]</p>` will be trimmed to `<p><span></span>[]</p>`. However I am not sure it is really correct. I suggest @pjasiun to review this as he had introduced `getTrimmed` method so he might have a broader view on this.