### PR TITLE
Internal: Set correct modelCursor in v->m docFrag converter.

### DIFF
--- a/src/conversion/view-to-model-converters.js
+++ b/src/conversion/view-to-model-converters.js
@@ -31,8 +31,10 @@ export function convertToModelFragment() {
 	return ( evt, data, conversionApi ) => {
 		// Second argument in `consumable.consume` is discarded for ViewDocumentFragment but is needed for ViewElement.
 		if ( !data.modelRange && conversionApi.consumable.consume( data.viewItem, { name: true } ) ) {
-			data = Object.assign( data, conversionApi.convertChildren( data.viewItem, data.modelCursor ) );
-			data.modelCursor = data.modelRange.end;
+			const { modelRange, modelCursor } = conversionApi.convertChildren( data.viewItem, data.modelCursor );
+
+			data.modelRange = modelRange;
+			data.modelCursor = modelCursor;
 		}
 	};
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Set correct modelCursor in v->m docFrag converter.. Closes #1277.

---

Needed by: https://github.com/ckeditor/ckeditor5-list/pull/94