### PR TITLE
Added model.DocumentSelection#hasOwnRange.

### DIFF
--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -120,6 +120,17 @@ export default class DocumentSelection extends Selection {
 	}
 
 	/**
+	 * Describes whether `DocumentSelection` has own range(s) set, or if it is defaulted to
+	 * {@link module:engine/model/document~Document#_getDefaultRange document's default range}.
+	 *
+	 * @readonly
+	 * @type {Boolean}
+	 */
+	get hasOwnRange() {
+		return this._ranges.length > 0;
+	}
+
+	/**
 	 * Unbinds all events previously bound by document selection.
 	 */
 	destroy() {

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -181,6 +181,18 @@ describe( 'DocumentSelection', () => {
 		} );
 	} );
 
+	describe( 'hasOwnRange', () => {
+		it( 'should return true if selection has any ranges set', () => {
+			selection.addRange( new Range( new Position( root, [ 0 ] ), new Position( root, [ 0 ] ) ) );
+
+			expect( selection.hasOwnRange ).to.be.true;
+		} );
+
+		it( 'should return false if selection has a default range', () => {
+			expect( selection.hasOwnRange ).to.be.false;
+		} );
+	} );
+
 	describe( 'addRange()', () => {
 		it( 'should convert added Range to LiveRange', () => {
 			selection.addRange( range );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `model.DocumentSelection#hasOwnRange`. Closes #1137.