### PR TITLE
Changed: Added `batch` parameter to `model.LiveRange#event:change`.

### DIFF
--- a/src/model/liverange.js
+++ b/src/model/liverange.js
@@ -85,6 +85,7 @@ export default class LiveRange extends Range {
 	 * @param {Object} data Object with additional information about the change. Those parameters are passed from
 	 * {@link module:engine/model/document~Document#event:change document change event}.
 	 * @param {String} data.type Change type.
+	 * @param {module:engine/model/batch~Batch} data.batch Batch which changed the live range.
 	 * @param {module:engine/model/range~Range} data.range Range containing the result of applied change.
 	 * @param {module:engine/model/position~Position} data.sourcePosition Source position for move, remove and reinsert change types.
 	 */
@@ -107,7 +108,7 @@ function bindWithDocument() {
 		'change',
 		( event, type, changes, batch, deltaType ) => {
 			if ( supportedTypes.has( type ) ) {
-				transform.call( this, type, deltaType, changes.range, changes.sourcePosition );
+				transform.call( this, type, deltaType, batch, changes.range, changes.sourcePosition );
 			}
 		},
 		{ priority: 'high' }
@@ -122,10 +123,11 @@ function bindWithDocument() {
  * @method transform
  * @param {String} [changeType] Type of change applied to the model document.
  * @param {String} [deltaType] Type of delta which introduced the change.
+ * @param {module:engine/model/batch~Batch} batch Batch which changes the live range.
  * @param {module:engine/model/range~Range} targetRange Range containing the result of applied change.
  * @param {module:engine/model/position~Position} [sourcePosition] Source position for move, remove and reinsert change types.
  */
-function transform( changeType, deltaType, targetRange, sourcePosition ) {
+function transform( changeType, deltaType, batch, targetRange, sourcePosition ) {
 	const howMany = targetRange.end.offset - targetRange.start.offset;
 	let targetPosition = targetRange.start;
 
@@ -159,6 +161,7 @@ function transform( changeType, deltaType, targetRange, sourcePosition ) {
 
 		this.fire( 'change', oldRange, {
 			type: changeType,
+			batch,
 			range: targetRange,
 			sourcePosition
 		} );

--- a/tests/model/liverange.js
+++ b/tests/model/liverange.js
@@ -102,7 +102,9 @@ describe( 'LiveRange', () => {
 			range: moveRange,
 			sourcePosition: moveSource
 		};
-		doc.fire( 'change', 'move', changes, null );
+		const batch = {};
+
+		doc.fire( 'change', 'move', changes, batch );
 
 		expect( spy.calledOnce ).to.be.true;
 
@@ -110,6 +112,8 @@ describe( 'LiveRange', () => {
 		expect( spy.args[ 0 ][ 1 ].isEqual( copy ) ).to.be.true;
 
 		// Second parameter is an object with data about model changes that caused the live range to change.
+		expect( spy.args[ 0 ][ 2 ].type ).to.equal( 'move' );
+		expect( spy.args[ 0 ][ 2 ].batch ).to.equal( batch );
 		expect( spy.args[ 0 ][ 2 ].range.isEqual( moveRange ) ).to.be.true;
 		expect( spy.args[ 0 ][ 2 ].sourcePosition.isEqual( moveSource ) ).to.be.true;
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `model.LiveRange#event:change` now contains `Batch` instance which changed the range in `data.batch`. Closes #1076.