### PR TITLE
T/730: Model#insertContent() will not produce invalid schema (when merging)

### DIFF
--- a/src/model/utils/insertcontent.js
+++ b/src/model/utils/insertcontent.js
@@ -282,8 +282,8 @@ class Insertion {
 			return;
 		}
 
-		const mergeLeft = canMergeLeft( this.canMergeWith, this.model.schema );
-		const mergeRight = canMergeRight( this.canMergeWith, this.model.schema );
+		const mergeLeft = this._canMergeLeft( node, context );
+		const mergeRight = this._canMergeRight( node, context );
 		const mergePosLeft = LivePosition.createBefore( node );
 		const mergePosRight = LivePosition.createAfter( node );
 
@@ -327,30 +327,38 @@ class Insertion {
 
 		mergePosLeft.detach();
 		mergePosRight.detach();
+	}
 
-		// @param {Set} canMergeWith
-		// @param {module:engine/model/schema~Schema} schema
-		// @returns {Boolean}
-		function canMergeLeft( canMergeWith, schema ) {
-			const previousSibling = node.previousSibling;
+	/**
+	 * Checks whether specified node can be merged with previous sibling element.
+	 *
+	 * @param {module:engine/model/node~Node} node The node which could potentially be merged.
+	 * @param {Object} context
+	 * @returns {Boolean}
+	 */
+	_canMergeLeft( node, context ) {
+		const previousSibling = node.previousSibling;
 
-			return context.isFirst &&
-				( previousSibling instanceof Element ) &&
-				canMergeWith.has( previousSibling ) &&
-				schema.checkMerge( previousSibling, node );
-		}
+		return context.isFirst &&
+			( previousSibling instanceof Element ) &&
+			this.canMergeWith.has( previousSibling ) &&
+			this.model.schema.checkMerge( previousSibling, node );
+	}
 
