### PR TITLE
Tweaked SplitDelta transformation to act better when deltas are undone

### DIFF
--- a/src/model/delta/basic-transformations.js
+++ b/src/model/delta/basic-transformations.js
@@ -225,7 +225,7 @@ addTransformationCase( SplitDelta, SplitDelta, ( a, b, context ) => {
 	if ( a.position.root == b.position.root && compareArrays( pathA, pathB ) == 'same' ) {
 		a = a.clone();
 
-		if ( a.position.offset <= b.position.offset ) {
+		if ( a.position.offset < b.position.offset || ( a.position.offset == b.position.offset && context.isStrong ) ) {
 			// If both first operations are `ReinsertOperation`s, we might need to transform `a._cloneOperation`,
 			// so it will take correct node from graveyard.
 			if (

--- a/src/model/delta/transform.js
+++ b/src/model/delta/transform.js
@@ -559,9 +559,6 @@ function getNormalizedDeltas( DeltaClass, operations ) {
 					} else {
 						delta = new MoveDelta();
 					}
-
-					// Unsticky the operation. Only operations in "special" deltas can be sticky.
-					o.isSticky = false;
 				}
 
 				delta.addOperation( o );

--- a/tests/model/delta/transform/splitdelta.js
+++ b/tests/model/delta/transform/splitdelta.js
@@ -69,11 +69,14 @@ describe( 'transform', () => {
 					operations: [
 						{
 							type: InsertOperation,
-							position: new Position( root, [ 3, 3, 4 ] ),
+							position: new Position( root, [ 3, 3, 5 ] ),
 							baseVersion
 						},
 						{
-							type: NoOperation,
+							type: MoveOperation,
+							sourcePosition: new Position( root, [ 3, 3, 4, 0 ] ),
+							howMany: 9,
+							targetPosition: new Position( root, [ 3, 3, 5, 0 ] ),
 							baseVersion: baseVersion + 1
 						}
 					]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Changed `SplitDelta` x `SplitDelta` transformation when split is at same position so it works better with undo. Closes #1130.