### PR TITLE
Allow to pass an array with CSS classes to HighlightDescriptor

### DIFF
--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -439,7 +439,7 @@ export default function buildModelConverter() {
  * can handle displaying highlight separately by providing `addHighlight` and `removeHighlight` custom
  * properties.
  *
- * @property {String} class CSS class that will be added to `span`
+ * @property {String|Array<String>} class CSS class or array of classes that will be added to `span`
  * {@link module:engine/view/attributeelement~AttributeElement} wrapping each text node in the highlighted content.
  * @property {Number} [priority] {@link module:engine/view/attributeelement~AttributeElement#priority} of the `span`
  * wrapping each text node in the highlighted content. If not provided, default 10 priority will be used.

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -569,7 +569,8 @@ export function highlightDescriptorToAttributeElement( descriptor ) {
 	const attributeElement = new ViewAttributeElement( 'span', descriptor.attributes );
 
 	if ( descriptor.class ) {
-		attributeElement.addClass( descriptor.class );
+		const cssClasses = Array.isArray( descriptor.class ) ? descriptor.class : [ descriptor.class ];
+		attributeElement.addClass( ...cssClasses );
 	}
 
 	if ( descriptor.priority ) {

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -1211,6 +1211,25 @@ describe( 'model-to-view-converters', () => {
 			}
 		} );
 
+		it( 'should return attribute element from descriptor object - array with classes', () => {
+			const descriptor = {
+				class: [ 'foo-class', 'bar-class' ],
+				attributes: { one: 1, two: 2 },
+				priority: 7,
+			};
+			const element = highlightDescriptorToAttributeElement( descriptor );
+
+			expect( element.is( 'attributeElement' ) ).to.be.true;
+			expect( element.name ).to.equal( 'span' );
+			expect( element.priority ).to.equal( 7 );
+			expect( element.hasClass( 'foo-class' ) ).to.be.true;
+			expect( element.hasClass( 'bar-class' ) ).to.be.true;
+
+			for ( const key of Object.keys( descriptor.attributes ) ) {
+				expect( element.getAttribute( key ) ).to.equal( descriptor.attributes[ key ] );
+			}
+		} );
+
 		it( 'should create element without class', () => {
 			const descriptor = {
 				attributes: { one: 1, two: 2 },


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: HighlightDescriptor can contain an array of CSS classes. Closes #1092.

---

### Additional information
Additional changes in widget repository: https://github.com/ckeditor/ckeditor5-widget/tree/t/ckeditor5-engine/1092
