### PR TITLE
Nodes should be removed from their original parent before they are moved to a new parent

### DIFF
--- a/src/controller/insertcontent.js
+++ b/src/controller/insertcontent.js
@@ -354,6 +354,11 @@ class Insertion {
 			}
 
 			if ( this._checkIsAllowed( node, [ paragraph ] ) ) {
+				// Prevent having same node in two parents.
+				if ( node.parent ) {
+					node.remove();
+				}
+
 				paragraph.appendChildren( node );
 				this._handleNode( paragraph, context );
 			}

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -212,7 +212,7 @@ export function mergeAttributes( position ) {
 	else if ( nodeBefore.is( 'attributeElement' ) && nodeAfter.is( 'attributeElement' ) && nodeBefore.isSimilar( nodeAfter ) ) {
 		// Move all children nodes from node placed after selection and remove that node.
 		const count = nodeBefore.childCount;
-		nodeBefore.appendChildren( nodeAfter.getChildren() );
+		nodeBefore.appendChildren( nodeAfter.removeChildren( 0, nodeAfter.childCount ) );
 		nodeAfter.remove();
 
 		// New position is located inside the first node, before new nodes.
@@ -831,8 +831,8 @@ function unwrapChildren( parent, startOffset, endOffset, attribute ) {
 
 		// If attributes are the similar, then unwrap.
 		if ( child.isSimilar( attribute ) ) {
-			const unwrapped = child.getChildren();
 			const count = child.childCount;
+			const unwrapped = child.removeChildren( 0, count );
 
 			// Replace wrapper element with its children
 			child.remove();
@@ -904,7 +904,7 @@ function wrapChildren( parent, startOffset, endOffset, attribute ) {
 			// Clone attribute.
 			const newAttribute = attribute.clone();
 
-			// Wrap current node with new attribute;
+			// Wrap current node with new attribute.
 			child.remove();
 			newAttribute.appendChildren( child );
 			parent.insertChildren( i, newAttribute );

--- a/tests/controller/insertcontent.js
+++ b/tests/controller/insertcontent.js
@@ -294,6 +294,16 @@ describe( 'DataController', () => {
 				expect( getData( doc ) ).to.equal( '<heading1>bar[]</heading1>' );
 			} );
 
+			it( 'autoparagraphs when just text is inserted', () => {
+				doc.schema.disallow( { name: '$text', inside: 'blockWidget' } );
+				doc.schema.allow( { name: 'paragraph', inside: 'blockWidget' } );
+
+				setData( doc, '<blockWidget>[]</blockWidget>' );
+				insertContent( dataController, new Text( 'foo' ), doc.selection );
+
+				expect( getData( doc ) ).to.equal( '<blockWidget><paragraph>foo[]</paragraph></blockWidget>' );
+			} );
+
 			describe( 'block to block handling', () => {
 				it( 'inserts one paragraph', () => {
 					setData( doc, '<paragraph>f[]oo</paragraph>' );

--- a/tests/view/writer/mergeattributes.js
+++ b/tests/view/writer/mergeattributes.js
@@ -143,5 +143,18 @@ describe( 'writer', () => {
 				'<container:p><ui:span></ui:span>[]<ui:span></ui:span></container:p>'
 			);
 		} );
+
+		it( 'should correctly move nodes when merging', () => {
+			// Check if nodes has been removed from old parent before adding to new parent.
+			const { view, selection } = parse(
+				'<container:p><attribute:b>foo</attribute:b>[]<attribute:b>bar</attribute:b></container:p>'
+			);
+
+			const b = view.getChild( 1 );
+
+			mergeAttributes( selection.getFirstPosition() );
+
+			expect( b.childCount ).to.equal( 0 );
+		} );
 	} );
 } );

--- a/tests/view/writer/unwrap.js
+++ b/tests/view/writer/unwrap.js
@@ -83,6 +83,16 @@ describe( 'writer', () => {
 			} ).to.throw( CKEditorError, 'view-writer-invalid-range-container' );
 		} );
 
+		it( 'should correctly move unwrapped nodes', () => {
+			// Check if nodes has been removed from old parent before adding to new parent.
+			const { view, selection } = parse( '<container:p>[<attribute:b>x</attribute:b>]</container:p>' );
+			const b = view.getChild( 0 );
+
+			unwrap( selection.getFirstRange(), parse( '<attribute:b></attribute:b>' ) );
+
+			expect( b.childCount ).to.equal( 0 );
+		} );
+
 		it( 'should unwrap single node', () => {
 			test(
 				'<container:p>[<attribute:b view-priority="1">foobar</attribute:b>]</container:p>',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed bugs in `view.Writer` and `controller.insertContent` that lead to a node being on the list of two different elements (parents). Closes #1139.