-		// @param {Set} canMergeWith
-		// @param {module:engine/model/schema~Schema} schema
-		// @returns {Boolean}
-		function canMergeRight( canMergeWith, schema ) {
-			const nextSibling = node.nextSibling;
+	/**
+	 * Checks whether specified node can be merged with next sibling element.
+	 *
+	 * @param {module:engine/model/node~Node} node The node which could potentially be merged.
+	 * @param {Object} context
+	 * @returns {Boolean}
+	 */
+	_canMergeRight( node, context ) {
+		const nextSibling = node.nextSibling;
 
-			return context.isLast &&
-				( nextSibling instanceof Element ) &&
-				canMergeWith.has( nextSibling ) &&
-				schema.checkMerge( node, nextSibling );
-		}
+		return context.isLast &&
+			( nextSibling instanceof Element ) &&
+			this.canMergeWith.has( nextSibling ) &&
+			this.model.schema.checkMerge( node, nextSibling );
 	}
 
 	/**

--- a/src/model/utils/insertcontent.js
+++ b/src/model/utils/insertcontent.js
@@ -282,8 +282,8 @@ class Insertion {
 			return;
 		}
 
-		const mergeLeft = context.isFirst && ( node.previousSibling instanceof Element ) && this.canMergeWith.has( node.previousSibling );
-		const mergeRight = context.isLast && ( node.nextSibling instanceof Element ) && this.canMergeWith.has( node.nextSibling );
+		const mergeLeft = canMergeLeft.call( this );
+		const mergeRight = canMergeRight.call( this );
 		const mergePosLeft = LivePosition.createBefore( node );
 		const mergePosRight = LivePosition.createAfter( node );
 
@@ -327,6 +327,24 @@ class Insertion {
 
 		mergePosLeft.detach();
 		mergePosRight.detach();
+
+		function canMergeLeft() {
+			const previousSibling = node.previousSibling;
+
+			return context.isFirst &&
+				( previousSibling instanceof Element ) &&
+				this.canMergeWith.has( previousSibling ) &&
+				this.model.schema.checkMerge( previousSibling, node );
+		}
+
+		function canMergeRight() {
+			const nextSibling = node.nextSibling;
+
+			return context.isLast &&
+				( nextSibling instanceof Element ) &&
+				this.canMergeWith.has( nextSibling ) &&
+				this.model.schema.checkMerge( node, nextSibling );
+		}
 	}
 
 	/**

--- a/src/model/utils/insertcontent.js
+++ b/src/model/utils/insertcontent.js
@@ -282,8 +282,8 @@ class Insertion {
 			return;
 		}
 
-		const mergeLeft = canMergeLeft.call( this );
-		const mergeRight = canMergeRight.call( this );
+		const mergeLeft = canMergeLeft( this.canMergeWith, this.model.schema );
+		const mergeRight = canMergeRight( this.canMergeWith, this.model.schema );
 		const mergePosLeft = LivePosition.createBefore( node );
 		const mergePosRight = LivePosition.createAfter( node );
 
@@ -328,22 +328,28 @@ class Insertion {
 		mergePosLeft.detach();
 		mergePosRight.detach();
 
-		function canMergeLeft() {
+		// @param {Set} canMergeWith
+		// @param {module:engine/model/schema~Schema} schema
+		// @returns {Boolean}
+		function canMergeLeft( canMergeWith, schema ) {
 			const previousSibling = node.previousSibling;
 
 			return context.isFirst &&
 				( previousSibling instanceof Element ) &&
-				this.canMergeWith.has( previousSibling ) &&
-				this.model.schema.checkMerge( previousSibling, node );
+				canMergeWith.has( previousSibling ) &&
+				schema.checkMerge( previousSibling, node );
 		}
 
-		function canMergeRight() {
+		// @param {Set} canMergeWith
+		// @param {module:engine/model/schema~Schema} schema
+		// @returns {Boolean}
+		function canMergeRight( canMergeWith, schema ) {
 			const nextSibling = node.nextSibling;
 
 			return context.isLast &&
 				( nextSibling instanceof Element ) &&
-				this.canMergeWith.has( nextSibling ) &&
-				this.model.schema.checkMerge( node, nextSibling );
+				canMergeWith.has( nextSibling ) &&
+				schema.checkMerge( node, nextSibling );
 		}
 	}
 

--- a/src/model/utils/insertcontent.js
+++ b/src/model/utils/insertcontent.js
@@ -165,6 +165,7 @@ class Insertion {
 	}
 
 	/**
+	 * @private
 	 * Handles insertion of a single node.
 	 *
 	 * @param {module:engine/model/node~Node} node
@@ -211,6 +212,7 @@ class Insertion {
 	}
 
 	/**
+	 * @private
 	 * @param {module:engine/model/element~Element} node The object element.
 	 * @param {Object} context
 	 */
@@ -226,6 +228,7 @@ class Insertion {
 	}
 
 	/**
+	 * @private
 	 * @param {module:engine/model/node~Node} node The disallowed node which needs to be handled.
 	 * @param {Object} context
 	 */
