### PR TITLE
Using model.Writer instead of constructor in tests and docs of conversion utils

### DIFF
--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -37,19 +37,13 @@ import cloneDeep from '@ckeditor/ckeditor5-utils/src/lib/lodash/cloneDeep';
  *		} );
  *
  *		upcastElementToElement( {
- *			view: {
- *				name: 'p',
- *				class: 'fancy'
- *			},
- *			model: new ModelElement( 'p', { fancy: true } )
- *		} );
- *
- *		upcastElementToElement( {
  * 			view: {
  *				name: 'p',
  *				class: 'heading'
  * 			},
- * 			model: viewElement => new ModelElement( 'heading', { level: viewElement.getAttribute( 'data-level' ) } )
+ * 			model: ( viewElement, modelWriter ) => {
+ * 				return modelWriter.createElement( 'heading', { level: viewElement.getAttribute( 'data-level' ) } );
+ * 			}
  * 		} );
  *
  * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -374,10 +374,8 @@ function _prepareToElementConverter( config ) {
 function _getModelElement( model, input, writer ) {
 	if ( model instanceof Function ) {
 		return model( input, writer );
-	} else if ( typeof model == 'string' ) {
-		return writer.createElement( model );
 	} else {
-		return model;
+		return writer.createElement( model );
 	}
 }
 

--- a/tests/conversion/upcast-converters.js
+++ b/tests/conversion/upcast-converters.js
@@ -101,24 +101,6 @@ describe( 'upcast-helpers', () => {
 			expectResult( new ViewContainerElement( 'p', { class: 'fancy' } ), '<fancyParagraph></fancyParagraph>' );
 		} );
 
-		it( 'config.model is element instance', () => {
-			schema.extend( 'paragraph', {
-				allowAttributes: [ 'fancy' ]
-			} );
-
-			const helper = upcastElementToElement( {
-				view: {
-					name: 'p',
-					class: 'fancy'
-				},
-				model: new ModelElement( 'paragraph', { fancy: true } )
-			} );
-
-			conversion.for( 'upcast' ).add( helper );
-
-			expectResult( new ViewContainerElement( 'p', { class: 'fancy' } ), '<paragraph fancy="true"></paragraph>' );
-		} );
-
 		it( 'config.model is a function', () => {
 			schema.register( 'heading', {
 				inheritAllFrom: '$block',
@@ -130,7 +112,9 @@ describe( 'upcast-helpers', () => {
 					name: 'p',
 					class: 'heading'
 				},
-				model: viewElement => new ModelElement( 'heading', { level: viewElement.getAttribute( 'data-level' ) } )
+				model: ( viewElement, modelWriter ) => {
+					return modelWriter.createElement( 'heading', { level: viewElement.getAttribute( 'data-level' ) } );
+				}
 			} );
 
 			conversion.for( 'upcast' ).add( helper );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Using `model.Writer` instead of `model.Element` constructor in tests and docs of conversion utils. Closes #1291.