### PR TITLE
Range#_getTransformedByInsertion handle isSticky flag properly for collapsed range

### DIFF
--- a/src/dev-utils/enableenginedebug.js
+++ b/src/dev-utils/enableenginedebug.js
@@ -382,7 +382,10 @@ function enableLoggingTools() {
 
 	MergeDelta.prototype.toString = function() {
 		return getClassName( this ) + `( ${ this.baseVersion } ): ` +
-			this.position.toString();
+			( this.position ?
+				this.position.toString() :
+				`(move from ${ this.operations[ 0 ].sourcePosition })`
+			);
 	};
 
 	MoveDelta.prototype.toString = function() {

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -342,7 +342,9 @@ const ot = {
 		InsertOperation( a, b, context ) {
 			// Create range from MoveOperation properties and transform it by insertion.
 			let range = Range.createFromPositionAndShift( a.sourcePosition, a.howMany );
-			range = range._getTransformedByInsertion( b.position, b.nodes.maxOffset, false, a.isSticky && !context.forceNotSticky )[ 0 ];
+			const includeB = a.isSticky && !context.forceNotSticky;
+
+			range = range._getTransformedByInsertion( b.position, b.nodes.maxOffset, false, includeB )[ 0 ];
 
 			// Check whether there is a forced order of nodes or use `context.isStrong` flag for conflict resolving.
 			const insertBefore = context.insertBefore === undefined ? !context.isStrong : context.insertBefore;

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -615,7 +615,7 @@ export default class Range {
 		} else {
 			const range = Range.createFromRange( this );
 
-			const insertBeforeStart = range.isCollapsed ? true : !isSticky;
+			const insertBeforeStart = !isSticky;
 			const insertBeforeEnd = range.isCollapsed ? true : isSticky;
 
 			range.start = range.start._getTransformedByInsertion( insertPosition, howMany, insertBeforeStart );

--- a/tests/dev-utils/enableenginedebug.js
+++ b/tests/dev-utils/enableenginedebug.js
@@ -397,6 +397,25 @@ describe( 'debug tools', () => {
 				expect( log.calledWithExactly( delta.toString() ) ).to.be.true;
 			} );
 
+			it( 'MergeDelta - NoOperation as second operation', () => {
+				const otherRoot = modelDoc.createRoot( '$root', 'otherRoot' );
+				const firstEle = new ModelElement( 'paragraph' );
+				const removedEle = new ModelElement( 'paragraph', null, [ new ModelText( 'foo' ) ] );
+
+				otherRoot.appendChildren( [ firstEle, removedEle ] );
+
+				const delta = new MergeDelta();
+				const move = new MoveOperation( ModelPosition.createAt( removedEle, 0 ), 3, ModelPosition.createAt( firstEle, 0 ), 0 );
+
+				delta.addOperation( move );
+				delta.addOperation( new NoOperation( 1 ) );
+
+				expect( delta.toString() ).to.equal( 'MergeDelta( 0 ): (move from otherRoot [ 1, 0 ])' );
+
+				delta.log();
+				expect( log.calledWithExactly( delta.toString() ) ).to.be.true;
+			} );
+
 			it( 'MoveDelta', () => {
 				const delta = new MoveDelta();
 				const move1 = new MoveOperation( ModelPosition.createAt( modelRoot, 0 ), 1, ModelPosition.createAt( modelRoot, 3 ), 0 );

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -572,11 +572,11 @@ describe( 'Range', () => {
 			expect( transformed[ 0 ].end.path ).to.deep.equal( [ 4, 4 ] );
 		} );
 
-		it( 'should move after inserted nodes if the range is collapsed and isSticky is true', () => {
+		it( 'should expand range after inserted nodes if the range is collapsed and isSticky is true', () => {
 			const range = new Range( new Position( root, [ 3, 2 ] ), new Position( root, [ 3, 2 ] ) );
 			const transformed = range._getTransformedByInsertion( new Position( root, [ 3, 2 ] ), 3, false, true );
 
-			expect( transformed[ 0 ].start.path ).to.deep.equal( [ 3, 5 ] );
+			expect( transformed[ 0 ].start.path ).to.deep.equal( [ 3, 2 ] );
 			expect( transformed[ 0 ].end.path ).to.deep.equal( [ 3, 5 ] );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `model.Range` now will be extended if it was collapsed and it was transformed by insertion. Closes #1159.