### PR TITLE
Range at the end of split element should be correctly moved to the new element

### DIFF
--- a/src/model/range.js
+++ b/src/model/range.js
@@ -496,6 +496,16 @@ export default class Range {
 				return [ new Range( targetPosition.getShiftedBy( this.start.offset ) ) ];
 			}
 			//
+			// Edge case for split delta.
+			//
+			if ( deltaType == 'split' && this.isCollapsed && this.end.isEqual( sourceRange.end ) ) {
+				// Collapsed range is at the end of split element.
+				// Without fix, the range would end up at the end of split (old) element instead of at the end of new element.
+				// That would happen because this range is not technically inside moved range. Last step below shows the fix.
+				// <p>foobar[]</p> -> <p>foobar[]</p><p></p> -> <p>foo[]</p><p>bar</p> -> <p>foo</p><p>bar[]</p>
+				return [ new Range( targetPosition.getShiftedBy( howMany ) ) ];
+			}
+			//
 			// Other edge cases:
 			//
 			// In all examples `[]` is `this` and `{}` is `sourceRange`, while `^` is move target position.

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -1024,6 +1024,19 @@ describe( 'Range', () => {
 				expect( transformed[ 0 ].start.path ).to.deep.equal( [ 0, 3 ] );
 				expect( transformed[ 0 ].end.path ).to.deep.equal( [ 1, 2 ] );
 			} );
+
+			it( 'split element which has collapsed range at the end', () => {
+				range.start = new Position( root, [ 0, 6 ] );
+				range.end = new Position( root, [ 0, 6 ] );
+
+				const delta = getSplitDelta( new Position( root, [ 0, 3 ] ), new Element( 'p' ), 3, 1 );
+
+				const transformed = range.getTransformedByDelta( delta );
+
+				expect( transformed.length ).to.equal( 1 );
+				expect( transformed[ 0 ].start.path ).to.deep.equal( [ 1, 3 ] );
+				expect( transformed[ 0 ].end.path ).to.deep.equal( [ 1, 3 ] );
+			} );
 		} );
 
 		describe( 'by MergeDelta', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `model.Range` now will be correctly transformed if it was at the end of split element. Instead of sticking to old element, it will be moved to the end of new element. Closes #1142.