### PR TITLE
T/1081: Renamed `Selection#isEntireContentSelected()` to `Selection#containsEntireContent()`.

### DIFF
--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -198,7 +198,7 @@ function replaceEntireContentWithParagraph( batch, selection ) {
 function shouldEntireContentBeReplacedWithParagraph( schema, selection ) {
 	const limitElement = schema.getLimitElement( selection );
 
-	if ( !selection.isEntireContentSelected( limitElement ) ) {
+	if ( !selection.containsEntireContent( limitElement ) ) {
 		return false;
 	}
 

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -667,7 +667,7 @@ export default class Selection {
 	 * @param {module:engine/model/element~Element} [element=this.anchor.root]
 	 * @returns {Boolean}
 	 */
-	isEntireContentSelected( element = this.anchor.root ) {
+	containsEntireContent( element = this.anchor.root ) {
 		const limitStartPosition = Position.createAt( element );
 		const limitEndPosition = Position.createAt( element, 'end' );
 

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -1307,7 +1307,7 @@ describe( 'Selection', () => {
 		} );
 	} );
 
-	describe( 'isEntireContentSelected()', () => {
+	describe( 'containsEntireContent()', () => {
 		beforeEach( () => {
 			doc.schema.registerItem( 'p', '$block' );
 			doc.schema.allow( { name: 'p', inside: '$root' } );
@@ -1316,13 +1316,13 @@ describe( 'Selection', () => {
 		it( 'returns true if the entire content in $root is selected', () => {
 			setData( doc, '<p>[Foo</p><p>Bom</p><p>Bar]</p>' );
 
-			expect( doc.selection.isEntireContentSelected() ).to.equal( true );
+			expect( doc.selection.containsEntireContent() ).to.equal( true );
 		} );
 
 		it( 'returns false when only a fragment of the content in $root is selected', () => {
 			setData( doc, '<p>Fo[o</p><p>Bom</p><p>Bar]</p>' );
 
-			expect( doc.selection.isEntireContentSelected() ).to.equal( false );
+			expect( doc.selection.containsEntireContent() ).to.equal( false );
 		} );
 
 		it( 'returns true if the entire content in specified element is selected', () => {
@@ -1331,7 +1331,7 @@ describe( 'Selection', () => {
 			const root = doc.getRoot();
 			const secondParagraph = root.getNodeByPath( [ 1 ] );
 
-			expect( doc.selection.isEntireContentSelected( secondParagraph ) ).to.equal( true );
+			expect( doc.selection.containsEntireContent( secondParagraph ) ).to.equal( true );
 		} );
 
 		it( 'returns false if the entire content in specified element is not selected', () => {
@@ -1340,7 +1340,7 @@ describe( 'Selection', () => {
 			const root = doc.getRoot();
 			const secondParagraph = root.getNodeByPath( [ 1 ] );
 
-			expect( doc.selection.isEntireContentSelected( secondParagraph ) ).to.equal( false );
+			expect( doc.selection.containsEntireContent( secondParagraph ) ).to.equal( false );
 		} );
 
 		it( 'returns false when the entire content except an empty element is selected', () => {
@@ -1349,19 +1349,19 @@ describe( 'Selection', () => {
 
 			setData( doc, '<p><img></img>[Foo]</p>' );
 
-			expect( doc.selection.isEntireContentSelected() ).to.equal( false );
+			expect( doc.selection.containsEntireContent() ).to.equal( false );
 		} );
 
 		it( 'returns true if the content is empty', () => {
 			setData( doc, '[]' );
 
-			expect( doc.selection.isEntireContentSelected() ).to.equal( true );
+			expect( doc.selection.containsEntireContent() ).to.equal( true );
 		} );
 
 		it( 'returns false if empty selection is at the end of non-empty content', () => {
 			setData( doc, '<p>Foo bar bom.</p>[]' );
 
-			expect( doc.selection.isEntireContentSelected() ).to.equal( false );
+			expect( doc.selection.containsEntireContent() ).to.equal( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Renamed `Selection#isEntireContentSelected()` to `Selection#containsEntireContent()`. Closes #1081.

---

### Additional information

Marked as internal because the `Selection#isEntireContentSelected()` has been introduced in current milestone. We have to remember about changing the method name in generated changelog.