### PR TITLE
SchemaContext enhancements.

### DIFF
--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -1174,7 +1174,7 @@ export class SchemaContext {
 	 * 		const ctx3 = ctx.concat( 'other' ); // [ 'elementParent', 'element', 'other' ]
 	 *
 	 * 		// Array with above.
-	 * 		const ctx3 = ctx.concat( [ 'other', element.getChild( 0 ) ] ); // [ 'elementParent', 'element', 'other', 'elementChild ]
+	 * 		const ctx4 = ctx.concat( [ 'other', element.getChild( 0 ) ] ); // [ 'elementParent', 'element', 'other', 'elementChild ]
 	 *
 	 * @param {String|module:engine/model/node~Node|Array<String|module:engine/model/node~Node>} definition
 	 * Definition of item(s) that will be added to current context.

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -1167,13 +1167,13 @@ export class SchemaContext {
 	 *
 	 * 		const ctx = new SchemaContext( element ); // [ 'elementParent', 'element' ]
 	 *
-	 * 		// Node.
+	 * 		// A node.
 	 * 		const ctx2 = ctx.concat( element.getChild( 0 ) ); // [ 'elementParent', 'element', 'elementChild' ]
 	 *
-	 * 		// String (element name).
+	 * 		// A string (element name).
 	 * 		const ctx3 = ctx.concat( 'other' ); // [ 'elementParent', 'element', 'other' ]
 	 *
-	 * 		// Array with above.
+	 * 		// An array with above.
 	 * 		const ctx4 = ctx.concat( [ 'other', element.getChild( 0 ) ] ); // [ 'elementParent', 'element', 'other', 'elementChild ]
 	 *
 	 * @param {String|module:engine/model/node~Node|Array<String|module:engine/model/node~Node>} definition

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -1165,16 +1165,17 @@ export class SchemaContext {
 	 * Returns new SchemaContext instance with additional items created from provided definition.
 	 * Definition can be:
 	 *
-	 * 		const ctx = new SchemaContext( element ); // [ 'elementParent', 'element' ]
+	 * 		const context = new SchemaContext( element ); // [ 'elementParent', 'element' ]
 	 *
 	 * 		// A node.
-	 * 		const ctx2 = ctx.concat( element.getChild( 0 ) ); // [ 'elementParent', 'element', 'elementChild' ]
+	 * 		const context2 = context.concat( element.getChild( 0 ) ); // [ 'elementParent', 'element', 'elementChild' ]
 	 *
 	 * 		// A string (element name).
-	 * 		const ctx3 = ctx.concat( 'other' ); // [ 'elementParent', 'element', 'other' ]
+	 * 		const context3 = context.concat( 'other' ); // [ 'elementParent', 'element', 'other' ]
 	 *
 	 * 		// An array with above.
-	 * 		const ctx4 = ctx.concat( [ 'other', element.getChild( 0 ) ] ); // [ 'elementParent', 'element', 'other', 'elementChild ]
+	 * 		const context4 = context
+	 * 			.concat( [ 'other', element.getChild( 0 ) ] ); // [ 'elementParent', 'element', 'other', 'elementChild ]
 	 *
 	 * @param {String|module:engine/model/node~Node|Array<String|module:engine/model/node~Node>} definition
 	 * Definition of item(s) that will be added to current context.

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -1165,17 +1165,25 @@ export class SchemaContext {
 	 * Returns new SchemaContext instance with additional items created from provided definition.
 	 * Definition can be:
 	 *
-	 * 		const context = new SchemaContext( element ); // [ 'elementParent', 'element' ]
+	 * 		const context = new SchemaContext( [ '$root' ] );
 	 *
-	 * 		// A node.
-	 * 		const context2 = context.concat( element.getChild( 0 ) ); // [ 'elementParent', 'element', 'elementChild' ]
+	 * 		// An element.
+	 * 		const fooElement = writer.createElement( 'fooElement' );
+	 * 		const newContext = context.concat( fooElement ); // [ '$root', 'fooElement' ]
+	 *
+	 * 		// A text node.
+	 * 		const text = writer.createText( 'foobar' );
+	 * 		const newContext = context.concat( text ); // [ '$root', '$text' ]
 	 *
 	 * 		// A string (element name).
-	 * 		const context3 = context.concat( 'other' ); // [ 'elementParent', 'element', 'other' ]
+	 * 		const newContext = context.concat( 'barElement' ); // [ '$root', 'barElement' ]
 	 *
 	 * 		// An array with above.
-	 * 		const context4 = context
-	 * 			.concat( [ 'other', element.getChild( 0 ) ] ); // [ 'elementParent', 'element', 'other', 'elementChild ]
+	 * 		const fooElement = writer.createElement( 'fooElement' );
+	 * 		const text = writer.createText( 'foobar' );
+	 * 		const newContext = context.concat( [ fooElement, 'barElement', text ] ); // [ '$root', 'fooElement', 'barElement', '$text' ]
+	 *
+	 * **Note** {module:engine/model/node~Node} that is already in the model tree will be added as the only item (without ancestors).
 	 *
 	 * @param {String|module:engine/model/node~Node|Array<String|module:engine/model/node~Node>} definition
 	 * Definition of item(s) that will be added to current context.

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -1166,12 +1166,12 @@ export class SchemaContext {
 	/**
 	 * Returns new SchemaContext instance with additional items created from provided definition.
 	 *
-	 * @param {String|module:engine/model/node~Node|module:engine/model/schema~SchemaContext|
-	 * Array<String|module:engine/model/node~Node>} definition Definition of item(s) that will be added to current context.
+	 * @param {String|module:engine/model/node~Node|Array<String|module:engine/model/node~Node>} definition
+	 * Definition of item(s) that will be added to current context.
 	 * @returns {module:engine/model/schema~SchemaContext} New SchemaContext instance.
 	 */
 	concat( definition ) {
-		if ( !( definition instanceof SchemaContext ) && !Array.isArray( definition ) ) {
+		if ( !Array.isArray( definition ) ) {
 			definition = [ definition ];
 		}
 

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -376,8 +376,7 @@ export default class Schema {
 	 *		schema.checkChild( model.document.getRoot(), paragraph ); // -> true
 	 *
 	 * @fires checkChild
-	 * @param {module:engine/model/schema~SchemaContextDefinition|module:engine/model/schema~SchemaContext} context
-	 * Context in which the child will be checked.
+	 * @param {module:engine/model/schema~SchemaContextDefinition} context Context in which the child will be checked.
 	 * @param {module:engine/model/node~Node|String} def The child to check.
 	 */
 	checkChild( context, def ) {
@@ -401,8 +400,7 @@ export default class Schema {
 	 *		schema.checkAttribute( textNode, 'bold' ); // -> true
 	 *
 	 * @fires checkAttribute
-	 * @param {module:engine/model/schema~SchemaContextDefinition|module:engine/model/schema~SchemaContext} context
-	 * Context in which the attribute will be checked.
+	 * @param {module:engine/model/schema~SchemaContextDefinition} context Context in which the attribute will be checked.
 	 * @param {String} attributeName
 	 */
 	checkAttribute( context, attributeName ) {
@@ -1243,6 +1241,8 @@ export class SchemaContext {
  * means that the context will be unrealistic (e.g. attributes of these nodes are not specified).
  * However, at times this may be the only way to define the context (e.g. when checking some
  * hypothetical situation).
+ * * By defining a {@link module:engine/model/schema~SchemaContext} instance - in this case the same instance as provided
+ * will be return.
  *
  * Examples of context definitions passed to the {@link module:engine/model/schema~Schema#checkChild `Schema#checkChild()`}
  * method:
@@ -1290,7 +1290,7 @@ export class SchemaContext {
  *		// Check in [ rootElement, paragraphElement, textNode ].
  *		schema.checkChild( [ ...positionInParagraph.getAncestors(), '$text' ], 'bold' );
  *
- * @typedef {module:engine/model/node~Node|module:engine/model/position~Position|
+ * @typedef {module:engine/model/node~Node|module:engine/model/position~Position|module:engine/model/schema~SchemaContext|
  * Array.<String|module:engine/model/node~Node>} module:engine/model/schema~SchemaContextDefinition
  */
 

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -1165,6 +1165,18 @@ export class SchemaContext {
 
 	/**
 	 * Returns new SchemaContext instance with additional items created from provided definition.
+	 * Definition can be:
+	 *
+	 * 		const ctx = new SchemaContext( element ); // [ 'elementParent', 'element' ]
+	 *
+	 * 		// Node.
+	 * 		const ctx2 = ctx.concat( element.getChild( 0 ) ); // [ 'elementParent', 'element', 'elementChild' ]
+	 *
+	 * 		// String (element name).
+	 * 		const ctx3 = ctx.concat( 'other' ); // [ 'elementParent', 'element', 'other' ]
+	 *
+	 * 		// Array with above.
+	 * 		const ctx3 = ctx.concat( [ 'other', element.getChild( 0 ) ] ); // [ 'elementParent', 'element', 'other', 'elementChild ]
 	 *
 	 * @param {String|module:engine/model/node~Node|Array<String|module:engine/model/node~Node>} definition
 	 * Definition of item(s) that will be added to current context.

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -1162,39 +1162,31 @@ export class SchemaContext {
 	}
 
 	/**
-	 * Returns new SchemaContext instance with additional items created from provided definition.
-	 * Definition can be:
+	 * Returns new SchemaContext instance with additional item
+	 *
+	 * Item can be added as:
 	 *
 	 * 		const context = new SchemaContext( [ '$root' ] );
 	 *
 	 * 		// An element.
 	 * 		const fooElement = writer.createElement( 'fooElement' );
-	 * 		const newContext = context.concat( fooElement ); // [ '$root', 'fooElement' ]
+	 * 		const newContext = context.push( fooElement ); // [ '$root', 'fooElement' ]
 	 *
 	 * 		// A text node.
 	 * 		const text = writer.createText( 'foobar' );
-	 * 		const newContext = context.concat( text ); // [ '$root', '$text' ]
+	 * 		const newContext = context.push( text ); // [ '$root', '$text' ]
 	 *
 	 * 		// A string (element name).
-	 * 		const newContext = context.concat( 'barElement' ); // [ '$root', 'barElement' ]
-	 *
-	 * 		// An array with above.
-	 * 		const fooElement = writer.createElement( 'fooElement' );
-	 * 		const text = writer.createText( 'foobar' );
-	 * 		const newContext = context.concat( [ fooElement, 'barElement', text ] ); // [ '$root', 'fooElement', 'barElement', '$text' ]
+	 * 		const newContext = context.push( 'barElement' ); // [ '$root', 'barElement' ]
 	 *
 	 * **Note** {module:engine/model/node~Node} that is already in the model tree will be added as the only item (without ancestors).
 	 *
-	 * @param {String|module:engine/model/node~Node|Array<String|module:engine/model/node~Node>} definition
-	 * Definition of item(s) that will be added to current context.
-	 * @returns {module:engine/model/schema~SchemaContext} New SchemaContext instance.
+	 * @param {String|module:engine/model/node~Node|Array<String|module:engine/model/node~Node>} item Item that will be added
+	 * to current context.
+	 * @returns {module:engine/model/schema~SchemaContext} New SchemaContext instance with additional item.
 	 */
-	concat( definition ) {
-		if ( !Array.isArray( definition ) ) {
-			definition = [ definition ];
-		}
-
-		const ctx = new SchemaContext( definition );
+	push( item ) {
+		const ctx = new SchemaContext( [ item ] );
 
 		ctx._items = [ ...this._items, ...ctx._items ];
 

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -2755,11 +2755,11 @@ describe( 'SchemaContext', () => {
 		} );
 	} );
 
-	describe( 'concat()', () => {
+	describe( 'push()', () => {
 		it( 'creates new SchemaContext instance with new item - #string', () => {
 			const ctx = new SchemaContext( [ 'a', 'b', 'c' ] );
 
-			const newCtx = ctx.concat( 'd' );
+			const newCtx = ctx.push( 'd' );
 
 			expect( newCtx ).to.instanceof( SchemaContext );
 			expect( newCtx ).to.not.equal( ctx );
@@ -2771,7 +2771,7 @@ describe( 'SchemaContext', () => {
 			const node = new Text( 'd' );
 			const ctx = new SchemaContext( [ 'a', 'b', 'c' ] );
 
-			const newCtx = ctx.concat( node );
+			const newCtx = ctx.push( node );
 
 			expect( newCtx ).to.instanceof( SchemaContext );
 			expect( newCtx ).to.not.equal( ctx );
@@ -2783,23 +2783,11 @@ describe( 'SchemaContext', () => {
 			const ctx = new SchemaContext( [ 'a', 'b', 'c' ] );
 			const parent = new Element( 'parent', null, new Element( 'd' ) );
 
-			const newCtx = ctx.concat( parent.getChild( 0 ) );
+			const newCtx = ctx.push( parent.getChild( 0 ) );
 
 			expect( newCtx ).to.instanceof( SchemaContext );
 			expect( newCtx ).to.not.equal( ctx );
 			expect( Array.from( newCtx.getNames() ) ).to.deep.equal( [ 'a', 'b', 'c', 'd' ] );
-			expect( Array.from( ctx.getNames() ) ).to.deep.equal( [ 'a', 'b', 'c' ] );
-		} );
-
-		it( 'creates new SchemaContext instance with new item - #array', () => {
-			const ctx = new SchemaContext( [ 'a', 'b', 'c' ] );
-			const parent = new Element( 'parent', null, new Element( 'f' ) );
-
-			const newCtx = ctx.concat( [ 'd', new Text( 'e' ), parent.getChild( 0 ) ] );
-
-			expect( newCtx ).to.instanceof( SchemaContext );
-			expect( newCtx ).to.not.equal( ctx );
-			expect( Array.from( newCtx.getNames() ) ).to.deep.equal( [ 'a', 'b', 'c', 'd', '$text', 'f' ] );
 			expect( Array.from( ctx.getNames() ) ).to.deep.equal( [ 'a', 'b', 'c' ] );
 		} );
 	} );

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -2779,7 +2779,7 @@ describe( 'SchemaContext', () => {
 			expect( Array.from( ctx.getNames() ) ).to.deep.equal( [ 'a', 'b', 'c' ] );
 		} );
 
-		it( 'creates new SchemaContext instance with new item - #node', () => {
+		it( 'creates new SchemaContext instance with new item - #element', () => {
 			const ctx = new SchemaContext( [ 'a', 'b', 'c' ] );
 			const parent = new Element( 'parent', null, new Element( 'd' ) );
 
@@ -2791,22 +2791,11 @@ describe( 'SchemaContext', () => {
 			expect( Array.from( ctx.getNames() ) ).to.deep.equal( [ 'a', 'b', 'c' ] );
 		} );
 
-		it( 'creates new SchemaContext instance with new item - #SchemaContext', () => {
-			const ctx = new SchemaContext( [ 'a', 'b', 'c' ] );
-			const schemaContext = new SchemaContext( [ 'd', 'e' ] );
-
-			const newCtx = ctx.concat( schemaContext );
-
-			expect( newCtx ).to.instanceof( SchemaContext );
-			expect( newCtx ).to.not.equal( ctx );
-			expect( Array.from( newCtx.getNames() ) ).to.deep.equal( [ 'a', 'b', 'c', 'd', 'e' ] );
-			expect( Array.from( ctx.getNames() ) ).to.deep.equal( [ 'a', 'b', 'c' ] );
-		} );
-
 		it( 'creates new SchemaContext instance with new item - #array', () => {
 			const ctx = new SchemaContext( [ 'a', 'b', 'c' ] );
+			const parent = new Element( 'parent', null, new Element( 'f' ) );
 
-			const newCtx = ctx.concat( [ 'd', new Text( 'e' ), new Element( 'f' ) ] );
+			const newCtx = ctx.concat( [ 'd', new Text( 'e' ), parent.getChild( 0 ) ] );
 
 			expect( newCtx ).to.instanceof( SchemaContext );
 			expect( newCtx ).to.not.equal( ctx );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Changed `SchemaContext#concat` to `SchemaContext#push`. Closes #1263.

BREAKING CHANGE: `SchemaContext#concat` has been changed to `SchemaContext#push`.

---

Related: https://github.com/ckeditor/ckeditor5-paragraph/tree/t/ckeditor5-engine/1263