### PR TITLE
Internal: Schema#findAllowedParent should not allow to split objects.

### DIFF
--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -736,7 +736,8 @@ export default class Schema {
 				return parent;
 			}
 
-			if ( this.isLimit( parent ) ) {
+			// Do not split limit elements and objects.
+			if ( this.isLimit( parent ) || this.isObject( parent ) ) {
 				return null;
 			}
 

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -722,7 +722,8 @@ export default class Schema {
 	/**
 	 * Tries to find position ancestors that allows to insert given node.
 	 * It starts searching from the given position and goes node by node to the top of the model tree
-	 * as long as {@link module:engine/model/schema~Schema#isLimit limit element} or top-most ancestor won't be reached.
+	 * as long as {@link module:engine/model/schema~Schema#isLimit limit element},
+	 * {@link module:engine/model/schema~Schema#isObject object element} or top-most ancestor won't be reached.
 	 *
 	 * @params {module:engine/model/node~Node} node Node for which allowed parent should be found.
 	 * @params {module:engine/model/position~Position} position Position from searching will start.

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -1386,7 +1386,7 @@ describe( 'Schema', () => {
 			} );
 		} );
 
-		it( 'should return position ancestor that allows to insert given note to it', () => {
+		it( 'should return position ancestor that allows to insert given node to it', () => {
 			const node = new Element( 'paragraph' );
 
 			const allowedParent = schema.findAllowedParent( node, Position.createAt( r1bQp ) );
@@ -1394,7 +1394,7 @@ describe( 'Schema', () => {
 			expect( allowedParent ).to.equal( r1bQ );
 		} );
 
-		it( 'should return position ancestor that allows to insert given note to it when position is already i such an element', () => {
+		it( 'should return position ancestor that allows to insert given node to it when position is already i such an element', () => {
 			const node = new Text( 'text' );
 
 			const parent = schema.findAllowedParent( node, Position.createAt( r1bQp ) );
@@ -1402,9 +1402,23 @@ describe( 'Schema', () => {
 			expect( parent ).to.equal( r1bQp );
 		} );
 
-		it( 'should return null when limit element will be reached before allowed parent', () => {
+		it( 'should return null when limit element is reached before allowed parent', () => {
 			schema.extend( 'blockQuote', {
 				isLimit: true
+			} );
+			schema.register( 'div', {
+				allowIn: '$root'
+			} );
+			const node = new Element( 'div' );
+
+			const parent = schema.findAllowedParent( node, Position.createAt( r1bQp ) );
+
+			expect( parent ).to.null;
+		} );
+
+		it( 'should return null when object element is reached before allowed parent', () => {
+			schema.extend( 'blockQuote', {
+				isObject: true
 			} );
 			schema.register( 'div', {
 				allowIn: '$root'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: `Schema#findAllowedParent` should do not allow to split objects. Closes https://github.com/ckeditor/ckeditor5-image/issues/171.