### PR TITLE
Bound view roots to model roots.

### DIFF
--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -155,7 +155,7 @@ export default class EditingController {
 			const viewRoot = new RootEditableElement( root.name );
 
 			viewRoot.rootName = root.rootName;
-			viewRoot.document = this;
+			viewRoot.document = this.view;
 			this.mapper.bindElements( root, viewRoot );
 
 			return viewRoot;

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -32,10 +32,6 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
  * including selection handling. It also creates {@link ~EditingController#view view document} which build a
  * browser-independent virtualization over the DOM elements. Editing controller also attach default converters.
  *
- * Editing controller binds {@link module:engine/view/document~Document#roots view roots collection} to
- * {@link module:engine/model/document~Document#roots model roots collection} so creating model root automatically
- * creates corresponding view root.
- *
  * @mixes module:utils/observablemixin~ObservableMixin
  */
 export default class EditingController {
@@ -147,7 +143,9 @@ export default class EditingController {
 		this.modelToView.on( 'selection', convertRangeSelection(), { priority: 'low' } );
 		this.modelToView.on( 'selection', convertCollapsedSelection(), { priority: 'low' } );
 
-		// Bind model and view roots.
+		// Binds {@link module:engine/view/document~Document#roots view roots collection} to
+		// {@link module:engine/model/document~Document#roots model roots collection} so creating
+		// model root automatically creates corresponding view root.
 		this.view.roots.bindTo( this.model.document.roots ).using( root => {
 			// $graveyard is a special root that has no reflection in the view.
 			if ( root.rootName == '$graveyard' ) {

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -7,6 +7,7 @@
  * @module engine/controller/editingcontroller
  */
 
+import RootEditableElement from '../view/rooteditableelement';
 import ModelDiffer from '../model/differ';
 import ViewDocument from '../view/document';
 import Mapper from '../conversion/mapper';
@@ -30,6 +31,8 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
  * Controller for the editing pipeline. The editing pipeline controls {@link ~EditingController#model model} rendering,
  * including selection handling. It also creates {@link ~EditingController#view view document} which build a
  * browser-independent virtualization over the DOM elements. Editing controller also attach default converters.
+ *
+ * Editing controller binds {@link model:engine/}
  *
  * @mixes module:utils/observablemixin~ObservableMixin
  */
@@ -141,33 +144,22 @@ export default class EditingController {
 		this.modelToView.on( 'selection', clearFakeSelection(), { priority: 'low' } );
 		this.modelToView.on( 'selection', convertRangeSelection(), { priority: 'low' } );
 		this.modelToView.on( 'selection', convertCollapsedSelection(), { priority: 'low' } );
-	}
 
-	/**
-	 * {@link module:engine/view/document~Document#createRoot Creates} a view root
-	 * and {@link module:engine/conversion/mapper~Mapper#bindElements binds}
-	 * the model root with view root and and view root with DOM element:
-	 *
-	 *		editing.createRoot( document.querySelector( div#editor ) );
-	 *
-	 * If the DOM element is not available at the time you want to create a view root, for instance it is iframe body
-	 * element, it is possible to create view element and bind the DOM element later:
-	 *
-	 *		editing.createRoot( 'body' );
-	 *		editing.view.attachDomRoot( iframe.contentDocument.body );
-	 *
-	 * @param {Element|String} domRoot DOM root element or the name of view root element if the DOM element will be
-	 * attached later.
-	 * @param {String} [name='main'] Root name.
-	 * @returns {module:engine/view/containerelement~ContainerElement} View root element.
-	 */
-	createRoot( domRoot, name = 'main' ) {
-		const viewRoot = this.view.createRoot( domRoot, name );
-		const modelRoot = this.model.document.getRoot( name );
+		// Bind model and view roots.
+		this.view.roots.bindTo( this.model.document.roots ).using( root => {
+			// $graveyard is a special root that has no reflection in the view.
+			if ( root.rootName == '$graveyard' ) {
+				return null;
+			}
 
-		this.mapper.bindElements( modelRoot, viewRoot );
+			const viewRoot = new RootEditableElement( root.name );
 
-		return viewRoot;
+			viewRoot.rootName = root.rootName;
+			viewRoot.document = this;
+			this.mapper.bindElements( root, viewRoot );
+
+			return viewRoot;
+		} );
 	}
 
 	/**

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -32,7 +32,9 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
  * including selection handling. It also creates {@link ~EditingController#view view document} which build a
  * browser-independent virtualization over the DOM elements. Editing controller also attach default converters.
  *
- * Editing controller binds {@link model:engine/}
+ * Editing controller binds {@link module:engine/view/document~Document#roots view roots collection} to
+ * {@link module:engine/model/document~Document#roots model roots collection} so creating model root automatically
+ * creates corresponding view root.
  *
  * @mixes module:utils/observablemixin~ObservableMixin
  */

--- a/src/dev-utils/enableenginedebug.js
+++ b/src/dev-utils/enableenginedebug.js
@@ -679,7 +679,7 @@ class DebugPlugin extends Plugin {
 function dumpTrees( document, version ) {
 	let string = '';
 
-	for ( const root of document.roots.values() ) {
+	for ( const root of document.roots ) {
 		string += root.printTree() + '\n';
 	}
 

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -191,7 +191,9 @@ export default class Document {
 	 * @returns {module:engine/model/rootelement~RootElement} Root registered under given name.
 	 */
 	getRoot( name = 'main' ) {
-		if ( !this.hasRoot( name ) ) {
+		const root = this.roots.get( name );
+
+		if ( !root ) {
 			/**
 			 * Root with specified name does not exist.
 			 *
@@ -204,17 +206,7 @@ export default class Document {
 			);
 		}
 
-		return this.roots.get( name );
-	}
-
-	/**
-	 * Checks if root with given name is defined.
-	 *
-	 * @param {String} name Name of root to check.
-	 * @returns {Boolean}
-	 */
-	hasRoot( name ) {
-		return !!this.roots.get( name );
+		return root;
 	}
 
 	/**

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -149,10 +149,6 @@ export default class Document {
 	/**
 	 * Creates a new top-level root.
 	 *
-	 * **Note**: Creating model root automatically creates corresponding
-	 * {@link module:engine/view/document~Document#roots view root} with the same name. Name of view root
-	 * will be hanged later on when dom root will be {@link module:engine/view/document~Document#attachDomRoot attached}.
-	 *
 	 * @param {String} [elementName='$root'] Element name. Defaults to `'$root'` which also have
 	 * some basic schema defined (`$block`s are allowed inside the `$root`). Make sure to define a proper
 	 * schema if you use a different name.

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -188,25 +188,11 @@ export default class Document {
 	 * Returns top-level root by its name.
 	 *
 	 * @param {String} [name='main'] Unique root name.
-	 * @returns {module:engine/model/rootelement~RootElement} Root registered under given name.
+	 * @returns {module:engine/model/rootelement~RootElement|null} Root registered under given name or null when
+	 * there is no root of given name.
 	 */
 	getRoot( name = 'main' ) {
-		const root = this.roots.get( name );
-
-		if ( !root ) {
-			/**
-			 * Root with specified name does not exist.
-			 *
-			 * @error model-document-getRoot-root-not-exist
-			 * @param {String} name
-			 */
-			throw new CKEditorError(
-				'model-document-getRoot-root-not-exist: Root with specified name does not exist.',
-				{ name }
-			);
-		}
-
-		return root;
+		return this.roots.get( name );
 	}
 
 	/**

--- a/src/model/operation/rootattributeoperation.js
+++ b/src/model/operation/rootattributeoperation.js
@@ -168,7 +168,7 @@ export default class RootAttributeOperation extends Operation {
 	 * @returns {module:engine/model/operation/rootattributeoperation~RootAttributeOperation}
 	 */
 	static fromJSON( json, document ) {
-		if ( !document.hasRoot( json.root ) ) {
+		if ( !document.getRoot( json.root ) ) {
 			/**
 			 * Cannot create RootAttributeOperation for document. Root with specified name does not exist.
 			 *

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -764,7 +764,7 @@ export default class Position {
 			return new Position( doc.graveyard, json.path );
 		}
 
-		if ( !doc.hasRoot( json.root ) ) {
+		if ( !doc.getRoot( json.root ) ) {
 			/**
 			 * Cannot create position for document. Root with specified name does not exist.
 			 *

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -217,7 +217,8 @@ export default class Document {
 	 * specific "main" root is returned.
 	 *
 	 * @param {String} [name='main'] Name of the root.
-	 * @returns {module:engine/view/rooteditableelement~RootEditableElement} The view root element with the specified name.
+	 * @returns {module:engine/view/rooteditableelement~RootEditableElement|null} The view root element with the specified name
+	 * or null when there is no root of given name.
 	 */
 	getRoot( name = 'main' ) {
 		return this.roots.get( name );

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -74,15 +74,15 @@ export default class Document {
 		this.domConverter = new DomConverter();
 
 		/**
-		 * Roots of the view tree. Map of the {module:engine/view/element~Element view elements} with roots names as keys.
+		 * Roots of the view tree. Collection of the {module:engine/view/element~Element view elements}.
 		 *
 		 * View roots are created as a result of binding between {@link module:engine/view/document~Document#roots} and
 		 * {@link module:engine/model/document~Document#roots} and this is handled by
-		 * {@link modeule:engine/controller/editingcontroller~EditingController}, so to create view root we need to create
+		 * {@link module:engine/controller/editingcontroller~EditingController}, so to create view root we need to create
 		 * model root using {@link module:engine/model/document~Document#createRoot}.
 		 *
 		 * @readonly
-		 * @member {Map} module:engine/view/document~Document#roots
+		 * @member {Collection} module:engine/view/document~Document#roots
 		 */
 		this.roots = new Collection( { idProperty: 'rootName' } );
 

--- a/src/view/rooteditableelement.js
+++ b/src/view/rooteditableelement.js
@@ -23,7 +23,6 @@ export default class RootEditableElement extends EditableElement {
 	/**
 	 * Creates root editable element.
 	 *
-	 * @param {module:engine/view/document~Document} document {@link module:engine/view/document~Document} that is an owner of the root.
 	 * @param {String} name Node name.
 	 */
 	constructor( name ) {
@@ -55,5 +54,17 @@ export default class RootEditableElement extends EditableElement {
 
 	set rootName( rootName ) {
 		this.setCustomProperty( rootNameSymbol, rootName );
+	}
+
+	/**
+	 * Overrides old element name and sets new one.
+	 * This is needed because name of view root has to be changed as the same as dom root name
+	 * when dom root is attached to view root.
+	 *
+	 * @protected
+	 * @param {String} name The new name of element.
+	 */
+	set _name( name ) {
+		this.name = name;
 	}
 }

--- a/src/view/rooteditableelement.js
+++ b/src/view/rooteditableelement.js
@@ -58,8 +58,9 @@ export default class RootEditableElement extends EditableElement {
 
 	/**
 	 * Overrides old element name and sets new one.
-	 * This is needed because name of view root has to be changed as the same as dom root name
-	 * when dom root is attached to view root.
+	 * This is needed because view roots are created before they are attached to the DOM.
+	 * The name of the root element is temporary at this stage. It has to be changed when the
+	 * view root element is attached to the DOM element.
 	 *
 	 * @protected
 	 * @param {String} name The new name of element.

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -62,6 +62,7 @@ describe( 'EditingController', () => {
 
 			expect( model.document.roots ).to.length( 2 );
 			expect( editing.view.roots ).to.length( 1 );
+			expect( editing.view.getRoot().document ).to.equal( editing.view );
 
 			expect( editing.view.getRoot().name ).to.equal( modelRoot.name ).to.equal( '$root' );
 		} );

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -20,8 +20,6 @@ import ModelPosition from '../../src/model/position';
 import ModelRange from '../../src/model/range';
 import ModelDocumentFragment from '../../src/model/documentfragment';
 
-import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
-
 import { parse, getData as getModelData } from '../../src/dev-utils/model';
 import { getData as getViewData } from '../../src/dev-utils/view';
 
@@ -55,71 +53,17 @@ describe( 'EditingController', () => {
 
 			sinon.assert.calledOnce( spy );
 		} );
-	} );
 
-	describe( 'createRoot()', () => {
-		let model, modelRoot, editing;
+		it( 'should bind view roots to model roots', () => {
+			expect( model.document.roots ).to.length( 1 ); // $graveyard
+			expect( editing.view.roots ).to.length( 0 );
 
-		beforeEach( () => {
-			model = new Model();
-			modelRoot = model.document.createRoot();
-			model.document.createRoot( '$root', 'header' );
+			const modelRoot = model.document.createRoot();
 
-			editing = new EditingController( model );
-		} );
+			expect( model.document.roots ).to.length( 2 );
+			expect( editing.view.roots ).to.length( 1 );
 
-		afterEach( () => {
-			editing.destroy();
-			model.markers.destroy();
-		} );
-
-		it( 'should create root', () => {
-			const domRoot = createElement( document, 'div', null, createElement( document, 'p' ) );
-
-			const viewRoot = editing.createRoot( domRoot );
-
-			expect( viewRoot ).to.equal( editing.view.getRoot() );
-			expect( domRoot ).to.equal( editing.view.getDomRoot() );
-
-			expect( editing.view.domConverter.mapViewToDom( viewRoot ) ).to.equal( domRoot );
-			expect( editing.view.renderer.markedChildren.has( viewRoot ) ).to.be.true;
-
-			expect( editing.mapper.toModelElement( viewRoot ) ).to.equal( modelRoot );
-			expect( editing.mapper.toViewElement( modelRoot ) ).to.equal( viewRoot );
-		} );
-
-		it( 'should create root with given name', () => {
-			const domRoot = createElement( document, 'div', null, createElement( document, 'p' ) );
-
-			const viewRoot = editing.createRoot( domRoot, 'header' );
-
-			expect( viewRoot ).to.equal( editing.view.getRoot( 'header' ) );
-			expect( domRoot ).to.equal( editing.view.getDomRoot( 'header' ) );
-
-			expect( editing.view.domConverter.mapViewToDom( viewRoot ) ).to.equal( domRoot );
-			expect( editing.view.renderer.markedChildren.has( viewRoot ) ).to.be.true;
-
-			expect( editing.mapper.toModelElement( viewRoot ) ).to.equal( model.document.getRoot( 'header' ) );
-			expect( editing.mapper.toViewElement( model.document.getRoot( 'header' ) ) ).to.equal( viewRoot );
-		} );
-
-		it( 'should be possible to attach DOM element later', () => {
-			const domRoot = createElement( document, 'div', null, createElement( document, 'p' ) );
-
-			const viewRoot = editing.createRoot( 'div' );
-
-			expect( viewRoot ).to.equal( editing.view.getRoot() );
-			expect( editing.view.getDomRoot() ).to.be.undefined;
-
-			editing.view.attachDomRoot( domRoot );
-
-			expect( domRoot ).to.equal( editing.view.getDomRoot() );
-
-			expect( editing.view.domConverter.mapViewToDom( viewRoot ) ).to.equal( domRoot );
-			expect( editing.view.renderer.markedChildren.has( viewRoot ) ).to.be.true;
-
-			expect( editing.mapper.toModelElement( viewRoot ) ).to.equal( modelRoot );
-			expect( editing.mapper.toViewElement( modelRoot ) ).to.equal( viewRoot );
+			expect( editing.view.getRoot().name ).to.equal( modelRoot.name ).to.equal( '$root' );
 		} );
 	} );
 
@@ -138,7 +82,9 @@ describe( 'EditingController', () => {
 			domRoot.contentEditable = true;
 
 			document.body.appendChild( domRoot );
-			viewRoot = editing.createRoot( domRoot );
+
+			viewRoot = editing.view.getRoot();
+			editing.view.attachDomRoot( domRoot );
 
 			model.schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 			model.schema.register( 'div', { inheritAllFrom: '$block' } );

--- a/tests/conversion/advanced-converters.js
+++ b/tests/conversion/advanced-converters.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global document */
-
 import Model from '../../src/model/model';
 import ModelElement from '../../src/model/element';
 import ModelText from '../../src/model/text';
@@ -42,8 +40,11 @@ describe( 'advanced-converters', () => {
 
 		const editing = new EditingController( model );
 
-		editing.view.attachDomRoot( document.createElement( 'div' ) );
 		viewRoot = editing.view.getRoot();
+
+		// Set name of view root the same as dom root.
+		// This is a mock of attaching view root to dom root.
+		viewRoot._name = 'div';
 
 		viewDispatcher = new ViewConversionDispatcher( model, { schema: { checkChild: () => true } } );
 		viewDispatcher.on( 'text', convertText() );

--- a/tests/conversion/advanced-converters.js
+++ b/tests/conversion/advanced-converters.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global document */
+
 import Model from '../../src/model/model';
 import ModelElement from '../../src/model/element';
 import ModelText from '../../src/model/text';
@@ -40,7 +42,8 @@ describe( 'advanced-converters', () => {
 
 		const editing = new EditingController( model );
 
-		viewRoot = editing.createRoot( 'div' );
+		editing.view.attachDomRoot( document.createElement( 'div' ) );
+		viewRoot = editing.view.getRoot();
 
 		viewDispatcher = new ViewConversionDispatcher( model, { schema: { checkChild: () => true } } );
 		viewDispatcher.on( 'text', convertText() );

--- a/tests/conversion/buildmodelconverter.js
+++ b/tests/conversion/buildmodelconverter.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global document */
+
 import buildModelConverter from '../../src/conversion/buildmodelconverter';
 
 import Model from '../../src/model/model';
@@ -63,7 +65,7 @@ describe( 'Model converter builder', () => {
 		modelRoot = modelDoc.createRoot();
 
 		controller = new EditingController( model );
-		controller.createRoot( 'div' );
+		controller.view.attachDomRoot( document.createElement( 'div' ) );
 
 		dispatcher = controller.modelToView;
 

--- a/tests/conversion/buildmodelconverter.js
+++ b/tests/conversion/buildmodelconverter.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global document */
-
 import buildModelConverter from '../../src/conversion/buildmodelconverter';
 
 import Model from '../../src/model/model';
@@ -65,7 +63,10 @@ describe( 'Model converter builder', () => {
 		modelRoot = modelDoc.createRoot();
 
 		controller = new EditingController( model );
-		controller.view.attachDomRoot( document.createElement( 'div' ) );
+
+		// Set name of view root the same as dom root.
+		// This is a mock of attaching view root to dom root.
+		controller.view.getRoot()._name = 'div';
 
 		dispatcher = controller.modelToView;
 

--- a/tests/conversion/definition-based-converters.js
+++ b/tests/conversion/definition-based-converters.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global document */
+
 import ModelElement from '../../src/model/element';
 import ModelText from '../../src/model/text';
 import ModelRange from '../../src/model/range';
@@ -112,7 +114,7 @@ describe( 'definition-based-converters', () => {
 		modelRoot = modelDoc.createRoot();
 
 		controller = new EditingController( model );
-		controller.createRoot( 'div' );
+		controller.view.attachDomRoot( document.createElement( 'div' ) );
 
 		viewRoot = controller.view.getRoot();
 		dispatcher = controller.modelToView;

--- a/tests/conversion/definition-based-converters.js
+++ b/tests/conversion/definition-based-converters.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global document */
-
 import ModelElement from '../../src/model/element';
 import ModelText from '../../src/model/text';
 import ModelRange from '../../src/model/range';
@@ -114,7 +112,10 @@ describe( 'definition-based-converters', () => {
 		modelRoot = modelDoc.createRoot();
 
 		controller = new EditingController( model );
-		controller.view.attachDomRoot( document.createElement( 'div' ) );
+
+		// Set name of view root the same as dom root.
+		// This is a mock of attaching view root to dom root.
+		controller.view.getRoot()._name = 'div';
 
 		viewRoot = controller.view.getRoot();
 		dispatcher = controller.modelToView;

--- a/tests/conversion/model-selection-to-view-converters.js
+++ b/tests/conversion/model-selection-to-view-converters.js
@@ -34,6 +34,7 @@ import {
 	removeHighlight
 } from '../../src/conversion/model-to-view-converters';
 
+import createViewRoot from '../view/_utils/createroot';
 import { stringify as stringifyView } from '../../src/dev-utils/view';
 import { setData as setModelData } from '../../src/dev-utils/model';
 
@@ -49,7 +50,7 @@ describe( 'model-selection-to-view-converters', () => {
 		model.schema.extend( '$text', { allowIn: '$root' } );
 
 		viewDoc = new ViewDocument();
-		viewRoot = viewDoc.createRoot( 'div' );
+		viewRoot = createViewRoot( viewDoc );
 		viewSelection = viewDoc.selection;
 
 		mapper = new Mapper();

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global document */
-
 import Model from '../../src/model/model';
 import ModelElement from '../../src/model/element';
 import ModelText from '../../src/model/text';
@@ -40,9 +38,12 @@ describe( 'model-to-view-converters', () => {
 		modelRoot = modelDoc.createRoot();
 
 		controller = new EditingController( model );
-		controller.view.attachDomRoot( document.createElement( 'div' ) );
 
 		viewRoot = controller.view.getRoot();
+		// Set name of view root the same as dom root.
+		// This is a mock of attaching view root to dom root.
+		controller.view.getRoot()._name = 'div';
+
 		dispatcher = controller.modelToView;
 
 		dispatcher.on( 'insert:paragraph', insertElement( () => new ViewContainerElement( 'p' ) ) );

--- a/tests/conversion/model-to-view-converters.js
+++ b/tests/conversion/model-to-view-converters.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global document */
+
 import Model from '../../src/model/model';
 import ModelElement from '../../src/model/element';
 import ModelText from '../../src/model/text';
@@ -38,7 +40,7 @@ describe( 'model-to-view-converters', () => {
 		modelRoot = modelDoc.createRoot();
 
 		controller = new EditingController( model );
-		controller.createRoot( 'div' );
+		controller.view.attachDomRoot( document.createElement( 'div' ) );
 
 		viewRoot = controller.view.getRoot();
 		dispatcher = controller.modelToView;

--- a/tests/conversion/view-selection-to-model-converters.js
+++ b/tests/conversion/view-selection-to-model-converters.js
@@ -6,6 +6,7 @@
 import ViewDocument from '../../src/view/document';
 import ViewSelection from '../../src/view/selection';
 import ViewRange from '../../src/view/range';
+import createViewRoot from '../view/_utils/createroot';
 
 import Model from '../../src/model/model';
 
@@ -26,7 +27,7 @@ describe( 'convertSelectionChange', () => {
 		modelSetData( model, '<paragraph>foo</paragraph><paragraph>bar</paragraph>' );
 
 		view = new ViewDocument();
-		viewRoot = view.createRoot( 'div' );
+		viewRoot = createViewRoot( view, 'div', 'main' );
 
 		viewSetData( view, '<p>foo</p><p>bar</p>' );
 

--- a/tests/dev-utils/enableenginedebug.js
+++ b/tests/dev-utils/enableenginedebug.js
@@ -46,6 +46,7 @@ import ViewTextProxy from '../../src/view/textproxy';
 import ViewDocumentFragment from '../../src/view/documentfragment';
 import ViewElement from '../../src/view/element';
 
+import createViewRoot from '../view/_utils/createroot';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 testUtils.createSinonSandbox();
@@ -104,14 +105,7 @@ describe( 'disableEngineDebug', () => {
 describe( 'debug tools', () => {
 	let DebugPlugin, log, error;
 
-	class TestEditor extends StandardEditor {
-		constructor( ...args ) {
-			super( ...args );
-
-			this.model.document.createRoot( 'main' );
-			this.editing.createRoot( this.element, 'main' );
-		}
-	}
+	class TestEditor extends StandardEditor {}
 
 	before( () => {
 		log = sinon.spy();
@@ -707,7 +701,7 @@ describe( 'debug tools', () => {
 
 		it( 'for view', () => {
 			const viewDoc = new ViewDocument();
-			const viewRoot = viewDoc.createRoot( 'div' );
+			const viewRoot = createViewRoot( viewDoc );
 
 			viewRoot.appendChildren( [
 				new ViewContainerElement( 'p', { foo: 'bar' }, [
@@ -849,14 +843,14 @@ describe( 'debug tools', () => {
 
 			viewDoc.log( 0 );
 			expectLog(
-				'<div></div>'
+				'<$root></$root>'
 			);
 
 			viewDoc.log( 2 );
 			expectLog(
-				'<div>' +
+				'<$root>' +
 				'\n\tfbar' +
-				'\n</div>'
+				'\n</$root>'
 			);
 
 			sinon.spy( modelDoc, 'log' );

--- a/tests/dev-utils/view.js
+++ b/tests/dev-utils/view.js
@@ -18,6 +18,7 @@ import Selection from '../../src/view/selection';
 import Range from '../../src/view/range';
 import Document from '../../src/view/document';
 import XmlDataProcessor from '../../src/dataprocessor/xmldataprocessor';
+import createViewRoot from '../view/_utils/createroot';
 
 describe( 'view test utils', () => {
 	describe( 'getData, setData', () => {
@@ -37,7 +38,7 @@ describe( 'view test utils', () => {
 				const stringifySpy = sandbox.spy( getData, '_stringify' );
 				const viewDocument = new Document();
 				const options = { showType: false, showPriority: false, withoutSelection: true };
-				const root = viewDocument.createRoot( element );
+				const root = createAttachedRoot( viewDocument, element );
 				root.appendChildren( new Element( 'p' ) );
 
 				expect( getData( viewDocument, options ) ).to.equal( '<p></p>' );
@@ -57,7 +58,7 @@ describe( 'view test utils', () => {
 				const stringifySpy = sandbox.spy( getData, '_stringify' );
 				const viewDocument = new Document();
 				const options = { showType: false, showPriority: false };
-				const root = viewDocument.createRoot( element );
+				const root = createAttachedRoot( viewDocument, element );
 				root.appendChildren( new Element( 'p' ) );
 
 				viewDocument.selection.addRange( Range.createFromParentsAndOffsets( root, 0, root, 1 ) );
@@ -87,7 +88,7 @@ describe( 'view test utils', () => {
 				const data = 'foobar<b>baz</b>';
 				const parseSpy = sandbox.spy( setData, '_parse' );
 
-				viewDocument.createRoot( document.createElement( 'div' ) );
+				createAttachedRoot( viewDocument, document.createElement( 'div' ) );
 				setData( viewDocument, data );
 
 				expect( getData( viewDocument ) ).to.equal( 'foobar<b>baz</b>' );
@@ -105,7 +106,7 @@ describe( 'view test utils', () => {
 				const data = '[<b>baz</b>]';
 				const parseSpy = sandbox.spy( setData, '_parse' );
 
-				viewDocument.createRoot( document.createElement( 'div' ) );
+				createAttachedRoot( viewDocument, document.createElement( 'div' ) );
 				setData( viewDocument, data );
 
 				expect( getData( viewDocument ) ).to.equal( '[<b>baz</b>]' );
@@ -677,3 +678,11 @@ describe( 'view test utils', () => {
 		} );
 	} );
 } );
+
+function createAttachedRoot( viewDocument, element ) {
+	const root = createViewRoot( viewDocument );
+
+	viewDocument.attachDomRoot( element );
+
+	return root;
+}

--- a/tests/dev-utils/view.js
+++ b/tests/dev-utils/view.js
@@ -682,7 +682,9 @@ describe( 'view test utils', () => {
 function createAttachedRoot( viewDocument, element ) {
 	const root = createViewRoot( viewDocument );
 
-	viewDocument.attachDomRoot( element );
+	// Set name of view root the same as dom root.
+	// This is a mock of attaching view root to dom root.
+	root._name = element.tagName.toLowerCase();
 
 	return root;
 }

--- a/tests/model/document/document.js
+++ b/tests/model/document/document.js
@@ -163,19 +163,20 @@ describe( 'Document', () => {
 	} );
 
 	describe( 'getRoot()', () => {
-		it( 'should return a RootElement previously created with given name', () => {
-			const newRoot = doc.createRoot();
-			const getRoot = doc.getRoot();
+		it( 'should return a RootElement with default "main" name', () => {
+			const newRoot = doc.createRoot( 'main' );
 
-			expect( getRoot ).to.equal( newRoot );
+			expect( doc.getRoot() ).to.equal( newRoot );
 		} );
 
-		it( 'should throw an error when trying to get non-existent root', () => {
-			expect(
-				() => {
-					doc.getRoot( 'root' );
-				}
-			).to.throw( CKEditorError, /model-document-getRoot-root-not-exist/ );
+		it( 'should return a RootElement with custom name', () => {
+			const newRoot = doc.createRoot( 'custom', 'custom' );
+
+			expect( doc.getRoot( 'custom' ) ).to.equal( newRoot );
+		} );
+
+		it( 'should return null when trying to get non-existent root', () => {
+			expect( doc.getRoot( 'not-existing' ) ).to.null;
 		} );
 	} );
 

--- a/tests/model/document/document.js
+++ b/tests/model/document/document.js
@@ -179,18 +179,6 @@ describe( 'Document', () => {
 		} );
 	} );
 
-	describe( 'hasRoot()', () => {
-		it( 'should return true when Document has RootElement with given name', () => {
-			doc.createRoot();
-
-			expect( doc.hasRoot( 'main' ) ).to.be.true;
-		} );
-
-		it( 'should return false when Document does not have RootElement with given name', () => {
-			expect( doc.hasRoot( 'noroot' ) ).to.be.false;
-		} );
-	} );
-
 	describe( 'selection', () => {
 		it( 'should get updated attributes whenever attribute operation is applied', () => {
 			sinon.spy( doc.selection, '_updateAttributes' );

--- a/tests/model/document/document.js
+++ b/tests/model/document/document.js
@@ -9,6 +9,7 @@ import RootElement from '../../../src/model/rootelement';
 import Batch from '../../../src/model/batch';
 import Delta from '../../../src/model/delta/delta';
 import Range from '../../../src/model/range';
+import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import count from '@ckeditor/ckeditor5-utils/src/count';
 import { jsonParseStringify } from '../../../tests/model/_utils/utils';
@@ -31,8 +32,8 @@ describe( 'Document', () => {
 			const doc = new Document( model );
 
 			expect( doc ).to.have.property( 'model' ).to.equal( model );
-			expect( doc ).to.have.property( 'roots' ).that.is.instanceof( Map );
-			expect( doc.roots.size ).to.equal( 1 );
+			expect( doc ).to.have.property( 'roots' ).that.is.instanceof( Collection );
+			expect( doc.roots.length ).to.equal( 1 );
 			expect( doc.graveyard ).to.be.instanceof( RootElement );
 			expect( doc.graveyard.maxOffset ).to.equal( 0 );
 			expect( count( doc.selection.getRanges() ) ).to.equal( 1 );
@@ -133,7 +134,7 @@ describe( 'Document', () => {
 		it( 'should create a new RootElement with default element and root names, add it to roots map and return it', () => {
 			const root = doc.createRoot();
 
-			expect( doc.roots.size ).to.equal( 2 );
+			expect( doc.roots.length ).to.equal( 2 );
 			expect( root ).to.be.instanceof( RootElement );
 			expect( root.maxOffset ).to.equal( 0 );
 			expect( root ).to.have.property( 'name', '$root' );
@@ -143,7 +144,7 @@ describe( 'Document', () => {
 		it( 'should create a new RootElement with custom element and root names, add it to roots map and return it', () => {
 			const root = doc.createRoot( 'customElementName', 'customRootName' );
 
-			expect( doc.roots.size ).to.equal( 2 );
+			expect( doc.roots.length ).to.equal( 2 );
 			expect( root ).to.be.instanceof( RootElement );
 			expect( root.maxOffset ).to.equal( 0 );
 			expect( root ).to.have.property( 'name', 'customElementName' );

--- a/tests/model/document/document.js
+++ b/tests/model/document/document.js
@@ -487,6 +487,33 @@ describe( 'Document', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy selection instance', () => {
+			const spy = sinon.spy( doc.selection, 'destroy' );
+
+			doc.destroy();
+
+			sinon.assert.calledOnce( spy );
+		} );
+
+		it( 'should stop listening to events', () => {
+			const spy = sinon.spy();
+
+			doc.listenTo( model, 'something', spy );
+
+			model.fire( 'something' );
+
+			sinon.assert.calledOnce( spy );
+
+			doc.destroy();
+
+			model.fire( 'something' );
+
+			// Still once.
+			sinon.assert.calledOnce( spy );
+		} );
+	} );
+
 	it( 'should be correctly converted to json', () => {
 		const serialized = jsonParseStringify( doc );
 

--- a/tests/view/_utils/createroot.js
+++ b/tests/view/_utils/createroot.js
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import RootEditableElement from '../../../src/view/rooteditableelement';
+
+/**
+ * Creates view root element and sets it to {@link module:engine/view/document~Document#roots roots collection}.
+ *
+ * @param {module:engine/view/document~Document} doc View document.
+ * @param {String} name Root element name.
+ * @param {String} rootName Root name.
+ * @returns {module:engine/view/rooteditableelement~RootEditableElement} Root element.
+ */
+export default function createRoot( doc, name = 'div', rootName = 'main' ) {
+	const root = new RootEditableElement( name );
+
+	root.document = doc;
+	root.rootName = rootName;
+	doc.roots.add( root );
+
+	return root;
+}

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -160,6 +160,10 @@ describe( 'Document', () => {
 
 			expect( viewDocument.getRoot( 'header' ) ).to.equal( viewDocument.roots.get( 'header' ) );
 		} );
+
+		it( 'should return null when trying to get non-existent root', () => {
+			expect( viewDocument.getRoot( 'not-existing' ) ).to.null;
+		} );
 	} );
 
 	describe( 'addObserver()', () => {

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -5,7 +5,6 @@
 
 /* globals document */
 
-import RootEditableElement from '../../../src/view/rooteditableelement';
 import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
 import Document from '../../../src/view/document';
 import Observer from '../../../src/view/observer/observer';
@@ -21,6 +20,7 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import count from '@ckeditor/ckeditor5-utils/src/count';
 import log from '@ckeditor/ckeditor5-utils/src/log';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
+import createViewRoot from '../_utils/createroot';
 
 testUtils.createSinonSandbox();
 
@@ -92,7 +92,7 @@ describe( 'Document', () => {
 	describe( 'attachDomRoot()', () => {
 		it( 'should attach DOM element to main view element', () => {
 			const domDiv = document.createElement( 'div' );
-			const viewRoot = createRoot( 'div', 'main', viewDocument );
+			const viewRoot = createViewRoot( viewDocument, 'div', 'main' );
 
 			expect( count( viewDocument.domRoots ) ).to.equal( 0 );
 
@@ -108,7 +108,7 @@ describe( 'Document', () => {
 
 		it( 'should attach DOM element to custom view element', () => {
 			const domH1 = document.createElement( 'h1' );
-			const viewH1 = createRoot( 'h1', 'header', viewDocument );
+			const viewH1 = createViewRoot( viewDocument, 'h1', 'header' );
 
 			expect( count( viewDocument.domRoots ) ).to.equal( 0 );
 
@@ -136,7 +136,7 @@ describe( 'Document', () => {
 			const observerMock = viewDocument.addObserver( ObserverMock );
 			const observerMockGlobalCount = viewDocument.addObserver( ObserverMockGlobalCount );
 
-			createRoot( 'div', 'root1', viewDocument );
+			createViewRoot( viewDocument, 'div', 'root1' );
 			viewDocument.attachDomRoot( document.createElement( 'div' ), 'root1' );
 
 			sinon.assert.calledOnce( observerMock.observe );
@@ -146,7 +146,7 @@ describe( 'Document', () => {
 
 	describe( 'getRoot()', () => {
 		it( 'should return "main" root', () => {
-			createRoot( 'div', 'main', viewDocument );
+			createViewRoot( viewDocument, 'div', 'main' );
 
 			expect( count( viewDocument.roots ) ).to.equal( 1 );
 
@@ -154,7 +154,7 @@ describe( 'Document', () => {
 		} );
 
 		it( 'should return named root', () => {
-			createRoot( 'h1', 'header', viewDocument );
+			createViewRoot( viewDocument, 'h1', 'header' );
 
 			expect( count( viewDocument.roots ) ).to.equal( 1 );
 
@@ -229,8 +229,8 @@ describe( 'Document', () => {
 		} );
 
 		it( 'should call observe on each root', () => {
-			createRoot( 'div', 'roo1', viewDocument );
-			createRoot( 'div', 'roo2', viewDocument );
+			createViewRoot( viewDocument, 'div', 'roo1' );
+			createViewRoot( viewDocument, 'div', 'roo2' );
 
 			viewDocument.attachDomRoot( document.createElement( 'div' ), 'roo1' );
 			viewDocument.attachDomRoot( document.createElement( 'div' ), 'roo2' );
@@ -271,7 +271,7 @@ describe( 'Document', () => {
 		} );
 
 		it( 'scrolls to the first range in selection with an offset', () => {
-			const root = createRoot( 'div', 'main', viewDocument );
+			const root = createViewRoot( viewDocument, 'div', 'main' );
 			const stub = testUtils.sinon.stub( global.window, 'scrollTo' );
 			const range = ViewRange.createIn( root );
 
@@ -340,7 +340,7 @@ describe( 'Document', () => {
 			domEditable = document.createElement( 'div' );
 			domEditable.setAttribute( 'contenteditable', 'true' );
 			document.body.appendChild( domEditable );
-			viewEditable = createRoot( 'div', 'main', viewDocument );
+			viewEditable = createViewRoot( viewDocument, 'div', 'main' );
 			viewDocument.attachDomRoot( domEditable );
 			viewDocument.selection.addRange( ViewRange.createFromParentsAndOffsets( viewEditable, 0, viewEditable, 0 ) );
 		} );
@@ -408,13 +408,3 @@ describe( 'Document', () => {
 		} );
 	} );
 } );
-
-function createRoot( name, rootName, viewDoc ) {
-	const viewRoot = new RootEditableElement( name );
-
-	viewRoot.rootName = rootName;
-	viewRoot.document = viewDoc;
-	viewDoc.roots.add( viewRoot );
-
-	return viewRoot;
-}

--- a/tests/view/document/document.js
+++ b/tests/view/document/document.js
@@ -5,6 +5,7 @@
 
 /* globals document */
 
+import RootEditableElement from '../../../src/view/rooteditableelement';
 import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
 import Document from '../../../src/view/document';
 import Observer from '../../../src/view/observer/observer';
@@ -88,27 +89,35 @@ describe( 'Document', () => {
 		} );
 	} );
 
-	describe( 'createRoot()', () => {
-		it( 'should create root', () => {
-			const domP = document.createElement( 'p' );
+	describe( 'attachDomRoot()', () => {
+		it( 'should attach DOM element to main view element', () => {
 			const domDiv = document.createElement( 'div' );
-			domDiv.appendChild( domP );
+			const viewRoot = createRoot( 'div', 'main', viewDocument );
 
-			const ret = viewDocument.createRoot( domDiv );
+			expect( count( viewDocument.domRoots ) ).to.equal( 0 );
+
+			viewDocument.attachDomRoot( domDiv );
 
 			expect( count( viewDocument.domRoots ) ).to.equal( 1 );
-			expect( count( viewDocument.roots ) ).to.equal( 1 );
 
-			const domRoot = viewDocument.getDomRoot();
-			const viewRoot = viewDocument.getRoot();
-
-			expect( ret ).to.equal( viewRoot );
-
-			expect( domRoot ).to.equal( domDiv );
+			expect( viewDocument.getDomRoot() ).to.equal( domDiv );
 			expect( viewDocument.domConverter.mapViewToDom( viewRoot ) ).to.equal( domDiv );
 
-			expect( viewRoot.name ).to.equal( 'div' );
 			expect( viewDocument.renderer.markedChildren.has( viewRoot ) ).to.be.true;
+		} );
+
+		it( 'should attach DOM element to custom view element', () => {
+			const domH1 = document.createElement( 'h1' );
+			const viewH1 = createRoot( 'h1', 'header', viewDocument );
+
+			expect( count( viewDocument.domRoots ) ).to.equal( 0 );
+
+			viewDocument.attachDomRoot( domH1, 'header' );
+
+			expect( count( viewDocument.domRoots ) ).to.equal( 1 );
+			expect( viewDocument.getDomRoot( 'header' ) ).to.equal( domH1 );
+			expect( viewDocument.domConverter.mapViewToDom( viewH1 ) ).to.equal( domH1 );
+			expect( viewDocument.renderer.markedChildren.has( viewH1 ) ).to.be.true;
 		} );
 
 		it( 'should call observe on each observer', () => {
@@ -127,96 +136,17 @@ describe( 'Document', () => {
 			const observerMock = viewDocument.addObserver( ObserverMock );
 			const observerMockGlobalCount = viewDocument.addObserver( ObserverMockGlobalCount );
 
-			viewDocument.createRoot( document.createElement( 'div' ), 'root1' );
+			createRoot( 'div', 'root1', viewDocument );
+			viewDocument.attachDomRoot( document.createElement( 'div' ), 'root1' );
 
 			sinon.assert.calledOnce( observerMock.observe );
 			sinon.assert.calledOnce( observerMockGlobalCount.observe );
-		} );
-
-		it( 'should create "main" root by default', () => {
-			const domDiv = document.createElement( 'div' );
-			const ret = viewDocument.createRoot( domDiv );
-
-			expect( count( viewDocument.domRoots ) ).to.equal( 1 );
-			expect( count( viewDocument.roots ) ).to.equal( 1 );
-
-			const domRoot = viewDocument.domRoots.get( 'main' );
-			const viewRoot = viewDocument.roots.get( 'main' );
-
-			expect( ret ).to.equal( viewRoot );
-
-			expect( domRoot ).to.equal( domDiv );
-		} );
-
-		it( 'should create root with given name', () => {
-			const domDiv = document.createElement( 'div' );
-			const ret = viewDocument.createRoot( domDiv, 'header' );
-
-			expect( count( viewDocument.domRoots ) ).to.equal( 1 );
-			expect( count( viewDocument.roots ) ).to.equal( 1 );
-
-			const domRoot = viewDocument.domRoots.get( 'header' );
-			const viewRoot = viewDocument.roots.get( 'header' );
-
-			expect( ret ).to.equal( viewRoot );
-
-			expect( domRoot ).to.equal( domDiv );
-		} );
-
-		it( 'should create root without attaching DOM element', () => {
-			const ret = viewDocument.createRoot( 'div' );
-
-			expect( count( viewDocument.domRoots ) ).to.equal( 0 );
-			expect( count( viewDocument.roots ) ).to.equal( 1 );
-			expect( ret ).to.equal( viewDocument.getRoot() );
-		} );
-	} );
-
-	describe( 'attachDomRoot()', () => {
-		it( 'should create root without attach DOM element to the view element', () => {
-			const domDiv = document.createElement( 'div' );
-			const viewRoot = viewDocument.createRoot( 'div' );
-
-			expect( count( viewDocument.domRoots ) ).to.equal( 0 );
-			expect( count( viewDocument.roots ) ).to.equal( 1 );
-			expect( viewRoot ).to.equal( viewDocument.getRoot() );
-
-			viewDocument.attachDomRoot( domDiv );
-
-			expect( count( viewDocument.domRoots ) ).to.equal( 1 );
-			expect( count( viewDocument.roots ) ).to.equal( 1 );
-
-			expect( viewDocument.getDomRoot() ).to.equal( domDiv );
-			expect( viewDocument.domConverter.mapViewToDom( viewRoot ) ).to.equal( domDiv );
-
-			expect( viewDocument.renderer.markedChildren.has( viewRoot ) ).to.be.true;
-		} );
-
-		it( 'should create root without attach DOM element to the view element with given name', () => {
-			const domH1 = document.createElement( 'h1' );
-			viewDocument.createRoot( 'DIV' );
-			const viewH1 = viewDocument.createRoot( 'h1', 'header' );
-
-			expect( count( viewDocument.domRoots ) ).to.equal( 0 );
-			expect( count( viewDocument.roots ) ).to.equal( 2 );
-			expect( viewH1 ).to.equal( viewDocument.getRoot( 'header' ) );
-
-			viewDocument.attachDomRoot( domH1, 'header' );
-
-			expect( count( viewDocument.domRoots ) ).to.equal( 1 );
-			expect( count( viewDocument.roots ) ).to.equal( 2 );
-
-			expect( viewDocument.getDomRoot( 'header' ) ).to.equal( domH1 );
-			expect( viewDocument.domConverter.mapViewToDom( viewH1 ) ).to.equal( domH1 );
-
-			expect( viewDocument.getRoot().name ).to.equal( 'div' );
-			expect( viewDocument.renderer.markedChildren.has( viewH1 ) ).to.be.true;
 		} );
 	} );
 
 	describe( 'getRoot()', () => {
 		it( 'should return "main" root', () => {
-			viewDocument.createRoot( document.createElement( 'div' ) );
+			createRoot( 'div', 'main', viewDocument );
 
 			expect( count( viewDocument.roots ) ).to.equal( 1 );
 
@@ -224,7 +154,7 @@ describe( 'Document', () => {
 		} );
 
 		it( 'should return named root', () => {
-			viewDocument.createRoot( document.createElement( 'h1' ), 'header' );
+			createRoot( 'h1', 'header', viewDocument );
 
 			expect( count( viewDocument.roots ) ).to.equal( 1 );
 
@@ -299,8 +229,11 @@ describe( 'Document', () => {
 		} );
 
 		it( 'should call observe on each root', () => {
-			viewDocument.createRoot( document.createElement( 'div' ), 'root1' );
-			viewDocument.createRoot( document.createElement( 'div' ), 'root2' );
+			createRoot( 'div', 'roo1', viewDocument );
+			createRoot( 'div', 'roo2', viewDocument );
+
+			viewDocument.attachDomRoot( document.createElement( 'div' ), 'roo1' );
+			viewDocument.attachDomRoot( document.createElement( 'div' ), 'roo2' );
 
 			const observerMock = viewDocument.addObserver( ObserverMock );
 
@@ -338,9 +271,11 @@ describe( 'Document', () => {
 		} );
 
 		it( 'scrolls to the first range in selection with an offset', () => {
+			const root = createRoot( 'div', 'main', viewDocument );
 			const stub = testUtils.sinon.stub( global.window, 'scrollTo' );
-			const root = viewDocument.createRoot( domRoot );
 			const range = ViewRange.createIn( root );
+
+			viewDocument.attachDomRoot( domRoot );
 
 			// Make sure the window will have to scroll to the domRoot.
 			Object.assign( domRoot.style, {
@@ -405,7 +340,8 @@ describe( 'Document', () => {
 			domEditable = document.createElement( 'div' );
 			domEditable.setAttribute( 'contenteditable', 'true' );
 			document.body.appendChild( domEditable );
-			viewEditable = viewDocument.createRoot( domEditable );
+			viewEditable = createRoot( 'div', 'main', viewDocument );
+			viewDocument.attachDomRoot( domEditable );
 			viewDocument.selection.addRange( ViewRange.createFromParentsAndOffsets( viewEditable, 0, viewEditable, 0 ) );
 		} );
 
@@ -472,3 +408,13 @@ describe( 'Document', () => {
 		} );
 	} );
 } );
+
+function createRoot( name, rootName, viewDoc ) {
+	const viewRoot = new RootEditableElement( name );
+
+	viewRoot.rootName = rootName;
+	viewRoot.document = viewDoc;
+	viewDoc.roots.add( viewRoot );
+
+	return viewRoot;
+}

--- a/tests/view/document/integration.js
+++ b/tests/view/document/integration.js
@@ -5,6 +5,7 @@
 
 /* globals document */
 
+import RootEditableElement from '../../../src/view/rooteditableelement';
 import Document from '../../../src/view/document';
 import ViewElement from '../../../src/view/element';
 import { isBlockFiller, BR_FILLER } from '../../../src/view/filler';
@@ -19,7 +20,9 @@ describe( 'Document integration', () => {
 		] );
 
 		const viewDocument = new Document();
-		viewDocument.createRoot( domDiv );
+
+		createRoot( 'div', 'main', viewDocument );
+		viewDocument.attachDomRoot( domDiv );
 		viewDocument.render();
 
 		expect( domDiv.childNodes.length ).to.equal( 1 );
@@ -32,7 +35,8 @@ describe( 'Document integration', () => {
 		const domDiv = document.createElement( 'div' );
 
 		const viewDocument = new Document();
-		viewDocument.createRoot( domDiv );
+		createRoot( 'div', 'main', viewDocument );
+		viewDocument.attachDomRoot( domDiv );
 
 		viewDocument.getRoot().appendChildren( new ViewElement( 'p' ) );
 		viewDocument.render();
@@ -47,7 +51,9 @@ describe( 'Document integration', () => {
 		const domRoot = document.createElement( 'div' );
 
 		const viewDocument = new Document();
-		const viewRoot = viewDocument.createRoot( domRoot );
+		const viewRoot = createRoot( 'div', 'main', viewDocument );
+
+		viewDocument.attachDomRoot( domRoot );
 
 		const viewP = new ViewElement( 'p', { class: 'foo' } );
 		viewRoot.appendChildren( viewP );
@@ -65,3 +71,13 @@ describe( 'Document integration', () => {
 		viewDocument.destroy();
 	} );
 } );
+
+function createRoot( name, rootName, viewDoc ) {
+	const viewRoot = new RootEditableElement( name );
+
+	viewRoot.rootName = rootName;
+	viewRoot.document = viewDoc;
+	viewDoc.roots.add( viewRoot );
+
+	return viewRoot;
+}

--- a/tests/view/document/jumpoverinlinefiller.js
+++ b/tests/view/document/jumpoverinlinefiller.js
@@ -5,11 +5,11 @@
 
 /* globals document */
 
-import RootEditableElement from '../../../src/view/rooteditableelement';
 import ViewRange from '../../../src/view/range';
 import ViewDocument from '../../../src/view/document';
 import { INLINE_FILLER_LENGTH, isInlineFiller, startsWithFiller } from '../../../src/view/filler';
 
+import createViewRoot from '../_utils/createroot';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
 
@@ -25,7 +25,7 @@ describe( 'Document', () => {
 		document.body.appendChild( domRoot );
 
 		viewDocument = new ViewDocument();
-		createRoot( 'div', 'main', viewDocument );
+		createViewRoot( viewDocument );
 		viewDocument.attachDomRoot( domRoot );
 
 		document.getSelection().removeAllRanges();
@@ -135,13 +135,3 @@ describe( 'Document', () => {
 		} );
 	} );
 } );
-
-function createRoot( name, rootName, viewDoc ) {
-	const viewRoot = new RootEditableElement( name );
-
-	viewRoot.rootName = rootName;
-	viewRoot.document = viewDoc;
-	viewDoc.roots.add( viewRoot );
-
-	return viewRoot;
-}

--- a/tests/view/document/jumpoverinlinefiller.js
+++ b/tests/view/document/jumpoverinlinefiller.js
@@ -5,6 +5,7 @@
 
 /* globals document */
 
+import RootEditableElement from '../../../src/view/rooteditableelement';
 import ViewRange from '../../../src/view/range';
 import ViewDocument from '../../../src/view/document';
 import { INLINE_FILLER_LENGTH, isInlineFiller, startsWithFiller } from '../../../src/view/filler';
@@ -24,7 +25,8 @@ describe( 'Document', () => {
 		document.body.appendChild( domRoot );
 
 		viewDocument = new ViewDocument();
-		viewDocument.createRoot( domRoot );
+		createRoot( 'div', 'main', viewDocument );
+		viewDocument.attachDomRoot( domRoot );
 
 		document.getSelection().removeAllRanges();
 
@@ -133,3 +135,13 @@ describe( 'Document', () => {
 		} );
 	} );
 } );
+
+function createRoot( name, rootName, viewDoc ) {
+	const viewRoot = new RootEditableElement( name );
+
+	viewRoot.rootName = rootName;
+	viewRoot.document = viewDoc;
+	viewDoc.roots.add( viewRoot );
+
+	return viewRoot;
+}

--- a/tests/view/document/jumpoveruielement.js
+++ b/tests/view/document/jumpoveruielement.js
@@ -7,13 +7,13 @@
 
 import ViewDocument from '../../../src/view/document';
 import UIElement from '../../../src/view/uielement';
-import RootEditableElement from '../../../src/view/rooteditableelement';
 import ViewContainerElement from '../../../src/view/containerelement';
 import ViewAttribtueElement from '../../../src/view/attributeelement';
 import ViewText from '../../../src/view/text';
 import ViewRange from '../../../src/view/range';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
+import createViewRoot from '../_utils/createroot';
 import { setData as setViewData } from '../../../src/dev-utils/view';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
@@ -36,7 +36,7 @@ describe( 'Document', () => {
 		document.body.appendChild( domRoot );
 
 		viewDocument = new ViewDocument();
-		viewRoot = createRoot( 'div', 'main', viewDocument );
+		viewRoot = createViewRoot( viewDocument );
 		viewDocument.attachDomRoot( domRoot );
 
 		domSelection = document.getSelection();
@@ -80,16 +80,6 @@ describe( 'Document', () => {
 		} else {
 			expect( domSelection.isCollapsed, 'isCollapsed' ).to.be.true;
 		}
-	}
-
-	function createRoot( name, rootName, viewDoc ) {
-		const viewRoot = new RootEditableElement( name );
-
-		viewRoot.rootName = rootName;
-		viewRoot.document = viewDoc;
-		viewDoc.roots.add( viewRoot );
-
-		return viewRoot;
 	}
 
 	describe( 'jump over ui element handler', () => {

--- a/tests/view/document/jumpoveruielement.js
+++ b/tests/view/document/jumpoveruielement.js
@@ -7,6 +7,7 @@
 
 import ViewDocument from '../../../src/view/document';
 import UIElement from '../../../src/view/uielement';
+import RootEditableElement from '../../../src/view/rooteditableelement';
 import ViewContainerElement from '../../../src/view/containerelement';
 import ViewAttribtueElement from '../../../src/view/attributeelement';
 import ViewText from '../../../src/view/text';
@@ -35,7 +36,8 @@ describe( 'Document', () => {
 		document.body.appendChild( domRoot );
 
 		viewDocument = new ViewDocument();
-		viewRoot = viewDocument.createRoot( domRoot );
+		viewRoot = createRoot( 'div', 'main', viewDocument );
+		viewDocument.attachDomRoot( domRoot );
 
 		domSelection = document.getSelection();
 		domSelection.removeAllRanges();
@@ -78,6 +80,16 @@ describe( 'Document', () => {
 		} else {
 			expect( domSelection.isCollapsed, 'isCollapsed' ).to.be.true;
 		}
+	}
+
+	function createRoot( name, rootName, viewDoc ) {
+		const viewRoot = new RootEditableElement( name );
+
+		viewRoot.rootName = rootName;
+		viewRoot.document = viewDoc;
+		viewDoc.roots.add( viewRoot );
+
+		return viewRoot;
 	}
 
 	describe( 'jump over ui element handler', () => {

--- a/tests/view/manual/clickobserver.js
+++ b/tests/view/manual/clickobserver.js
@@ -7,6 +7,7 @@
 
 import Document from '../../../src/view/document';
 import DomEventObserver from '../../../src/view/observer/domeventobserver';
+import createViewRoot from '../_utils/createroot';
 
 const viewDocument = new Document();
 
@@ -45,8 +46,10 @@ document.getElementById( 'disable1' ).addEventListener( 'click', () => observer1
 // Random order.
 viewDocument.addObserver( ClickObserver1 );
 
-viewDocument.createRoot( document.getElementById( 'clickerA' ), 'clickerA' );
+createViewRoot( viewDocument, 'div', 'clickerA' );
+viewDocument.attachDomRoot( document.getElementById( 'clickerA' ), 'clickerA' );
 
 viewDocument.addObserver( ClickObserver2 );
 
-viewDocument.createRoot( document.getElementById( 'clickerB' ), 'clickerB' );
+createViewRoot( viewDocument, 'div', 'clickerB' );
+viewDocument.attachDomRoot( document.getElementById( 'clickerB' ), 'clickerB' );

--- a/tests/view/manual/fakeselection.js
+++ b/tests/view/manual/fakeselection.js
@@ -8,12 +8,15 @@
 import ViewDocument from '../../../src/view/document';
 import DomEventObserver from '../../../src/view/observer/domeventobserver';
 import ViewRange from '../../../src/view/range';
+import createViewRoot from '../_utils/createroot';
 import { setData } from '../../../src/dev-utils/view';
 
 const viewDocument = new ViewDocument();
 const domEditable = document.getElementById( 'editor' );
-const viewRoot = viewDocument.createRoot( domEditable );
+const viewRoot = createViewRoot();
 let viewStrong;
+
+viewDocument.attachDomRoot( domEditable );
 
 // Add mouseup oberver.
 viewDocument.addObserver( class extends DomEventObserver {

--- a/tests/view/observer/domeventobserver.js
+++ b/tests/view/observer/domeventobserver.js
@@ -9,6 +9,7 @@ import DomEventObserver from '../../../src/view/observer/domeventobserver';
 import Observer from '../../../src/view/observer/observer';
 import ViewDocument from '../../../src/view/document';
 import UIElement from '../../../src/view/uielement';
+import createViewRoot from '../_utils/createroot';
 
 class ClickObserver extends DomEventObserver {
 	constructor( document ) {
@@ -66,7 +67,8 @@ describe( 'DomEventObserver', () => {
 		const domEvent = new MouseEvent( 'click' );
 		const evtSpy = sinon.spy();
 
-		viewDocument.createRoot( domElement, 'root' );
+		createViewRoot( viewDocument );
+		viewDocument.attachDomRoot( domElement );
 		viewDocument.addObserver( ClickObserver );
 		viewDocument.on( 'click', evtSpy );
 
@@ -88,7 +90,8 @@ describe( 'DomEventObserver', () => {
 		const evtSpy1 = sinon.spy();
 		const evtSpy2 = sinon.spy();
 
-		viewDocument.createRoot( domElement, 'root' );
+		createViewRoot( viewDocument );
+		viewDocument.attachDomRoot( domElement );
 		viewDocument.addObserver( MultiObserver );
 		viewDocument.on( 'evt1', evtSpy1 );
 		viewDocument.on( 'evt2', evtSpy2 );
@@ -105,7 +108,8 @@ describe( 'DomEventObserver', () => {
 		const domEvent = new MouseEvent( 'click' );
 		const evtSpy = sinon.spy();
 
-		viewDocument.createRoot( domElement, 'root' );
+		createViewRoot( viewDocument );
+		viewDocument.attachDomRoot( domElement );
 		const testObserver = viewDocument.addObserver( ClickObserver );
 		viewDocument.on( 'click', evtSpy );
 
@@ -121,7 +125,8 @@ describe( 'DomEventObserver', () => {
 		const domEvent = new MouseEvent( 'click' );
 		const evtSpy = sinon.spy();
 
-		viewDocument.createRoot( domElement, 'root' );
+		createViewRoot( viewDocument );
+		viewDocument.attachDomRoot( domElement );
 		const testObserver = viewDocument.addObserver( ClickObserver );
 		viewDocument.on( 'click', evtSpy );
 
@@ -143,7 +148,8 @@ describe( 'DomEventObserver', () => {
 		const childDomElement = document.createElement( 'p' );
 		const domEvent = new MouseEvent( 'click' );
 		domElement.appendChild( childDomElement );
-		viewDocument.createRoot( domElement, 'root' );
+		createViewRoot( viewDocument );
+		viewDocument.attachDomRoot( domElement );
 		viewDocument.addObserver( ClickCapturingObserver );
 
 		viewDocument.on( 'click', ( evt, domEventData ) => {
@@ -168,7 +174,8 @@ describe( 'DomEventObserver', () => {
 
 		beforeEach( () => {
 			domRoot = document.createElement( 'div' );
-			const viewRoot = viewDocument.createRoot( domRoot, 'root' );
+			const viewRoot = createViewRoot( viewDocument );
+			viewDocument.attachDomRoot( domRoot );
 			uiElement = new MyUIElement( 'p' );
 			viewRoot.appendChildren( uiElement );
 			viewDocument.render();

--- a/tests/view/observer/fakeselectionobserver.js
+++ b/tests/view/observer/fakeselectionobserver.js
@@ -9,6 +9,7 @@ import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
 import FakeSelectionObserver from '../../../src/view/observer/fakeselectionobserver';
 import ViewDocument from '../../../src/view/document';
 import DomEventData from '../../../src/view/observer/domeventdata';
+import createViewRoot from '../_utils/createroot';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import { setData, stringify } from '../../../src/dev-utils/view';
 
@@ -28,7 +29,8 @@ describe( 'FakeSelectionObserver', () => {
 
 	beforeEach( () => {
 		viewDocument = new ViewDocument();
-		root = viewDocument.createRoot( domRoot );
+		root = createViewRoot( viewDocument );
+		viewDocument.attachDomRoot( domRoot );
 		observer = viewDocument.getObserver( FakeSelectionObserver );
 		viewDocument.selection.setFake();
 	} );

--- a/tests/view/observer/focusobserver.js
+++ b/tests/view/observer/focusobserver.js
@@ -7,6 +7,7 @@
 import FocusObserver from '../../../src/view/observer/focusobserver';
 import ViewDocument from '../../../src/view/document';
 import ViewRange from '../../../src/view/range';
+import createViewRoot from '../_utils/createroot';
 import { setData } from '../../../src/dev-utils/view';
 
 describe( 'FocusObserver', () => {
@@ -72,7 +73,8 @@ describe( 'FocusObserver', () => {
 			domMain = document.createElement( 'div' );
 			domHeader = document.createElement( 'h1' );
 
-			viewMain = viewDocument.createRoot( domMain );
+			viewMain = createViewRoot( viewDocument );
+			viewDocument.attachDomRoot( domMain );
 		} );
 
 		it( 'should set isFocused to true on focus', () => {
@@ -149,7 +151,8 @@ describe( 'FocusObserver', () => {
 			document.body.appendChild( domRoot );
 
 			viewDocument = new ViewDocument();
-			viewDocument.createRoot( domRoot );
+			createViewRoot( viewDocument );
+			viewDocument.attachDomRoot( domRoot );
 
 			observer = viewDocument.getObserver( FocusObserver );
 		} );

--- a/tests/view/observer/mutationobserver.js
+++ b/tests/view/observer/mutationobserver.js
@@ -8,6 +8,7 @@
 import ViewDocument from '../../../src/view/document';
 import MutationObserver from '../../../src/view/observer/mutationobserver';
 import UIElement from '../../../src/view/uielement';
+import createViewRoot from '../_utils/createroot';
 import { parse } from '../../../src/dev-utils/view';
 
 describe( 'MutationObserver', () => {
@@ -22,7 +23,8 @@ describe( 'MutationObserver', () => {
 		domEditor = document.getElementById( 'main' );
 		lastMutations = null;
 
-		viewDocument.createRoot( domEditor );
+		createViewRoot( viewDocument );
+		viewDocument.attachDomRoot( domEditor );
 		viewDocument.selection.removeAllRanges();
 		document.getSelection().removeAllRanges();
 
@@ -62,7 +64,8 @@ describe( 'MutationObserver', () => {
 	it( 'should not observe if disabled', () => {
 		const additional = document.getElementById( 'additional' );
 		mutationObserver.disable();
-		viewDocument.createRoot( additional, 'additional' );
+		createViewRoot( viewDocument, 'div', 'additional' );
+		viewDocument.attachDomRoot( additional, 'additional' );
 
 		additional.textContent = 'foobar';
 		mutationObserver.flush();
@@ -196,7 +199,8 @@ describe( 'MutationObserver', () => {
 		const domAdditionalEditor = document.getElementById( 'additional' );
 
 		// Prepare AdditionalEditor
-		viewDocument.createRoot( domAdditionalEditor, 'additional' );
+		createViewRoot( viewDocument, 'div', 'additional' );
+		viewDocument.attachDomRoot( domAdditionalEditor, 'additional' );
 
 		viewDocument.getRoot( 'additional' ).appendChildren(
 			parse( '<container:p>foo</container:p><container:p>bar</container:p>' ) );

--- a/tests/view/observer/selectionobserver.js
+++ b/tests/view/observer/selectionobserver.js
@@ -12,6 +12,7 @@ import ViewDocument from '../../../src/view/document';
 import SelectionObserver from '../../../src/view/observer/selectionobserver';
 import FocusObserver from '../../../src/view/observer/focusobserver';
 import log from '@ckeditor/ckeditor5-utils/src/log';
+import createViewRoot from '../_utils/createroot';
 import { parse } from '../../../src/dev-utils/view';
 
 testUtils.createSinonSandbox();
@@ -27,7 +28,8 @@ describe( 'SelectionObserver', () => {
 		domDocument.body.appendChild( domRoot );
 
 		viewDocument = new ViewDocument();
-		viewDocument.createRoot( domMain );
+		createViewRoot( viewDocument );
+		viewDocument.attachDomRoot( domMain );
 
 		selectionObserver = viewDocument.getObserver( SelectionObserver );
 
@@ -83,7 +85,8 @@ describe( 'SelectionObserver', () => {
 
 	it( 'should add only one listener to one document', done => {
 		// Add second roots to ensure that listener is added once.
-		viewDocument.createRoot( domDocument.getElementById( 'additional' ), 'additional' );
+		createViewRoot( viewDocument, 'div', 'additional' );
+		viewDocument.attachDomRoot( domDocument.getElementById( 'additional' ), 'additional' );
 
 		viewDocument.on( 'selectionChange', () => {
 			done();

--- a/tests/view/placeholder.js
+++ b/tests/view/placeholder.js
@@ -4,6 +4,7 @@
  */
 
 import { attachPlaceholder, detachPlaceholder } from '../../src/view/placeholder';
+import createViewRoot from './_utils/createroot';
 import ViewContainerElement from '../../src/view/containerelement';
 import ViewDocument from '../../src/view/document';
 import ViewRange from '../../src/view/range';
@@ -14,7 +15,7 @@ describe( 'placeholder', () => {
 
 	beforeEach( () => {
 		viewDocument = new ViewDocument();
-		viewRoot = viewDocument.createRoot( 'main' );
+		viewRoot = createViewRoot( viewDocument );
 		viewDocument.isFocused = true;
 	} );
 
@@ -131,7 +132,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 			const secondDocument = new ViewDocument();
 			secondDocument.isFocused = true;
-			const secondRoot = secondDocument.createRoot( 'main' );
+			const secondRoot = createViewRoot( secondDocument );
 			setData( secondDocument, '<div></div><div>{another div}</div>' );
 			const secondElement = secondRoot.getChild( 0 );
 

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -19,6 +19,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import { parse, setData as setViewData, getData as getViewData } from '../../src/dev-utils/view';
 import { INLINE_FILLER, INLINE_FILLER_LENGTH, isBlockFiller, BR_FILLER } from '../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+import createViewRoot from './_utils/createroot';
 import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
 import { unwrap, insert, remove } from '../../src/view/writer';
 import normalizeHtml from '@ckeditor/ckeditor5-utils/tests/_utils/normalizehtml';
@@ -1880,7 +1881,8 @@ describe( 'Renderer', () => {
 			viewDoc = new ViewDocument();
 			domRoot = document.createElement( 'div' );
 			document.body.appendChild( domRoot );
-			viewRoot = viewDoc.createRoot( domRoot );
+			viewRoot = createViewRoot( viewDoc );
+			viewDoc.attachDomRoot( domRoot );
 			converter = viewDoc.domConverter;
 		} );
 

--- a/tests/view/rooteditableelement.js
+++ b/tests/view/rooteditableelement.js
@@ -69,6 +69,18 @@ describe( 'RootEditableElement', () => {
 		} );
 	} );
 
+	describe( '_name', () => {
+		it( 'should set new name to element', () => {
+			const el = new RootEditableElement( '$root' );
+
+			expect( el.name ).to.equal( '$root' );
+
+			el._name = 'div';
+
+			expect( el.name ).to.equal( 'div' );
+		} );
+	} );
+
 	it( 'should be cloned properly', () => {
 		const root = new RootEditableElement( 'h1' );
 		root.document = createDocumentMock();

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -11,6 +11,7 @@ import Text from '../../src/view/text';
 import Position from '../../src/view/position';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import count from '@ckeditor/ckeditor5-utils/src/count';
+import createViewRoot from './_utils/createroot';
 import { parse } from '../../src/dev-utils/view';
 
 describe( 'Selection', () => {
@@ -878,7 +879,7 @@ describe( 'Selection', () => {
 		it( 'should return EditableElement when selection is placed inside', () => {
 			const viewDocument = new Document();
 			const selection = viewDocument.selection;
-			const root = viewDocument.createRoot( 'div' );
+			const root = createViewRoot( viewDocument, 'div', 'main' );
 			const element = new Element( 'p' );
 			root.appendChildren( element );
 

--- a/tests/view/treewalker.js
+++ b/tests/view/treewalker.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document */
-
 import Document from '../../src/view/document';
 import DocumentFragment from '../../src/view/documentfragment';
 import AttributeElement from '../../src/view/attributeelement';
@@ -13,6 +11,7 @@ import Text from '../../src/view/text';
 import TreeWalker from '../../src/view/treewalker';
 import Position from '../../src/view/position';
 import Range from '../../src/view/range';
+import createViewRoot from './_utils/createroot';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 describe( 'TreeWalker', () => {
@@ -20,7 +19,7 @@ describe( 'TreeWalker', () => {
 
 	before( () => {
 		doc = new Document();
-		root = doc.createRoot( document.createElement( 'div' ) );
+		root = createViewRoot( doc );
 
 		// root
 		//  |- img1

--- a/tests/view/utils-tests/createroot.js
+++ b/tests/view/utils-tests/createroot.js
@@ -1,0 +1,38 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import Document from '../../../src/view/document.js';
+import RootAttributeElement from '../../../src/view/rooteditableelement.js';
+import createRoot from '../_utils/createroot.js';
+
+describe( 'createRoot', () => {
+	let viewDoc;
+
+	beforeEach( () => {
+		viewDoc = new Document();
+	} );
+
+	it( 'should create view root element with given data', () => {
+		const root = createRoot( viewDoc, 'h1', 'header' );
+
+		expect( root ).to.instanceof( RootAttributeElement );
+		expect( root.name ).to.equal( 'h1' );
+		expect( root.rootName ).to.equal( 'header' );
+	} );
+
+	it( 'should create view root element with default data', () => {
+		const root = createRoot( viewDoc );
+
+		expect( root ).to.instanceof( RootAttributeElement );
+		expect( root.name ).to.equal( 'div' );
+		expect( root.rootName ).to.equal( 'main' );
+	} );
+
+	it( 'should insert root element to view document roots collection', () => {
+		const root = createRoot( viewDoc );
+
+		expect( viewDoc.getRoot() ).to.equal( root );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Bound collection of view roots to collection of model roots. Closes https://github.com/ckeditor/ckeditor5-core/issues/110.

BREAKING CHANGE: `view/Document#roots` and `model/Document#roots` now are `Collection` instances.
BREAKING CHANGE `view/Document#createRoot` is removed in favor of roots collections binding.
BREAKING CHANGE: `view/Model#hasRoot` is removed in favor of `view/Model#getRoot`.
BREAKING CHANGE: `EditingController#createRoot` is removed.

---

Part of: https://github.com/ckeditor/ckeditor5-core/pull/114