### PR TITLE
`Schema#getLimitElement()` will work with multi-ranges selection

### DIFF
--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -581,12 +581,22 @@ export default class Schema {
 	getLimitElement( selection ) {
 		// Find the common ancestor for all selection's ranges.
 		let element = Array.from( selection.getRanges() )
-			.reduce( ( node, range ) => {
-				if ( !node ) {
-					return range.getCommonAncestor();
+			.reduce( ( element, range ) => {
+				const rangeCommonAncestor = range.getCommonAncestor();
+
+				if ( !element ) {
+					return rangeCommonAncestor;
 				}
 
-				return node.getCommonAncestor( range.getCommonAncestor() );
+				// If the element or the common ancestor for the selection's range is a root element, use it
+				// because the root element is on the top of the tree and it's the common ancestor for all selection's ranges.
+				if ( element.is( 'rootElement' ) ) {
+					return element;
+				} else if  ( rangeCommonAncestor.is( 'rootElement' ) ) {
+					return rangeCommonAncestor;
+				}
+
+				return element.getCommonAncestor( rangeCommonAncestor );
 			}, null );
 
 		while ( !this.isLimit( element ) ) {

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -588,15 +588,7 @@ export default class Schema {
 					return rangeCommonAncestor;
 				}
 
-				// If the element or the common ancestor for the selection's range is a root element, use it
-				// because the root element is on the top of the tree and it's the common ancestor for all selection's ranges.
-				if ( element.is( 'rootElement' ) ) {
-					return element;
-				} else if ( rangeCommonAncestor.is( 'rootElement' ) ) {
-					return rangeCommonAncestor;
-				}
-
-				return element.getCommonAncestor( rangeCommonAncestor );
+				return element.getCommonAncestor( rangeCommonAncestor, { includeSelf: true } );
 			}, null );
 
 		while ( !this.isLimit( element ) ) {

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -592,7 +592,7 @@ export default class Schema {
 				// because the root element is on the top of the tree and it's the common ancestor for all selection's ranges.
 				if ( element.is( 'rootElement' ) ) {
 					return element;
-				} else if  ( rangeCommonAncestor.is( 'rootElement' ) ) {
+				} else if ( rangeCommonAncestor.is( 'rootElement' ) ) {
 					return rangeCommonAncestor;
 				}
 

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -934,7 +934,7 @@ describe( 'Schema', () => {
 			expect( schema.getLimitElement( doc.selection ) ).to.equal( root );
 		} );
 
-		it( 'works fine with multi-range selections if the first one has the root element as a limit element', () => {
+		it( 'works fine with multi-range selections if the first range has the root element as a limit element', () => {
 			setData(
 				model,
 				'<image>' +
@@ -950,7 +950,7 @@ describe( 'Schema', () => {
 			expect( schema.getLimitElement( doc.selection ) ).to.equal( root );
 		} );
 
-		it( 'works fine with multi-range selections if the second one has the root element as a limit element', () => {
+		it( 'works fine with multi-range selections if the last range has the root element as a limit element', () => {
 			setData(
 				model,
 				'<paragraph>Paragraph item 1</paragraph>' +

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -933,6 +933,38 @@ describe( 'Schema', () => {
 
 			expect( schema.getLimitElement( doc.selection ) ).to.equal( root );
 		} );
+
+		it( 'works fine with multi-range selections if the first one has the root element as a limit element', () => {
+			setData(
+				model,
+				'<image>' +
+					'<caption>[Foo</caption>' +
+				'</image>' +
+				'<article>' +
+					'<paragraph>Paragraph in article]</paragraph>' +
+				'</article>' +
+				'<paragraph>Paragraph item 1</paragraph>' +
+				'<paragraph>Paragraph [item 2]</paragraph>'
+			);
+
+			expect( schema.getLimitElement( doc.selection ) ).to.equal( root );
+		} );
+
+		it( 'works fine with multi-range selections if the second one has the root element as a limit element', () => {
+			setData(
+				model,
+				'<paragraph>Paragraph item 1</paragraph>' +
+				'<paragraph>Paragraph [item 2]</paragraph>' +
+				'<image>' +
+					'<caption>[Foo</caption>' +
+				'</image>' +
+				'<article>' +
+					'<paragraph>Paragraph in article]</paragraph>' +
+				'</article>'
+			);
+
+			expect( schema.getLimitElement( doc.selection ) ).to.equal( root );
+		} );
 	} );
 
 	describe( 'checkAttributeInSelection()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `Schema#getLimitElement()` will return a proper limit element (the root element) if one of the selection's ranges have the root element as the limit element. Closes #1275.