### PR TITLE
Introduced `DataController#removeDisallowedAttributes`

### DIFF
--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -29,6 +29,8 @@ import deleteContent from './deletecontent';
 import modifySelection from './modifyselection';
 import getSelectedContent from './getselectedcontent';
 
+import Schema from '../model/schema';
+
 /**
  * Controller for the data pipeline. The data pipeline controls how data is retrieved from the document
  * and set inside it. Hence, the controller features two methods which allow to {@link ~DataController#get get}
@@ -274,7 +276,7 @@ export default class DataController {
 	 * @param {Object} options See {@link module:engine/controller/deletecontent~deleteContent}'s options.
 	 */
 	deleteContent( selection, batch, options ) {
-		deleteContent( selection, batch, options );
+		deleteContent( this, selection, batch, options );
 	}
 
 	/**
@@ -325,6 +327,47 @@ export default class DataController {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Removes disallowed by {@link module:engine/model/schema~Schema schema} attributes from given nodes.
+	 * When {@link module:engine/model/batch~Batch batch} parameter is provided then attributes will be removed
+	 * by creating {@link module:engine/model/delta/attributedelta~AttributeDelta attributeDeltas} otherwise
+	 * attributes will be removed directly from provided nodes using {@link module:engine/model/node~Node node} API.
+	 *
+	 * @param {Iterable.<module:engine/model/node~Node>} nodes Nodes that will be filtered.
+	 * @param {module:engine/model/schema~SchemaPath} inside Path inside which schema will be checked.
+	 * @param {module:engine/model/batch~Batch} [batch] Batch to which the deltas will be added.
+	 */
+	removeDisallowedAttributes( nodes, inside, batch ) {
+		const schema = this.model.schema;
+
+		for ( const node of nodes ) {
+			const name = node.is( 'text' ) ? '$text' : node.name;
+			const attributes = Array.from( node.getAttributeKeys() );
+			const normalizedQueryPath = Schema._normalizeQueryPath( inside );
+			const queryPath = normalizedQueryPath.join( ' ' );
+
+			// When node with attributes is not allowed in current position.
+			if ( !schema.check( { name, attributes, inside: queryPath } ) ) {
+				// Let's remove attributes one by one.
+				// This should be improved to check all combination of attributes.
+				for ( const attribute of node.getAttributeKeys() ) {
+					if ( !schema.check( { name, attributes: attribute, inside: queryPath } ) ) {
+						if ( batch ) {
+							batch.removeAttribute( node, attribute );
+						} else {
+							node.removeAttribute( attribute );
+						}
+					}
+				}
+			}
+
+			if ( node.is( 'element' ) ) {
+				const newQueryPath = normalizedQueryPath.concat( [ node.name ] );
+				this.removeDisallowedAttributes( node.getChildren(), newQueryPath, batch );
+			}
+		}
 	}
 }
 

--- a/src/controller/deletecontent.js
+++ b/src/controller/deletecontent.js
@@ -15,6 +15,8 @@ import Element from '../model/element';
 /**
  * Deletes content of the selection and merge siblings. The resulting selection is always collapsed.
  *
+ * @param {module:engine/controller/datacontroller~DataController} dataController The data controller in context of which the deletion
+ * should be performed.
  * @param {module:engine/model/selection~Selection} selection Selection of which the content should be deleted.
  * @param {module:engine/model/batch~Batch} batch Batch to which the deltas will be added.
  * @param {Object} [options]
@@ -36,7 +38,7 @@ import Element from '../model/element';
  * * `<paragraph>^</paragraph>` with the option disabled (`doNotResetEntireContent == false`)
  * * `<heading>^</heading>` with enabled (`doNotResetEntireContent == true`).
  */
