### PR TITLE
convertSelectionMarker should use HighlightDescriptor#id

### DIFF
--- a/src/conversion/model-selection-to-view-converters.js
+++ b/src/conversion/model-selection-to-view-converters.js
@@ -176,6 +176,10 @@ export function convertSelectionMarker( highlightDescriptor ) {
 			return;
 		}
 
+		if ( !descriptor.id ) {
+			descriptor.id = data.markerName;
+		}
+
 		const viewElement = createViewElementFromHighlightDescriptor( descriptor );
 		const consumableName = 'selectionMarker:' + data.markerName;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `AttributeElement`s created by selection conversion were not merged with `AttributeElement`s created by markers conversion. Closes #1117.