### PR TITLE
Schema.checkAttributeInSelection uses existing element's attributes when querying schema

### DIFF
--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -332,7 +332,11 @@ export default class Schema {
 					// If returned item does not have name property, it is a TextFragment.
 					const name = value.item.name || '$text';
 
-					if ( this.check( { name, inside: value.previousPosition, attributes: attribute } ) ) {
+					// Attribute should be checked together with existing attributes.
+					// See https://github.com/ckeditor/ckeditor5-engine/issues/1110.
+					const attributes = Array.from( value.item.getAttributeKeys() ).concat( attribute );
+
+					if ( this.check( { name, inside: value.previousPosition, attributes } ) ) {
 						// If we found a node that is allowed to have the attribute, return true.
 						return true;
 					}

--- a/tests/model/schema/schema.js
+++ b/tests/model/schema/schema.js
@@ -492,6 +492,7 @@ describe( 'Schema', () => {
 			schema.registerItem( 'p', '$block' );
 			schema.registerItem( 'h1', '$block' );
 			schema.registerItem( 'img', '$inline' );
+			schema.registerItem( 'figure' );
 
 			// Bold text is allowed only in P.
 			schema.allow( { name: '$text', attributes: 'bold', inside: 'p' } );
@@ -499,6 +500,10 @@ describe( 'Schema', () => {
 
 			// Disallow bold on image.
 			schema.disallow( { name: 'img', attributes: 'bold', inside: '$root' } );
+
+			// Figure must have name attribute and optional title attribute.
+			schema.requireAttributes( 'figure', [ 'name' ] );
+			schema.allow( { name: 'figure', attributes: [ 'title', 'name' ], inside: '$root' } );
 		} );
 
 		describe( 'when selection is collapsed', () => {
@@ -543,6 +548,16 @@ describe( 'Schema', () => {
 				// Selection on two images which can't be bold.
 				setData( doc, '<p>foo[<img /><img />]bar</p>' );
 				expect( schema.checkAttributeInSelection( doc.selection, attribute ) ).to.be.false;
+			} );
+
+			it( 'should return true when checking element with required attribute', () => {
+				setData( doc, '[<figure name="figure"></figure>]' );
+				expect( schema.checkAttributeInSelection( doc.selection, 'title' ) ).to.be.true;
+			} );
+
+			it( 'should return true when checking element when attribute is already present', () => {
+				setData( doc, '[<figure name="figure" title="title"></figure>]' );
+				expect( schema.checkAttributeInSelection( doc.selection, 'title' ) ).to.be.true;
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Schema.checkAttributeInSelection uses existing element's attributes when querying schema. Closes #1110.