-export default function deleteContent( selection, batch, options = {} ) {
+export default function deleteContent( dataController, selection, batch, options = {} ) {
 	if ( selection.isCollapsed ) {
 		return;
 	}
@@ -74,7 +76,7 @@ export default function deleteContent( selection, batch, options = {} ) {
 		//
 		// e.g. bold is disallowed for <H1>
 		// <h1>Fo{o</h1><p>b}a<b>r</b><p> -> <h1>Fo{}a<b>r</b><h1> -> <h1>Fo{}ar<h1>.
-		removeDisallowedAttributes( startPos.parent.getChildren(), startPos, batch );
+		dataController.removeDisallowedAttributes( startPos.parent.getChildren(), startPos, batch );
 	}
 
 	selection.setCollapsedAt( startPos );
@@ -216,40 +218,4 @@ function shouldEntireContentBeReplacedWithParagraph( schema, selection ) {
 	}
 
 	return schema.check( { name: 'paragraph', inside: limitElement.name } );
-}
-
-// Gets a name under which we should check this node in the schema.
-//
-// @param {module:engine/model/node~Node} node The node.
-// @returns {String} node name.
-function getNodeSchemaName( node ) {
-	return node.is( 'text' ) ? '$text' : node.name;
-}
-
-// Creates AttributeDeltas that removes attributes that are disallowed by schema on given node and its children.
-//
-// @param {Array<module:engine/model/node~Node>} nodes Nodes that will be filtered.
-// @param {module:engine/model/schema~SchemaPath} inside Path inside which schema will be checked.
-// @param {module:engine/model/batch~Batch} batch Batch to which the deltas will be added.
-function removeDisallowedAttributes( nodes, inside, batch ) {
-	const schema = batch.document.schema;
-
-	for ( const node of nodes ) {
-		const name = getNodeSchemaName( node );
-
-		// When node with attributes is not allowed in current position.
-		if ( !schema.check( { name, inside, attributes: Array.from( node.getAttributeKeys() ) } ) ) {
-			// Let's remove attributes one by one.
-			// This should be improved to check all combination of attributes.
-			for ( const attribute of node.getAttributeKeys() ) {
-				if ( !schema.check( { name, inside, attributes: attribute } ) ) {
-					batch.removeAttribute( node, attribute );
-				}
-			}
-		}
-
-		if ( node.is( 'element' ) ) {
-			removeDisallowedAttributes( node.getChildren(), Position.createAt( node ), batch );
-		}
-	}
 }

--- a/src/controller/insertcontent.js
+++ b/src/controller/insertcontent.js
@@ -229,7 +229,7 @@ class Insertion {
 		// If the node is a text and bare text is allowed in current position it means that the node
 		// contains disallowed attributes and we have to remove them.
 		else if ( this.schema.check( { name: '$text', inside: this.position } ) ) {
-			removeDisallowedAttributes( [ node ], this.position, this.schema );
+			this.dataController.removeDisallowedAttributes( [ node ], this.position );
 			this._handleNode( node, context );
 		}
 		// If text is not allowed, try autoparagraphing.
@@ -291,7 +291,7 @@ class Insertion {
 			// We need to check and strip disallowed attributes in all nested nodes because after merge
 			// some attributes could end up in a path where are disallowed.
 			const parent = position.nodeBefore;
-			removeDisallowedAttributes( parent.getChildren(), Position.createAt( parent ), this.schema, this.batch );
+			this.dataController.removeDisallowedAttributes( parent.getChildren(), Position.createAt( parent ), this.batch );
 
 			this.position = Position.createFromPosition( position );
 			position.detach();
@@ -318,7 +318,7 @@ class Insertion {
 
 			// We need to check and strip disallowed attributes in all nested nodes because after merge
 			// some attributes could end up in a place where are disallowed.
-			removeDisallowedAttributes( position.parent.getChildren(), position, this.schema, this.batch );
+			this.dataController.removeDisallowedAttributes( position.parent.getChildren(), position, this.batch );
 
 			this.position = Position.createFromPosition( position );
 			position.detach();
@@ -330,7 +330,7 @@ class Insertion {
 		// When there was no merge we need to check and strip disallowed attributes in all nested nodes of
 		// just inserted node because some attributes could end up in a place where are disallowed.
 		if ( !mergeLeft && !mergeRight ) {
-			removeDisallowedAttributes( node.getChildren(), Position.createAt( node ), this.schema, this.batch );
+			this.dataController.removeDisallowedAttributes( node.getChildren(), Position.createAt( node ), this.batch );
 		}
 	}
 
@@ -350,7 +350,7 @@ class Insertion {
 			// When node is a text and is disallowed by schema it means that contains disallowed attributes
 			// and we need to remove them.
 			if ( node.is( 'text' ) && !this._checkIsAllowed( node, [ paragraph ] ) ) {
-				removeDisallowedAttributes( [ node ], [ paragraph ], this.schema );
+				this.dataController.removeDisallowedAttributes( [ node ], [ paragraph ] );
 			}
 
 			if ( this._checkIsAllowed( node, [ paragraph ] ) ) {
@@ -452,37 +452,4 @@ class Insertion {
 // @returns {String} Node name.
 function getNodeSchemaName( node ) {
 	return node.is( 'text' ) ? '$text' : node.name;
-}
-
-// Removes disallowed by schema attributes from given nodes. When batch parameter is provided then
-// attributes will be removed by creating AttributeDeltas otherwise attributes will be removed
-// directly from provided nodes.
-//
-// @param {Array<module:engine/model/node~Node>} nodes Nodes that will be filtered.
-// @param {module:engine/model/schema~SchemaPath} inside Path inside which schema will be checked.
-// @param {module:engine/model/schema~Schema} schema Schema instance uses for element validation.
-// @param {module:engine/model/batch~Batch} [batch] Batch to which the deltas will be added.
-function removeDisallowedAttributes( nodes, inside, schema, batch ) {
-	for ( const node of nodes ) {
-		const name = getNodeSchemaName( node );
-
-		// When node with attributes is not allowed in current position.
-		if ( !schema.check( { name, inside, attributes: Array.from( node.getAttributeKeys() ) } ) ) {
-			// Let's remove attributes one by one.
-			// This should be improved to check all combination of attributes.
-			for ( const attribute of node.getAttributeKeys() ) {
-				if ( !schema.check( { name, inside, attributes: attribute } ) ) {
-					if ( batch ) {
-						batch.removeAttribute( node, attribute );
-					} else {
-						node.removeAttribute( attribute );
-					}
-				}
-			}
-		}
-
-		if ( node.is( 'element' ) ) {
-			removeDisallowedAttributes( node.getChildren(), Position.createAt( node ), schema, batch );
-		}
-	}
 }

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -45,7 +45,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'parse', () => {
+	describe( 'parse()', () => {
 		it( 'should set text', () => {
 			schema.allow( { name: '$text', inside: '$root' } );
 			const model = data.parse( '<p>foo<b>bar</b></p>' );
@@ -102,7 +102,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'toModel', () => {
+	describe( 'toModel()', () => {
 		beforeEach( () => {
 			schema.registerItem( 'paragraph', '$block' );
 
@@ -141,7 +141,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'set', () => {
+	describe( 'set()', () => {
 		it( 'should set data to root', () => {
 			schema.allow( { name: '$text', inside: '$root' } );
 			data.set( 'foo' );
@@ -193,7 +193,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'get', () => {
+	describe( 'get()', () => {
 		it( 'should get paragraph with text', () => {
 			modelDocument.schema.registerItem( 'paragraph', '$block' );
 			setData( modelDocument, '<paragraph>foo</paragraph>' );
@@ -263,7 +263,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'stringify', () => {
+	describe( 'stringify()', () => {
 		beforeEach( () => {
 			modelDocument.schema.registerItem( 'paragraph', '$block' );
 			modelDocument.schema.registerItem( 'div' );
@@ -287,7 +287,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'toView', () => {
+	describe( 'toView()', () => {
 		beforeEach( () => {
 			modelDocument.schema.registerItem( 'paragraph', '$block' );
 			modelDocument.schema.registerItem( 'div' );
@@ -328,7 +328,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'destroy', () => {
+	describe( 'destroy()', () => {
 		it( 'should be there for you', () => {
 			// Should not throw.
 			data.destroy();
@@ -337,7 +337,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'insertContent', () => {
+	describe( 'insertContent()', () => {
 		it( 'should be decorated', () => {
 			schema.allow( { name: '$text', inside: '$root' } ); // To surpress warnings.
 
@@ -371,7 +371,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'deleteContent', () => {
+	describe( 'deleteContent()', () => {
 		it( 'should be decorated', () => {
 			const spy = sinon.spy();
 
@@ -393,7 +393,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'modifySelection', () => {
+	describe( 'modifySelection()', () => {
 		it( 'should be decorated', () => {
 			schema.registerItem( 'paragraph', '$block' );
 			setData( modelDocument, '<paragraph>fo[ob]ar</paragraph>' );
@@ -418,7 +418,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'getSelectedContent', () => {
+	describe( 'getSelectedContent()', () => {
 		it( 'should be decorated', () => {
 			const spy = sinon.spy();
 			const sel = new ModelSelection();
@@ -441,7 +441,7 @@ describe( 'DataController', () => {
 		} );
 	} );
 
-	describe( 'hasContent', () => {
+	describe( 'hasContent()', () => {
 		let root;
 
 		beforeEach( () => {

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -12,8 +12,11 @@ import buildModelConverter from '../../src/conversion/buildmodelconverter';
 
 import ModelDocumentFragment from '../../src/model/documentfragment';
 import ModelText from '../../src/model/text';
+import ModelElement from '../../src/model/element';
 import ModelRange from '../../src/model/range';
+import ModelPosition from '../../src/model/position';
 import ModelSelection from '../../src/model/selection';
+import AttributeDelta from '../../src/model/delta/attributedelta';
 
 import ViewDocumentFragment from '../../src/view/documentfragment';
 
@@ -521,6 +524,160 @@ describe( 'DataController', () => {
 			const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 1 );
 
 			expect( data.hasContent( range ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'removeDisallowedAttributes()', () => {
+		beforeEach( () => {
+			schema.registerItem( 'paragraph', '$block' );
+			schema.registerItem( 'div', '$block' );
+			schema.registerItem( 'image' );
+			schema.objects.add( 'image' );
+			schema.allow( { name: '$block', inside: 'div' } );
+		} );
+
+		describe( 'filtering attributes from nodes', () => {
+			let text, image;
+
+			beforeEach( () => {
+				schema.allow( { name: '$text', attributes: [ 'a' ], inside: '$root' } );
+				schema.allow( { name: 'image', attributes: [ 'b' ], inside: '$root' } );
+
+				text = new ModelText( 'foo', { a: 1, b: 1 } );
+				image = new ModelElement( 'image', { a: 1, b: 1 } );
+			} );
+
+			it( 'should filter out disallowed attributes from given nodes', () => {
+				data.removeDisallowedAttributes( [ text, image ], '$root' );
+
+				expect( Array.from( text.getAttributeKeys() ) ).to.deep.equal( [ 'a' ] );
+				expect( Array.from( image.getAttributeKeys() ) ).to.deep.equal( [ 'b' ] );
+			} );
+
+			it( 'should filter out disallowed attributes from given nodes (batch)', () => {
+				const root = modelDocument.getRoot();
+				const batch = modelDocument.batch();
+
+				root.appendChildren( [ text, image ] );
+
+				data.removeDisallowedAttributes( [ text, image ], '$root', batch );
+
+				expect( Array.from( text.getAttributeKeys() ) ).to.deep.equal( [ 'a' ] );
+				expect( Array.from( image.getAttributeKeys() ) ).to.deep.equal( [ 'b' ] );
+
+				expect( batch.deltas ).to.length( 2 );
+				expect( batch.deltas[ 0 ] ).to.instanceof( AttributeDelta );
+				expect( batch.deltas[ 1 ] ).to.instanceof( AttributeDelta );
+			} );
+		} );
+
+		describe( 'filtering attributes from child nodes', () => {
+			let div;
+
+			beforeEach( () => {
+				schema.allow( { name: '$text', attributes: [ 'a' ], inside: 'div' } );
+				schema.allow( { name: '$text', attributes: [ 'b' ], inside: 'div paragraph' } );
+				schema.allow( { name: 'image', attributes: [ 'a' ], inside: 'div' } );
+				schema.allow( { name: 'image', attributes: [ 'b' ], inside: 'div paragraph' } );
+
+				const foo = new ModelText( 'foo', { a: 1, b: 1 } );
+				const bar = new ModelText( 'bar', { a: 1, b: 1 } );
+				const imageInDiv = new ModelElement( 'image', { a: 1, b: 1 } );
+				const imageInParagraph = new ModelElement( 'image', { a: 1, b: 1 } );
+				const paragraph = new ModelElement( 'paragraph', [], [ foo, imageInParagraph ] );
+
+				div = new ModelElement( 'div', [], [ paragraph, bar, imageInDiv ] );
+			} );
+
+			it( 'should filter out disallowed attributes from child nodes', () => {
+				data.removeDisallowedAttributes( [ div ], '$root' );
+
+				expect( stringify( div ) )
+					.to.equal(
+						'<div>' +
+							'<paragraph>' +
+								'<$text b="1">foo</$text>' +
+								'<image b="1"></image>' +
+							'</paragraph>' +
+							'<$text a="1">bar</$text>' +
+							'<image a="1"></image>' +
+						'</div>'
+					);
+			} );
+
+			it( 'should filter out disallowed attributes from child nodes (batch)', () => {
+				const root = modelDocument.getRoot();
+				const batch = modelDocument.batch();
+
+				root.appendChildren( [ div ] );
+
+				data.removeDisallowedAttributes( [ div ], '$root', batch );
+
+				expect( batch.deltas ).to.length( 4 );
+				expect( batch.deltas[ 0 ] ).to.instanceof( AttributeDelta );
+				expect( batch.deltas[ 1 ] ).to.instanceof( AttributeDelta );
+				expect( batch.deltas[ 2 ] ).to.instanceof( AttributeDelta );
+				expect( batch.deltas[ 3 ] ).to.instanceof( AttributeDelta );
+
+				expect( getData( modelDocument, { withoutSelection: true } ) )
+					.to.equal(
+						'<div>' +
+							'<paragraph>' +
+								'<$text b="1">foo</$text>' +
+								'<image b="1"></image>' +
+							'</paragraph>' +
+							'<$text a="1">bar</$text>' +
+							'<image a="1"></image>' +
+						'</div>'
+					);
+			} );
+		} );
+
+		describe( 'allowed parameters', () => {
+			let frag;
+
+			beforeEach( () => {
+				schema.allow( { name: '$text', attributes: [ 'a' ], inside: '$root' } );
+				schema.allow( { name: '$text', attributes: [ 'b' ], inside: 'paragraph' } );
+
+				frag = new ModelDocumentFragment( [
+					new ModelText( 'foo', { a: 1 } ),
+					new ModelElement( 'paragraph', [], [ new ModelText( 'bar', { a: 1, b: 1 } ) ] ),
+					new ModelText( 'biz', { b: 1 } )
+				] );
+			} );
+
+			it( 'should accept iterable as nodes', () => {
+				data.removeDisallowedAttributes( frag.getChildren(), '$root' );
+
+				expect( stringify( frag ) )
+					.to.equal( '<$text a="1">foo</$text><paragraph><$text b="1">bar</$text></paragraph>biz' );
+			} );
+
+			it( 'should accept Position as inside', () => {
+				data.removeDisallowedAttributes( frag.getChildren(), ModelPosition.createAt( modelDocument.getRoot() ) );
+
+				expect( stringify( frag ) )
+					.to.equal( '<$text a="1">foo</$text><paragraph><$text b="1">bar</$text></paragraph>biz' );
+			} );
+
+			it( 'should accept Node as inside', () => {
+				data.removeDisallowedAttributes( frag.getChildren(), [ modelDocument.getRoot() ] );
+
+				expect( stringify( frag ) )
+					.to.equal( '<$text a="1">foo</$text><paragraph><$text b="1">bar</$text></paragraph>biz' );
+			} );
+		} );
+
+		it( 'should not filter out allowed combination of attributes', () => {
+			schema.allow( { name: 'image', attributes: [ 'a', 'b' ] } );
+			schema.requireAttributes( 'image', [ 'a', 'b' ] );
+
+			const image = new ModelElement( 'image', { a: 1, b: 1 } );
+
+			data.removeDisallowedAttributes( [ image ], '$root' );
+
+			expect( Array.from( image.getAttributeKeys() ) ).to.deep.equal( [ 'a', 'b' ] );
 		} );
 	} );
 } );

--- a/tests/controller/deletecontent.js
+++ b/tests/controller/deletecontent.js
@@ -4,6 +4,7 @@
  */
 
 import Document from '../../src/model/document';
+import DataController from '../../src/controller/datacontroller';
 import Position from '../../src/model/position';
 import Range from '../../src/model/range';
 import Element from '../../src/model/element';
@@ -11,13 +12,15 @@ import deleteContent from '../../src/controller/deletecontent';
 import { setData, getData } from '../../src/dev-utils/model';
 
 describe( 'DataController', () => {
-	let doc;
+	let doc, dataController;
 
 	describe( 'deleteContent', () => {
 		describe( 'in simple scenarios', () => {
 			beforeEach( () => {
 				doc = new Document();
 				doc.createRoot();
+
+				dataController = new DataController( doc );
 
 				const schema = doc.schema;
 
@@ -42,7 +45,7 @@ describe( 'DataController', () => {
 			it( 'deletes single character (backward selection)', () => {
 				setData( doc, 'f[o]o', { lastRangeBackward: true } );
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc ) ).to.equal( 'f[]o' );
 			} );
@@ -83,6 +86,8 @@ describe( 'DataController', () => {
 				doc = new Document();
 				doc.createRoot();
 
+				dataController = new DataController( doc );
+
 				const schema = doc.schema;
 
 				schema.registerItem( 'image', '$inline' );
@@ -95,7 +100,7 @@ describe( 'DataController', () => {
 			it( 'deletes characters (first half has attrs)', () => {
 				setData( doc, '<$text bold="true">fo[o</$text>b]ar' );
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc ) ).to.equal( '<$text bold="true">fo[]</$text>ar' );
 				expect( doc.selection.getAttribute( 'bold' ) ).to.equal( true );
@@ -104,7 +109,7 @@ describe( 'DataController', () => {
 			it( 'deletes characters (2nd half has attrs)', () => {
 				setData( doc, 'fo[o<$text bold="true">b]ar</$text>' );
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc ) ).to.equal( 'fo[]<$text bold="true">ar</$text>' );
 				expect( doc.selection.getAttribute( 'bold' ) ).to.undefined;
@@ -113,7 +118,7 @@ describe( 'DataController', () => {
 			it( 'clears selection attrs when emptied content', () => {
 				setData( doc, '<paragraph>x</paragraph><paragraph>[<$text bold="true">foo</$text>]</paragraph><paragraph>y</paragraph>' );
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc ) ).to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>y</paragraph>' );
 				expect( doc.selection.getAttribute( 'bold' ) ).to.undefined;
@@ -130,7 +135,7 @@ describe( 'DataController', () => {
 					}
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc ) ).to.equal( '<paragraph>x<$text bold="true">a[]b</$text>y</paragraph>' );
 				expect( doc.selection.getAttribute( 'bold' ) ).to.equal( true );
@@ -150,6 +155,8 @@ describe( 'DataController', () => {
 			beforeEach( () => {
 				doc = new Document();
 				doc.createRoot();
+
+				dataController = new DataController( doc );
 
 				const schema = doc.schema;
 
@@ -204,7 +211,7 @@ describe( 'DataController', () => {
 					{ lastRangeBackward: true }
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc ) ).to.equal( '<paragraph>x</paragraph><heading1>fo[]ar</heading1><paragraph>y</paragraph>' );
 			} );
@@ -240,7 +247,7 @@ describe( 'DataController', () => {
 				const spyMerge = sinon.spy( batch, 'merge' );
 				const spyRemove = sinon.spy( batch, 'remove' );
 
-				deleteContent( doc.selection, batch );
+				deleteContent( dataController, doc.selection, batch );
 
 				expect( getData( doc ) ).to.equal( '<paragraph>ab[]</paragraph>' );
 
@@ -255,7 +262,7 @@ describe( 'DataController', () => {
 				const spyMerge = sinon.spy( batch, 'merge' );
 				const spyMove = sinon.spy( batch, 'move' );
 
-				deleteContent( doc.selection, batch );
+				deleteContent( dataController, doc.selection, batch );
 
 				expect( getData( doc ) ).to.equal( '<paragraph>ab[]gh</paragraph>' );
 
@@ -307,7 +314,7 @@ describe( 'DataController', () => {
 
 					doc.selection.setRanges( [ range ] );
 
-					deleteContent( doc.selection, doc.batch() );
+					deleteContent( dataController, doc.selection, doc.batch() );
 
 					expect( getData( doc ) )
 						.to.equal( '<pparent>x<paragraph>x<pchild>fo[]ar</pchild>y</paragraph>y</pparent>' );
@@ -352,7 +359,7 @@ describe( 'DataController', () => {
 
 					doc.selection.setRanges( [ range ] );
 
-					deleteContent( doc.selection, doc.batch() );
+					deleteContent( dataController, doc.selection, doc.batch() );
 
 					expect( getData( doc ) )
 						.to.equal( '<pparent>x<paragraph>foo<pchild>ba[]om</pchild></paragraph></pparent>' );
@@ -395,7 +402,7 @@ describe( 'DataController', () => {
 
 					doc.selection.setRanges( [ range ] );
 
-					deleteContent( doc.selection, doc.batch() );
+					deleteContent( dataController, doc.selection, doc.batch() );
 
 					expect( getData( doc ) )
 						.to.equal( '<paragraph>fo[]</paragraph>' );
@@ -487,6 +494,8 @@ describe( 'DataController', () => {
 				// Special root which allows only blockWidgets inside itself.
 				doc.createRoot( 'restrictedRoot', 'restrictedRoot' );
 
+				dataController = new DataController( doc );
+
 				const schema = doc.schema;
 
 				schema.limits.add( 'restrictedRoot' );
@@ -514,7 +523,7 @@ describe( 'DataController', () => {
 					{ rootName: 'paragraphRoot' }
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc, { rootName: 'paragraphRoot' } ) )
 					.to.equal( 'x[]z' );
@@ -527,7 +536,7 @@ describe( 'DataController', () => {
 					{ rootName: 'bodyRoot' }
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc, { rootName: 'bodyRoot' } ) )
 					.to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>z</paragraph>' );
@@ -540,7 +549,7 @@ describe( 'DataController', () => {
 					{ rootName: 'bodyRoot' }
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc, { rootName: 'bodyRoot' } ) )
 					.to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>z</paragraph>' );
@@ -553,7 +562,7 @@ describe( 'DataController', () => {
 					{ rootName: 'bodyRoot' }
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc, { rootName: 'bodyRoot' } ) )
 					.to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>z</paragraph>' );
@@ -566,7 +575,7 @@ describe( 'DataController', () => {
 					{ rootName: 'bodyRoot' }
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc, { rootName: 'bodyRoot' } ) )
 					.to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>z</paragraph>' );
@@ -579,7 +588,7 @@ describe( 'DataController', () => {
 					{ rootName: 'bodyRoot' }
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc, { rootName: 'bodyRoot' } ) )
 					.to.equal( '<paragraph>[]</paragraph>' );
@@ -592,7 +601,7 @@ describe( 'DataController', () => {
 					{ rootName: 'restrictedRoot' }
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc, { rootName: 'restrictedRoot' } ) )
 					.to.equal( '<blockWidget></blockWidget>[]<blockWidget></blockWidget>' );
@@ -603,6 +612,8 @@ describe( 'DataController', () => {
 			beforeEach( () => {
 				doc = new Document();
 				doc.createRoot();
+
+				dataController = new DataController( doc );
 
 				const schema = doc.schema;
 
@@ -660,6 +671,8 @@ describe( 'DataController', () => {
 				doc = new Document();
 				doc.createRoot();
 
+				dataController = new DataController( doc );
+
 				const schema = doc.schema;
 
 				schema.registerItem( 'blockLimit' );
@@ -706,6 +719,8 @@ describe( 'DataController', () => {
 			beforeEach( () => {
 				doc = new Document();
 				doc.createRoot();
+
+				dataController = new DataController( doc );
 
 				const schema = doc.schema;
 
@@ -783,7 +798,7 @@ describe( 'DataController', () => {
 					{ rootName: 'paragraphRoot' }
 				);
 
-				deleteContent( doc.selection, doc.batch() );
+				deleteContent( dataController, doc.selection, doc.batch() );
 
 				expect( getData( doc, { rootName: 'paragraphRoot' } ) )
 					.to.equal( 'x[]z' );
@@ -803,7 +818,7 @@ describe( 'DataController', () => {
 			it( title, () => {
 				setData( doc, input );
 
-				deleteContent( doc.selection, doc.batch(), options );
+				deleteContent( dataController, doc.selection, doc.batch(), options );
 
 				expect( getData( doc ) ).to.equal( output );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `DataController#removeDisallowedAttributes` method to filter out disallowed by schema attributes from given nodes. Used this method to filter nodes by `insertContent` and `deleteContent`. Closes #1120.