### PR TITLE
T/1239 Allowed passing true as view.Matcher's attribute match to check if that attribute is set

### DIFF
--- a/src/view/element.js
+++ b/src/view/element.js
@@ -329,6 +329,8 @@ export default class Element extends Node {
 	 * @fires module:engine/view/node~Node#change
 	 */
 	setAttribute( key, value ) {
+		value = String( value );
+
 		this._fireChange( 'attributes', this );
 
 		if ( key == 'class' ) {

--- a/src/view/matcher.js
+++ b/src/view/matcher.js
@@ -41,8 +41,9 @@ export default class Matcher {
 	 *
 	 *		matcher.add( {
 	 *			attribute: {
-	 *				title: 'foobar',
-	 *				foo: /^\w+/
+	 *				title: 'foobar',	// Attribute title should equal 'foobar'.
+	 *				foo: /^\w+/,		// Attribute foo should match /^\w+/ regexp.
+	 *				bar: true			// Attribute bar should be set (can be empty).
 	 *			}
 	 *		} );
 	 *
@@ -95,8 +96,10 @@ export default class Matcher {
 	 * {@link module:engine/view/matcher~Matcher#match match} or {@link module:engine/view/matcher~Matcher#matchAll matchAll} methods.
 	 * @param {String|RegExp} [pattern.name] Name or regular expression to match element's name.
 	 * @param {Object} [pattern.attribute] Object with key-value pairs representing attributes to match. Each object key
-	 * represents attribute name. Value under that key can be either a string or a regular expression and it will be
-	 * used to match attribute value.
+	 * represents attribute name. Value under that key can be either:
+	 * * `true` - then attribute is just required (can be empty),
+	 * * a string - then attribute has to be equal, or
+	 * * a regular expression - then attribute has to match the expression.
 	 * @param {String|RegExp|Array} [pattern.class] Class name or array of class names to match. Each name can be
 	 * provided in a form of string or regular expression.
 	 * @param {Object} [pattern.style] Object with key-value pairs representing styles to match. Each object key
@@ -295,7 +298,9 @@ function matchAttributes( patterns, element ) {
 		if ( element.hasAttribute( name ) ) {
 			const attribute = element.getAttribute( name );
 
-			if ( pattern instanceof RegExp ) {
+			if ( pattern === true ) {
+				match.push( name );
+			} else if ( pattern instanceof RegExp ) {
 				if ( pattern.test( attribute ) ) {
 					match.push( name );
 				} else {

--- a/tests/view/element.js
+++ b/tests/view/element.js
@@ -430,6 +430,12 @@ describe( 'Element', () => {
 				expect( el._attrs.get( 'foo' ) ).to.equal( 'bar' );
 			} );
 
+			it( 'should cast attribute value to a string', () => {
+				el.setAttribute( 'foo', true );
+
+				expect( el._attrs.get( 'foo' ) ).to.equal( 'true' );
+			} );
+
 			it( 'should fire change event with attributes type', done => {
 				el.once( 'change:attributes', eventInfo => {
 					expect( eventInfo.source ).to.equal( el );

--- a/tests/view/matcher.js
+++ b/tests/view/matcher.js
@@ -126,6 +126,34 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
+		it( 'should match if element has given attribute', () => {
+			const pattern = {
+				attribute: {
+					title: true
+				}
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( 'p', { title: 'foobar'	} );
+			const el2 = new Element( 'p', { title: '' } );
+			const el3 = new Element( 'p' );
+
+			let result = matcher.match( el1 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attribute' ).that.is.an( 'array' );
+			expect( result.match.attribute[ 0 ] ).equal( 'title' );
+
+			result = matcher.match( el2 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el2 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attribute' ).that.is.an( 'array' );
+			expect( result.match.attribute[ 0 ] ).equal( 'title' );
+
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
 		it( 'should match element class names', () => {
 			const pattern = { class: 'foobar' };
 			const matcher = new Matcher( pattern );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Allowed passing `true` as `view.Matcher`'s attribute match to check if that attribute is set. Closes #1239.

---

### Additional information

Close only after PR #1241.