### PR TITLE
T/1158: Removed "renderer-skipped-selection-rendering" warning

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -15,7 +15,6 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import diff from '@ckeditor/ckeditor5-utils/src/diff';
 import insertAt from '@ckeditor/ckeditor5-utils/src/dom/insertat';
 import remove from '@ckeditor/ckeditor5-utils/src/dom/remove';
-import log from '@ckeditor/ckeditor5-utils/src/log';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
@@ -640,16 +639,6 @@ export default class Renderer {
 
 		// If selection is not collapsed, it does not need to be updated if it is similar.
 		if ( !this.selection.isCollapsed && this.selection.isSimilar( oldViewSelection ) ) {
-			const data = {
-				oldSelection: oldViewSelection,
-				currentSelection: this.selection
-			};
-
-			log.warn(
-				'renderer-skipped-selection-rendering: The selection was not rendered due to its similarity to the current one.',
-				data
-			);
-
 			// Selection did not changed and is correct, do not update.
 			return false;
 		}

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -20,7 +20,6 @@ import { parse, setData as setViewData, getData as getViewData } from '../../src
 import { INLINE_FILLER, INLINE_FILLER_LENGTH, isBlockFiller, BR_FILLER } from '../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
-import log from '@ckeditor/ckeditor5-utils/src/log';
 import { unwrap, insert, remove } from '../../src/view/writer';
 import normalizeHtml from '@ckeditor/ckeditor5-utils/tests/_utils/normalizehtml';
 
@@ -1459,11 +1458,7 @@ describe( 'Renderer', () => {
 		describe( 'similar selection', () => {
 			// Use spies to check selection updates. Some selection positions are not achievable in some
 			// browsers (e.g. <p>Foo<b>{}Bar</b></p> in Chrome) so asserting dom selection after rendering would fail.
-			let selectionCollapseSpy, selectionExtendSpy, logWarnStub;
-
-			before( () => {
-				logWarnStub = sinon.stub( log, 'warn' );
-			} );
+			let selectionCollapseSpy, selectionExtendSpy;
 
 			afterEach( () => {
 				if ( selectionCollapseSpy ) {
@@ -1475,11 +1470,6 @@ describe( 'Renderer', () => {
 					selectionExtendSpy.restore();
 					selectionExtendSpy = null;
 				}
-				logWarnStub.reset();
-			} );
-
-			after( () => {
-				logWarnStub.restore();
 			} );
 
 			it( 'should always render collapsed selection even if it is similar', () => {
@@ -1520,7 +1510,6 @@ describe( 'Renderer', () => {
 				expect( selectionCollapseSpy.calledWith( domB.childNodes[ 0 ], 0 ) ).to.true;
 				expect( selectionExtendSpy.calledOnce ).to.true;
 				expect( selectionExtendSpy.calledWith( domB.childNodes[ 0 ], 0 ) ).to.true;
-				expect( logWarnStub.notCalled ).to.true;
 			} );
 
 			it( 'should always render collapsed selection even if it is similar (with empty element)', () => {
@@ -1560,7 +1549,6 @@ describe( 'Renderer', () => {
 				expect( selectionCollapseSpy.calledWith( domP.childNodes[ 0 ], 3 ) ).to.true;
 				expect( selectionExtendSpy.calledOnce ).to.true;
 				expect( selectionExtendSpy.calledWith( domP.childNodes[ 0 ], 3 ) ).to.true;
-				expect( logWarnStub.notCalled ).to.true;
 			} );
 
 			it( 'should always render non-collapsed selection if it not is similar', () => {
@@ -1601,7 +1589,6 @@ describe( 'Renderer', () => {
 				expect( selectionCollapseSpy.calledWith( domP.childNodes[ 0 ], 2 ) ).to.true;
 				expect( selectionExtendSpy.calledOnce ).to.true;
 				expect( selectionExtendSpy.calledWith( domB.childNodes[ 0 ], 1 ) ).to.true;
-				expect( logWarnStub.notCalled ).to.true;
 			} );
 
 			it( 'should always render selection (even if it is same in view) if current dom selection is in incorrect place', () => {
@@ -1669,7 +1656,6 @@ describe( 'Renderer', () => {
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
 				expect( selectionExtendSpy.notCalled ).to.true;
-				expect( logWarnStub.called ).to.true;
 			} );
 
 			it( 'should not render non-collapsed selection it is similar (element end)', () => {
@@ -1708,7 +1694,6 @@ describe( 'Renderer', () => {
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
 				expect( selectionExtendSpy.notCalled ).to.true;
-				expect( logWarnStub.called ).to.true;
 			} );
 
 			it( 'should not render non-collapsed selection it is similar (element start - nested)', () => {
@@ -1747,7 +1732,6 @@ describe( 'Renderer', () => {
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
 				expect( selectionExtendSpy.notCalled ).to.true;
-				expect( logWarnStub.called ).to.true;
 			} );
 
 			it( 'should not render non-collapsed selection it is similar (element end - nested)', () => {
@@ -1785,7 +1769,6 @@ describe( 'Renderer', () => {
 
 				expect( selectionCollapseSpy.notCalled ).to.true;
 				expect( selectionExtendSpy.notCalled ).to.true;
-				expect( logWarnStub.called ).to.true;
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed `renderer-skipped-selection-rendering` warning. Closes #1158.
