### PR TITLE
MergeDelta x MoveDelta transformation case should not be applied in undo mode

### DIFF
--- a/src/model/delta/basic-transformations.js
+++ b/src/model/delta/basic-transformations.js
@@ -141,8 +141,10 @@ addTransformationCase( MarkerDelta, RenameDelta, transformMarkerDelta );
 
 // Add special case for MoveDelta x MergeDelta transformation.
 addTransformationCase( MoveDelta, MergeDelta, ( a, b, context ) => {
-	// Do not apply special transformation case if `MergeDelta` has `NoOperation` as the second operation.
-	if ( !b.position ) {
+	const undoMode = context.aWasUndone || context.bWasUndone;
+
+	// Do not apply special transformation case in undo mode or if `MergeDelta` has `NoOperation` as the second operation.
+	if ( undoMode || !b.position ) {
 		return defaultTransform( a, b, context );
 	}
 
@@ -185,8 +187,10 @@ addTransformationCase( MergeDelta, InsertDelta, ( a, b, context ) => {
 
 // Add special case for MergeDelta x MoveDelta transformation.
 addTransformationCase( MergeDelta, MoveDelta, ( a, b, context ) => {
-	// Do not apply special transformation case if `MergeDelta` has `NoOperation` as the second operation.
-	if ( !a.position ) {
+	const undoMode = context.aWasUndone || context.bWasUndone;
+
+	// Do not apply special transformation case in undo mode or if `MergeDelta` has `NoOperation` as the second operation.
+	if ( undoMode || !a.position ) {
 		return defaultTransform( a, b, context );
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Undo did no changes instead of merging elements, in a scenario when an element was split and then the "new" element was removed.

---

### Additional information

Originally reported here: https://github.com/ckeditor/ckeditor5-undo/issues/65#issuecomment-323682195

A PR in undo with a test will follow.