### PR TITLE
T/1063: Introduce `Selection#isEntireContentSelected( element )`

### DIFF
--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -197,13 +197,8 @@ function replaceEntireContentWithParagraph( batch, selection ) {
 // * whether the paragraph is allowed in schema in the common ancestor.
 function shouldEntireContentBeReplacedWithParagraph( schema, selection ) {
 	const limitElement = schema.getLimitElement( selection );
-	const limitStartPosition = Position.createAt( limitElement );
-	const limitEndPosition = Position.createAt( limitElement, 'end' );
 
-	if (
-		!limitStartPosition.isTouching( selection.getFirstPosition() ) ||
-		!limitEndPosition.isTouching( selection.getLastPosition() )
-	) {
+	if ( !selection.isEntireContentSelected( limitElement ) ) {
 		return false;
 	}
 

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -629,6 +629,9 @@ export default class Selection {
 	 * at a position {@link module:engine/model/position~Position#isTouching touching} the element's start and ends at position
 	 * touching the element's end.
 	 *
+	 * By default, this method will check whether the entire content of the selection's current root is selected.
+	 * Useful to check if e.g. the user has just pressed <kbd>Ctrl</kbd> + <kbd>A</kbd>.
+	 *
 	 * @param {module:engine/model/element~Element} [element=this.anchor.root]
 	 * @returns {Boolean}
 	 */

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -625,6 +625,20 @@ export default class Selection {
 	}
 
 	/**
+	 * Checks whether the entire content in specified element is selected.
+	 *
+	 * @param {module:engine/model/element~Element} element
+	 * @returns {Boolean}
+	 */
+	isEntireContentSelected( element ) {
+		const limitStartPosition = Position.createAt( element );
+		const limitEndPosition = Position.createAt( element, 'end' );
+
+		return limitStartPosition.isTouching( this.getFirstPosition() ) &&
+			limitEndPosition.isTouching( this.getLastPosition() );
+	}
+
+	/**
 	 * Creates and returns an instance of `Selection` that is a clone of given selection, meaning that it has same
 	 * ranges and same direction as this selection.
 	 *

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -625,12 +625,14 @@ export default class Selection {
 	}
 
 	/**
-	 * Checks whether the entire content in specified element is selected.
+	 * Checks whether the selection contains the entire content of the given element. This means that selection must start
+	 * at a position {@link module:engine/model/position~Position#isTouching touching} the element's start and ends at position
+	 * touching the element's end.
 	 *
-	 * @param {module:engine/model/element~Element} element
+	 * @param {module:engine/model/element~Element} [element=this.anchor.root]
 	 * @returns {Boolean}
 	 */
-	isEntireContentSelected( element ) {
+	isEntireContentSelected( element = this.anchor.root ) {
 		const limitStartPosition = Position.createAt( element );
 		const limitEndPosition = Position.createAt( element, 'end' );
 

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -1247,17 +1247,13 @@ describe( 'Selection', () => {
 		it( 'returns true if the entire content in $root is selected', () => {
 			setData( doc, '<p>[Foo</p><p>Bom</p><p>Bar]</p>' );
 
-			const root = doc.getRoot();
-
-			expect( doc.selection.isEntireContentSelected( root ) ).to.equal( true );
+			expect( doc.selection.isEntireContentSelected() ).to.equal( true );
 		} );
 
 		it( 'returns false when only a fragment of the content in $root is selected', () => {
 			setData( doc, '<p>Fo[o</p><p>Bom</p><p>Bar]</p>' );
 
-			const root = doc.getRoot();
-
-			expect( doc.selection.isEntireContentSelected( root ) ).to.equal( false );
+			expect( doc.selection.isEntireContentSelected() ).to.equal( false );
 		} );
 
 		it( 'returns true if the entire content in specified element is selected', () => {
@@ -1284,9 +1280,19 @@ describe( 'Selection', () => {
 
 			setData( doc, '<p><img></img>[Foo]</p>' );
 
-			const root = doc.getRoot();
+			expect( doc.selection.isEntireContentSelected() ).to.equal( false );
+		} );
 
-			expect( doc.selection.isEntireContentSelected( root ) ).to.equal( false );
+		it( 'returns true if the content is empty', () => {
+			setData( doc, '[]' );
+
+			expect( doc.selection.isEntireContentSelected() ).to.equal( true );
+		} );
+
+		it( 'returns false if empty selection is at the end of non-empty content', () => {
+			setData( doc, '<p>Foo bar bom.</p>[]' );
+
+			expect( doc.selection.isEntireContentSelected() ).to.equal( false );
 		} );
 	} );
 } );

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -1237,4 +1237,56 @@ describe( 'Selection', () => {
 			} );
 		} );
 	} );
+
+	describe( 'isEntireContentSelected()', () => {
+		beforeEach( () => {
+			doc.schema.registerItem( 'p', '$block' );
+			doc.schema.allow( { name: 'p', inside: '$root' } );
+		} );
+
+		it( 'returns true if the entire content in $root is selected', () => {
+			setData( doc, '<p>[Foo</p><p>Bom</p><p>Bar]</p>' );
+
+			const root = doc.getRoot();
+
+			expect( doc.selection.isEntireContentSelected( root ) ).to.equal( true );
+		} );
+
+		it( 'returns false when only a fragment of the content in $root is selected', () => {
+			setData( doc, '<p>Fo[o</p><p>Bom</p><p>Bar]</p>' );
+
+			const root = doc.getRoot();
+
+			expect( doc.selection.isEntireContentSelected( root ) ).to.equal( false );
+		} );
+
+		it( 'returns true if the entire content in specified element is selected', () => {
+			setData( doc, '<p>Foo</p><p>[Bom]</p><p>Bar</p>' );
+
+			const root = doc.getRoot();
+			const secondParagraph = root.getNodeByPath( [ 1 ] );
+
+			expect( doc.selection.isEntireContentSelected( secondParagraph ) ).to.equal( true );
+		} );
+
+		it( 'returns false if the entire content in specified element is not selected', () => {
+			setData( doc, '<p>Foo</p><p>[Bom</p><p>B]ar</p>' );
+
+			const root = doc.getRoot();
+			const secondParagraph = root.getNodeByPath( [ 1 ] );
+
+			expect( doc.selection.isEntireContentSelected( secondParagraph ) ).to.equal( false );
+		} );
+
+		it( 'returns false when the entire content except an empty element is selected', () => {
+			doc.schema.registerItem( 'img', '$inline' );
+			doc.schema.allow( { name: 'img', inside: 'p' } );
+
+			setData( doc, '<p><img></img>[Foo]</p>' );
+
+			const root = doc.getRoot();
+
+			expect( doc.selection.isEntireContentSelected( root ) ).to.equal( false );
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added `Selection#isEntireContentSelected( element )`. Closes #1063.
