### PR TITLE
T/1126: Spaces inside <code>

### DIFF
--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -65,7 +65,7 @@ export default class DomConverter {
 		 *
 		 * @member {Array.<String>} module:engine/view/domconverter~DomConverter#preElements
 		 */
-		this.preElements = [ 'pre', 'code' ];
+		this.preElements = [ 'pre' ];
 
 		/**
 		 * Tag names of DOM `Element`s which are considered block elements.

--- a/tests/view/domconverter/view-to-dom.js
+++ b/tests/view/domconverter/view-to-dom.js
@@ -413,11 +413,11 @@ describe( 'DomConverter', () => {
 			} );
 
 			it( 'text node before in a preformatted node', () => {
-				const viewCode = new ViewAttributeElement( 'code', null, new ViewText( 'foo   ' ) );
+				const viewCode = new ViewAttributeElement( 'pre', null, new ViewText( 'foo   ' ) );
 				const viewDiv = new ViewContainerElement( 'div', null, [ viewCode, new ViewText( ' bar' ) ] );
 				const domDiv = converter.viewToDom( viewDiv, document );
 
-				expect( domDiv.innerHTML ).to.equal( '<code>foo   </code> bar' );
+				expect( domDiv.innerHTML ).to.equal( '<pre>foo   </pre> bar' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Allows rendering spaces inside the `<code>` element in a normal way. Closes #1126.
