### PR TITLE
Prevent adding inline filler to non-editable content. 

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -381,6 +381,11 @@ export default class Renderer {
 			return false;
 		}
 
+		// Block adding inline filler inside elements with contenteditable=false.
+		if ( _isNotEditable( selectionParent ) ) {
+			return false;
+		}
+
 		// We have block filler, we do not need inline one.
 		if ( selectionOffset === selectionParent.getFillerOffset() ) {
 			return false;
@@ -708,3 +713,18 @@ export default class Renderer {
 }
 
 mix( Renderer, ObservableMixin );
+
+// Checks if contents inside provided element are not editable.
+//
+// @private
+// @param {module:engine/view/element~Element} element
+// @returns {Boolean}
+function _isNotEditable( element ) {
+	if ( element.getAttribute( 'contenteditable' ) === false ) {
+		return true;
+	}
+
+	const parent = element.findAncestor( element => element.hasAttribute( 'contenteditable' ) );
+
+	return parent && !parent.getAttribute( 'contenteditable' );
+}

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -382,6 +382,7 @@ export default class Renderer {
 		}
 
 		// Block adding inline filler inside elements with contenteditable=false.
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1170
 		if ( _isNotEditable( selectionParent ) ) {
 			return false;
 		}
@@ -720,11 +721,11 @@ mix( Renderer, ObservableMixin );
 // @param {module:engine/view/element~Element} element
 // @returns {Boolean}
 function _isNotEditable( element ) {
-	if ( element.getAttribute( 'contenteditable' ) === false ) {
+	if ( element.getAttribute( 'contenteditable' ) == 'false' ) {
 		return true;
 	}
 
 	const parent = element.findAncestor( element => element.hasAttribute( 'contenteditable' ) );
 
-	return parent && !parent.getAttribute( 'contenteditable' );
+	return parent && parent.getAttribute( 'contenteditable' ) == 'false';
 }

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -381,9 +381,9 @@ export default class Renderer {
 			return false;
 		}
 
-		// Block adding inline filler inside elements with contenteditable=false.
+		// Prevent adding inline filler inside elements with contenteditable=false.
 		// https://github.com/ckeditor/ckeditor5-engine/issues/1170
-		if ( _isNotEditable( selectionParent ) ) {
+		if ( !_isEditable( selectionParent ) ) {
 			return false;
 		}
 
@@ -715,17 +715,17 @@ export default class Renderer {
 
 mix( Renderer, ObservableMixin );
 
-// Checks if contents inside provided element are not editable.
+// Checks if provided element is editable.
 //
 // @private
 // @param {module:engine/view/element~Element} element
 // @returns {Boolean}
-function _isNotEditable( element ) {
+function _isEditable( element ) {
 	if ( element.getAttribute( 'contenteditable' ) == 'false' ) {
-		return true;
+		return false;
 	}
 
 	const parent = element.findAncestor( element => element.hasAttribute( 'contenteditable' ) );
 
-	return parent && parent.getAttribute( 'contenteditable' ) == 'false';
+	return !parent || parent.getAttribute( 'contenteditable' ) == 'true';
 }

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -410,6 +410,50 @@ describe( 'Renderer', () => {
 			expect( viewRoot ).to.be.ok;
 		} );
 
+		it( 'should not add filler when inside contenteditable=false parent', () => {
+			const { view: viewP, selection: newSelection } = parse(
+				'<container:p>foo<attribute:b contenteditable="false">[]</attribute:b>bar</container:p>' );
+
+			viewRoot.appendChildren( viewP );
+			selection.setTo( newSelection );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			expect( domRoot.childNodes.length ).to.equal( 1 );
+			expect( domRoot.childNodes[ 0 ].tagName.toLowerCase() ).to.equal( 'p' );
+
+			const domP = domRoot.childNodes[ 0 ];
+
+			expect( domP.childNodes.length ).to.equal( 3 );
+			expect( domP.childNodes[ 0 ].data ).to.equal( 'foo' );
+			expect( domP.childNodes[ 2 ].data ).to.equal( 'bar' );
+			expect( domP.childNodes[ 1 ].tagName.toLowerCase() ).to.equal( 'b' );
+			expect( domP.childNodes[ 1 ].childNodes.length ).to.equal( 0 );
+		} );
+
+		it( 'should not add filler when inside contenteditable=false ancestor', () => {
+			const { view: viewP, selection: newSelection } = parse(
+				'<container:p contenteditable="false">foo<attribute:b>[]</attribute:b>bar</container:p>' );
+
+			viewRoot.appendChildren( viewP );
+			selection.setTo( newSelection );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			expect( domRoot.childNodes.length ).to.equal( 1 );
+			expect( domRoot.childNodes[ 0 ].tagName.toLowerCase() ).to.equal( 'p' );
+
+			const domP = domRoot.childNodes[ 0 ];
+
+			expect( domP.childNodes.length ).to.equal( 3 );
+			expect( domP.childNodes[ 0 ].data ).to.equal( 'foo' );
+			expect( domP.childNodes[ 2 ].data ).to.equal( 'bar' );
+			expect( domP.childNodes[ 1 ].tagName.toLowerCase() ).to.equal( 'b' );
+			expect( domP.childNodes[ 1 ].childNodes.length ).to.equal( 0 );
+		} );
+
 		it( 'should add and remove inline filler in case <p>foo<b>[]</b>bar</p>', () => {
 			const domSelection = document.getSelection();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevent adding inline filler to non-editable content. Closes #1170.

---

### Additional information
Please close after https://github.com/ckeditor/ckeditor5-widget/pull/27