@@ -241,6 +244,7 @@ class Insertion {
 	}
 
 	/**
+	 * @private
 	 * @param {module:engine/model/node~Node} node The node to insert.
 	 */
 	_insert( node ) {
@@ -274,6 +278,7 @@ class Insertion {
 	}
 
 	/**
+	 * @private
 	 * @param {module:engine/model/node~Node} node The node which could potentially be merged.
 	 * @param {Object} context
 	 */
@@ -332,6 +337,7 @@ class Insertion {
 	/**
 	 * Checks whether specified node can be merged with previous sibling element.
 	 *
+	 * @private
 	 * @param {module:engine/model/node~Node} node The node which could potentially be merged.
 	 * @param {Object} context
 	 * @returns {Boolean}
@@ -348,6 +354,7 @@ class Insertion {
 	/**
 	 * Checks whether specified node can be merged with next sibling element.
 	 *
+	 * @private
 	 * @param {module:engine/model/node~Node} node The node which could potentially be merged.
 	 * @param {Object} context
 	 * @returns {Boolean}
@@ -364,6 +371,7 @@ class Insertion {
 	/**
 	 * Tries wrapping the node in a new paragraph and inserting it this way.
 	 *
+	 * @private
 	 * @param {module:engine/model/node~Node} node The node which needs to be autoparagraphed.
 	 * @param {Object} context
 	 */
@@ -380,6 +388,7 @@ class Insertion {
 	}
 
 	/**
+	 * @private
 	 * @param {module:engine/model/node~Node} node
 	 * @returns {Boolean} Whether an allowed position was found.
 	 * `false` is returned if the node isn't allowed at any position up in the tree, `true` if was.
@@ -425,6 +434,7 @@ class Insertion {
 	/**
 	 * Gets the element in which the given node is allowed. It checks the passed element and all its ancestors.
 	 *
+	 * @private
 	 * @param {module:engine/model/node~Node} node The node to check.
 	 * @param {module:engine/model/element~Element} element The element in which the node's correctness should be checked.
 	 * @returns {module:engine/model/element~Element|null}

--- a/tests/model/utils/insertcontent.js
+++ b/tests/model/utils/insertcontent.js
@@ -407,6 +407,25 @@ describe( 'DataController utils', () => {
 						'<paragraph>b</paragraph>'
 					);
 				} );
+
+				it( 'should not merge a paragraph wrapped in blockQuote with lists', () => {
+					model.schema.register( 'blockQuote', {
+						allowWhere: '$block',
+						allowContentOf: '$root',
+					} );
+
+					setData( model, '<listItem>fo[]o</listItem>' );
+
+					insertHelper( '<blockQuote><paragraph>xxx</paragraph></blockQuote><heading1>yyy</heading1>' );
+
+					expect( getData( model ) ).to.equal(
+						'<listItem>fo</listItem>' +
+						'<blockQuote>' +
+						'<paragraph>xxx</paragraph>' +
+						'</blockQuote>' +
+						'<heading1>yyy[]o</heading1>'
+					);
+				} );
 			} );
 
 			describe( 'mixed content to block', () => {

--- a/tests/model/utils/insertcontent.js
+++ b/tests/model/utils/insertcontent.js
@@ -408,7 +408,7 @@ describe( 'DataController utils', () => {
 					);
 				} );
 
-				it( 'should not merge a paragraph wrapped in blockQuote with lists', () => {
+				it( 'should not merge a paragraph wrapped in blockQuote with list item (checking left merge)', () => {
 					model.schema.register( 'blockQuote', {
 						allowWhere: '$block',
 						allowContentOf: '$root',
@@ -424,6 +424,44 @@ describe( 'DataController utils', () => {
 						'<paragraph>xxx</paragraph>' +
 						'</blockQuote>' +
 						'<heading1>yyy[]o</heading1>'
+					);
+				} );
+
+				it( 'should not merge a paragraph wrapped in blockQuote with list item (checking right merge)', () => {
+					model.schema.register( 'blockQuote', {
+						allowWhere: '$block',
+						allowContentOf: '$root',
+					} );
+
+					setData( model, '<listItem>fo[]o</listItem>' );
+
+					insertHelper( '<heading1>yyy</heading1><blockQuote><paragraph>xxx</paragraph></blockQuote>' );
+
+					expect( getData( model ) ).to.equal(
+						'<listItem>foyyy</listItem>' +
+						'<blockQuote>' +
+						'<paragraph>xxx</paragraph>' +
+						'</blockQuote>' +
+						'<listItem>[]o</listItem>'
+					);
+				} );
+
+				it( 'should not merge a paragraph wrapped in blockQuote with list item (checking both merges)', () => {
+					model.schema.register( 'blockQuote', {
+						allowWhere: '$block',
+						allowContentOf: '$root',
+					} );
+
+					setData( model, '<listItem>fo[]o</listItem>' );
+
+					insertHelper( '<blockQuote><paragraph>xxx</paragraph></blockQuote>' );
+
+					expect( getData( model ) ).to.equal(
+						'<listItem>fo</listItem>' +
+						'<blockQuote>' +
+						'<paragraph>xxx</paragraph>' +
+						'</blockQuote>' +
+						'<listItem>[]o</listItem>'
 					);
 				} );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `Model#insertContent()` will not merge nodes if a schema after merging will be incorrect. Closes ckeditor/ckeditor5#730.
