### PR TITLE
Fixes in OT for MoveOperation

### DIFF
--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -462,12 +462,20 @@ const ot = {
 			// two separate ranges. Also we have to discard two difference parts.
 			const aCompB = compareArrays( a.sourcePosition.getParentPath(), b.sourcePosition.getParentPath() );
 
-			if ( aCompB == 'prefix' || aCompB == 'extension' ) {
+			if ( aCompB == 'prefix' || aCompB == 'extension' && a.sourcePosition.root == b.sourcePosition.root ) {
 				// Transform `rangeA` by `b` operation and make operation out of it, and that's all.
 				// Note that this is a simplified version of default case, but here we treat the common part (whole `rangeA`)
 				// like a one difference part.
+				//
+				// On a rare occasion, `rangeA` may be collapsed. This means that the move operation moves 0 nodes.
+				// When this happens, be sure to transform positions accordingly, avoiding situation where range start
+				// is moved past the range start.
+				//
+				// Cache the value, because range's start position will soon change.
+				const isCollapsed = rangeA.isCollapsed;
+
 				rangeA.start = rangeA.start._getTransformedByMove( b.sourcePosition, b.targetPosition, b.howMany, !includeB );
-				rangeA.end = rangeA.end._getTransformedByMove( b.sourcePosition, b.targetPosition, b.howMany, includeB );
+				rangeA.end = rangeA.end._getTransformedByMove( b.sourcePosition, b.targetPosition, b.howMany, isCollapsed || includeB );
 
 				return makeMoveOperationsFromRanges( [ rangeA ], newTargetPosition, a );
 			}

--- a/tests/model/operation/transform.js
+++ b/tests/model/operation/transform.js
@@ -2824,6 +2824,72 @@ describe( 'transform', () => {
 
 				expectOperation( transOp[ 0 ], expected );
 			} );
+
+			// #1167
+			it( 'operations source positions paths are related but are in different roots', () => {
+				const op = new MoveOperation(
+					new Position( root, [ 0, 6 ] ),
+					2,
+					new Position( root, [ 1, 0 ] ),
+					baseVersion
+				);
+
+				op.isSticky = true;
+
+				const transformBy = new MoveOperation(
+					new Position( doc.graveyard, [ 0 ] ),
+					1,
+					new Position( root, [ 0, 6 ] ),
+					baseVersion
+				);
+
+				const transOp = transform( op, transformBy, { isStrong: true, forceNotSticky: true } );
+
+				expect( transOp.length ).to.equal( 1 );
+
+				expected.sourcePosition.path = [ 0, 7 ];
+
+				expectOperation( transOp[ 0 ], {
+					type: MoveOperation,
+					sourcePosition: new Position( root, [ 0, 7 ] ),
+					targetPosition: new Position( root, [ 1, 0 ] ),
+					howMany: 2,
+					baseVersion: baseVersion + 1
+				} );
+			} );
+
+			// #1167
+			it( 'transformed operation moves 0 nodes', () => {
+				const op = new MoveOperation(
+					new Position( root, [ 0, 6 ] ),
+					0,
+					new Position( root, [ 1, 0 ] ),
+					baseVersion
+				);
+
+				op.isSticky = true;
+
+				const transformBy = new MoveOperation(
+					new Position( root, [ 3 ] ),
+					2,
+					new Position( root, [ 0, 6 ] ),
+					baseVersion
+				);
+
+				const transOp = transform( op, transformBy, { isStrong: true, forceNotSticky: true } );
+
+				expect( transOp.length ).to.equal( 1 );
+
+				expected.sourcePosition.path = [ 0, 7 ];
+
+				expectOperation( transOp[ 0 ], {
+					type: MoveOperation,
+					sourcePosition: new Position( root, [ 0, 8 ] ),
+					targetPosition: new Position( root, [ 1, 0 ] ),
+					howMany: 0,
+					baseVersion: baseVersion + 1
+				} );
+			} );
 		} );
 
 		describe( 'by RemoveOperation', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed bug in `MoveOperation` transformation causing undo to behave incorrectly. Closes #1167.