### PR TITLE
Schema should ignore attributes stored in elements by DocumentSelection

### DIFF
--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -392,6 +392,17 @@ export default class DocumentSelection extends Selection {
 	}
 
 	/**
+	 * Checks whether given attribute key is an attribute stored on an element.
+	 *
+	 * @protected
+	 * @param {String} key
+	 * @returns {Boolean}
+	 */
+	static _isStoreAttributeKey( key ) {
+		return key.indexOf( storePrefix ) == 0;
+	}
+
+	/**
 	 * Internal method for setting `DocumentSelection` attribute. Supports attribute priorities (through `directChange`
 	 * parameter).
 	 *

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -392,14 +392,14 @@ export default class DocumentSelection extends Selection {
 	}
 
 	/**
-	 * Checks whether given attribute key is an attribute stored on an element.
+	 * Checks whether the given attribute key is an attribute stored on an element.
 	 *
 	 * @protected
 	 * @param {String} key
 	 * @returns {Boolean}
 	 */
 	static _isStoreAttributeKey( key ) {
-		return key.indexOf( storePrefix ) == 0;
+		return key.startsWith( storePrefix );
 	}
 
 	/**

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -10,6 +10,7 @@
 import Position from './position';
 import Element from './element';
 import Range from './range';
+import DocumentSelection from './documentselection';
 import clone from '@ckeditor/ckeditor5-utils/src/lib/lodash/clone';
 import isArray from '@ckeditor/ckeditor5-utils/src/lib/lodash/isArray';
 import isString from '@ckeditor/ckeditor5-utils/src/lib/lodash/isString';
@@ -217,6 +218,13 @@ export default class Schema {
 		// Keep in mind that if the query has no attributes, query.attribute was converted to an array
 		// with a single `undefined` value. This fits the algorithm well.
 		for ( const attribute of query.attributes ) {
+			// Skip all attributes that are stored in elements.
+			// This isn't perfect solution but we have to deal with it for now.
+			// `attribute` may have `undefined` value.
+			if ( attribute && DocumentSelection._isStoreAttributeKey( attribute ) ) {
+				continue;
+			}
+
 			let matched = false;
 
 			for ( const schemaItem of schemaItems ) {

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -386,6 +386,16 @@ describe( 'DocumentSelection', () => {
 		} );
 	} );
 
+	describe( '_isStoreAttributeKey', () => {
+		it( 'should return true if given key is a key of an attribute stored in element by DocumentSelection', () => {
+			expect( DocumentSelection._isStoreAttributeKey( fooStoreAttrKey ) ).to.be.true;
+		} );
+
+		it( 'should return false if given key is not a key of an attribute stored in element by DocumentSelection', () => {
+			expect( DocumentSelection._isStoreAttributeKey( 'foo' ) ).to.be.false;
+		} );
+	} );
+
 	// DocumentSelection uses LiveRanges so here are only simple test to see if integration is
 	// working well, without getting into complicated corner cases.
 	describe( 'after applying an operation should get updated and fire events', () => {

--- a/tests/model/schema/schema.js
+++ b/tests/model/schema/schema.js
@@ -242,6 +242,16 @@ describe( 'Schema', () => {
 			it( 'should omit path elements that are added to schema', () => {
 				expect( schema.check( { name: '$inline', inside: '$block new $block' } ) ).to.be.true;
 			} );
+
+			it( 'should ignore attributes stored in elements by document selection', () => {
+				expect( schema.check( { name: '$block', attributes: 'selection:foo', inside: '$root' } ) ).to.be.true;
+			} );
+
+			it( 'should disallow attribute stored in an element if that attribute was explicitly disallowed', () => {
+				schema.disallow( { name: '$block', attributes: [ 'selection:foo' ], inside: '$root' } );
+
+				expect( schema.check( { name: '$block', attributes: [ 'selection:foo' ], inside: '$root' } ) ).to.be.false;
+			} );
 		} );
 
 		describe( 'array of elements as inside', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed bug when `blockquote` could not be applied on an empty `paragraph` with a basic style (bold, etc.) active. Closes #1127.

-------------

### Additional information

`model.Schema` now will ignore attributes stored by `DocumentSelection` when checking if given element with attributes is allowed in given path. It will be still possible to explicitly disallow such elements.