### PR TITLE
Add id to HighlightDescriptor

### DIFF
--- a/src/conversion/buildmodelconverter.js
+++ b/src/conversion/buildmodelconverter.js
@@ -441,6 +441,8 @@ export default function buildModelConverter() {
  *
  * @property {String|Array.<String>} class CSS class or array of classes that will be added to `span`
  * {@link module:engine/view/attributeelement~AttributeElement} wrapping each text node in the highlighted content.
+ * @property {String} [id] Descriptor identifier. If not provided, marker's name from which given highlight is created
+ * will be used.
  * @property {Number} [priority] {@link module:engine/view/attributeelement~AttributeElement#priority} of the `span`
  * wrapping each text node in the highlighted content. If not provided, default 10 priority will be used.
  * @property {Object} [attributes] Attributes that will be added to `span`

--- a/src/conversion/model-to-view-converters.js
+++ b/src/conversion/model-to-view-converters.js
@@ -447,6 +447,7 @@ export function highlightText( highlightDescriptor ) {
  * priority, priority 10 will be used as default, to be compliant with
  * {@link module:engine/conversion/model-to-view-converters~highlightText} method which uses default priority of
  * {@link module:engine/view/attributeelement~AttributeElement}.
+ * If highlight descriptor will not provide id property, name of the marker will be used.
  * When `addHighlight` and `removeHighlight` custom properties are not present, element is not converted
  * in any special way. This means that converters will proceed to convert element's child nodes.
  *
@@ -471,6 +472,10 @@ export function highlightElement( highlightDescriptor ) {
 
 		if ( !descriptor.priority ) {
 			descriptor.priority = 10;
+		}
+
+		if ( !descriptor.id ) {
+			descriptor.id = data.markerName;
 		}
 
 		const viewElement = conversionApi.mapper.toViewElement( modelItem );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added `id` property to HighlightDescriptor. Closes #1102.

---

### Additional information

Changes in widget repository: https://github.com/ckeditor/ckeditor5-widget/tree/t/ckeditor5-engine/1102.