### PR TITLE
Fixed: Improved range by merge delta transformation case.

### DIFF
--- a/src/model/range.js
+++ b/src/model/range.js
@@ -492,8 +492,13 @@ export default class Range {
 				// Collapsed range is in merged element, at the beginning or at the end of it.
 				// Without fix, the range would end up in the graveyard, together with removed element.
 				// <p>foo</p><p>[]bar</p> -> <p>foobar</p><p>[]</p> -> <p>foobar</p> -> <p>foo[]bar</p>
-				// <p>foo</p><p>bar[]</p>
-				// return [ new Range( targetPosition.getShiftedBy( this.start.offset ) ) ];
+				// <p>foo</p><p>bar[]</p> -> <p>foobar</p><p>[]</p> -> <p>foobar</p> -> <p>foobar[]</p>
+				//
+				// In most cases, `sourceRange.start.offset` for merge delta's move operation would be 0,
+				// so this formula might look overcomplicated.
+				// However in some scenarios, after operational transformation, move operation might not
+				// in fact start from 0 and we need to properly count new offset.
+				// https://github.com/ckeditor/ckeditor5-engine/pull/1133#issuecomment-329080668.
 				const offset = this.start.offset - sourceRange.start.offset;
 
 				return [ new Range( targetPosition.getShiftedBy( offset ) ) ];

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -493,7 +493,10 @@ export default class Range {
 				// Without fix, the range would end up in the graveyard, together with removed element.
 				// <p>foo</p><p>[]bar</p> -> <p>foobar</p><p>[]</p> -> <p>foobar</p> -> <p>foo[]bar</p>
 				// <p>foo</p><p>bar[]</p>
-				return [ new Range( targetPosition.getShiftedBy( this.start.offset ) ) ];
+				// return [ new Range( targetPosition.getShiftedBy( this.start.offset ) ) ];
+				const offset = this.start.offset - sourceRange.start.offset;
+
+				return [ new Range( targetPosition.getShiftedBy( offset ) ) ];
 			}
 			//
 			// Other edge cases:

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -9,6 +9,9 @@ import Element from '../../src/model/element';
 import Text from '../../src/model/text';
 import Document from '../../src/model/document';
 import TreeWalker from '../../src/model/treewalker';
+import MergeDelta from '../../src/model/delta/mergedelta';
+import MoveOperation from '../../src/model/operation/moveoperation';
+import RemoveOperation from '../../src/model/operation/removeoperation';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import { jsonParseStringify } from '../../tests/model/_utils/utils';
 
@@ -1055,6 +1058,22 @@ describe( 'Range', () => {
 				expect( transformed.length ).to.equal( 1 );
 				expect( transformed[ 0 ].start.path ).to.deep.equal( [ 0, 0, 1 ] );
 				expect( transformed[ 0 ].end.path ).to.deep.equal( [ 0, 1, 1 ] );
+			} );
+
+			// #1132
+			it( 'merge delta has move operation that does not start from offset 0', () => {
+				const range = new Range( new Position( root, [ 1, 10 ] ), new Position( root, [ 1, 20 ] ) );
+
+				// Such unusual delta may be a result of transformation.
+				const delta = new MergeDelta();
+				delta.addOperation( new MoveOperation( new Position( root, [ 1, 10 ] ), 10, new Position( root, [ 0, 10 ] ), 0 ) );
+				delta.addOperation( new RemoveOperation( new Position( root, [ 1 ] ), 1, new Position( doc.graveyard, [ 0 ] ), 1 ) );
+
+				const transformed = range.getTransformedByDelta( delta );
+
+				expect( transformed.length ).to.equal( 1 );
+				expect( transformed[ 0 ].start.path ).to.deep.equal( [ 0, 10 ] );
+				expect( transformed[ 0 ].end.path ).to.deep.equal( [ 0, 20 ] );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed a bug in `Range#getTransformedByDelta()` that caused editor crash after some `MergeDelta`s was transformed. Closes #1132.