### PR TITLE
View selection correctness was not checked and fixed when view selection was converted to model

### DIFF
--- a/src/conversion/view-selection-to-model-converters.js
+++ b/src/conversion/view-selection-to-model-converters.js
@@ -11,6 +11,7 @@
  */
 
 import ModelSelection from '../model/selection';
+import ModelRange from '../model/range';
 
 /**
  * Function factory, creates a callback function which converts a {@link module:engine/view/selection~Selection view selection} taken
@@ -34,7 +35,12 @@ export function convertSelectionChange( modelDocument, mapper ) {
 		const ranges = [];
 
 		for ( const viewRange of viewSelection.getRanges() ) {
-			ranges.push( mapper.toModelRange( viewRange ) );
+			const mappedRange = mapper.toModelRange( viewRange );
+
+			const correctModelRangeStart = modelDocument.getNearestSelectionRange( mappedRange.start ).start;
+			const correctModelRangeEnd = modelDocument.getNearestSelectionRange( mappedRange.end ).end;
+
+			ranges.push( new ModelRange( correctModelRangeStart, correctModelRangeEnd ) );
 		}
 
 		modelSelection.setRanges( ranges, viewSelection.isBackward );

--- a/src/conversion/view-selection-to-model-converters.js
+++ b/src/conversion/view-selection-to-model-converters.js
@@ -37,10 +37,17 @@ export function convertSelectionChange( modelDocument, mapper ) {
 		for ( const viewRange of viewSelection.getRanges() ) {
 			const mappedRange = mapper.toModelRange( viewRange );
 
-			const correctModelRangeStart = modelDocument.getNearestSelectionRange( mappedRange.start ).start;
-			const correctModelRangeEnd = modelDocument.getNearestSelectionRange( mappedRange.end ).end;
+			const correctModelRangeStart = modelDocument.getNearestSelectionRange( mappedRange.start );
+			const correctModelRangeEnd = modelDocument.getNearestSelectionRange( mappedRange.end );
 
-			ranges.push( new ModelRange( correctModelRangeStart, correctModelRangeEnd ) );
+			// If the mapped range is incorrect. Skip it.
+			// Both `correctModelRangeStart` and `correctModelRangeEnd` are checked, although it seems that if
+			// one is `null` (incorrect) the other always should be `null` too. But to be safe, both are checked.
+			if ( !correctModelRangeStart || !correctModelRangeEnd ) {
+				continue;
+			}
+
+			ranges.push( new ModelRange( correctModelRangeStart.start, correctModelRangeEnd.end ) );
 		}
 
 		modelSelection.setRanges( ranges, viewSelection.isBackward );

--- a/tests/conversion/view-selection-to-model-converters.js
+++ b/tests/conversion/view-selection-to-model-converters.js
@@ -124,4 +124,14 @@ describe( 'convertSelectionChange', () => {
 
 		expect( spy.called ).to.be.false;
 	} );
+
+	it( 'should handle incorrect view selection and convert it to correct model selection', () => {
+		const viewSelection = new ViewSelection();
+
+		viewSelection.addRange( ViewRange.createFromParentsAndOffsets( viewRoot, 0, viewRoot, 0 ) );
+
+		convertSelection( null, { newSelection: viewSelection } );
+
+		expect( modelGetData( model ) ).to.equal( '<paragraph>[]foo</paragraph><paragraph>bar</paragraph>' );
+	} );
 } );

--- a/tests/conversion/view-selection-to-model-converters.js
+++ b/tests/conversion/view-selection-to-model-converters.js
@@ -134,4 +134,17 @@ describe( 'convertSelectionChange', () => {
 
 		expect( modelGetData( model ) ).to.equal( '<paragraph>[]foo</paragraph><paragraph>bar</paragraph>' );
 	} );
+
+	it( 'should not crash if there is no correct position for model selection', () => {
+		modelSetData( model, '' );
+		viewSetData( view, '' );
+
+		const viewSelection = new ViewSelection();
+
+		viewSelection.addRange( ViewRange.createFromParentsAndOffsets( viewRoot, 0, viewRoot, 0 ) );
+
+		convertSelection( null, { newSelection: viewSelection } );
+
+		expect( modelGetData( model ) ).to.equal( '[]' );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Incorrect view selection was converted to incorrect model selection, causing bugs when DOM selection was placed in a wrong place. Closes https://github.com/ckeditor/ckeditor5/issues/562.