### PR TITLE
View render() and change() methods create new change block

### DIFF
--- a/src/conversion/downcastdispatcher.js
+++ b/src/conversion/downcastdispatcher.js
@@ -476,7 +476,6 @@ export default class DowncastDispatcher {
 	 * @param {Object} data Additional information about the change.
 	 * @param {module:engine/model/item~Item} data.item Inserted item.
 	 * @param {module:engine/model/range~Range} data.range Range spanning over inserted item.
-	 * @param {module:engine/conversion/modelconsumable~ModelConsumable} consumable Values to consume.
 	 * @param {Object} conversionApi Conversion interface to be used by callback, passed in `DowncastDispatcher` constructor.
 	 */
 

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -109,6 +109,7 @@ export default class Document {
 	 * Performs post-fixer loops. Executes post-fixer callbacks as long as none of them has done any changes to the model.
 	 *
 	 * @protected
+	 * @param {module:engine/view/writer~Writer} writer
 	 */
 	_callPostFixers( writer ) {
 		let wasFixed = false;

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -67,7 +67,7 @@ export default class Document {
 		this.set( 'isFocused', false );
 
 		/**
-		 * Post-fixer callbacks registered to the model document.
+		 * Post-fixer callbacks registered to the view document.
 		 *
 		 * @private
 		 * @member {Set}
@@ -88,8 +88,8 @@ export default class Document {
 	}
 
 	/**
-	 * Used to register a post-fixer callback. A post-fixer mechanism that allows to update view tree just before rendering
-	 * to the DOM is started.
+	 * Used to register a post-fixer callback. A post-fixers mechanism allows to update view tree just before rendering
+	 * to the DOM.
 	 *
 	 * Post-fixers are fired just after all changes from the outermost change block were applied but
 	 * before the {@link module:engine/view/view~View#event:render render event} is fired. If a post-fixer callback made

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -88,38 +88,16 @@ export default class Document {
 	}
 
 	/**
-	 * TODO: update docs
-	 * Used to register a post-fixer callback. A post-fixer mechanism guarantees that the features that listen to
-	 * the {@link module:engine/model/model~Model#event:_change model's change event} will operate on a correct model state.
+	 * Used to register a post-fixer callback. A post-fixer mechanism that allows to update view tree just before rendering
+	 * to the DOM is started.
 	 *
-	 * An execution of a feature may lead to an incorrect document tree state. The callbacks are used to fix the document tree after
-	 * it has changed. Post-fixers are fired just after all changes from the outermost change block were applied but
-	 * before the {@link module:engine/model/document~Document#event:change change event} is fired. If a post-fixer callback made
+	 * Post-fixers are fired just after all changes from the outermost change block were applied but
+	 * before the {@link module:engine/view/view~View#event:render render event} is fired. If a post-fixer callback made
 	 * a change, it should return `true`. When this happens, all post-fixers are fired again to check if something else should
 	 * not be fixed in the new document tree state.
 	 *
-	 * As a parameter, a post-fixer callback receives a {@link module:engine/model/writer~Writer writer} instance connected with the
-	 * executed changes block. Thanks to that, all changes done by the callback will be added to the same
-	 * {@link module:engine/model/batch~Batch batch} (and undo step) as the original changes. This makes post-fixer changes transparent
-	 * for the user.
-	 *
-	 * An example of a post-fixer is a callback that checks if all the data were removed from the editor. If so, the
-	 * callback should add an empty paragraph so that the editor is never empty:
-	 *
-	 *		document.registerPostFixer( writer => {
-	 *			const changes = document.differ.getChanges();
-	 *
-	 *			// Check if the changes lead to an empty root in the editor.
-	 *			for ( const entry of changes ) {
-	 *				if ( entry.type == 'remove' && entry.position.root.isEmpty ) {
-	 *					writer.insertElement( 'paragraph', entry.position.root, 0 );
-	 *
-	 *					// It is fine to return early, even if multiple roots would need to be fixed.
-	 *					// All post-fixers will be fired again, so if there are more empty roots, those will be fixed, too.
-	 *					return true;
-	 *				}
-	 *			}
-	 *		} );
+	 * As a parameter, a post-fixer callback receives a {@link module:engine/view/writer~Writer writer} instance connected with the
+	 * executed changes block.
 	 *
 	 * @param {Function} postFixer
 	 */

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -65,6 +65,14 @@ export default class Document {
 		 * @member {Boolean} module:engine/view/document~Document#isFocused
 		 */
 		this.set( 'isFocused', false );
+
+		/**
+		 * Post-fixer callbacks registered to the model document.
+		 *
+		 * @private
+		 * @member {Set}
+		 */
+		this._postFixers = new Set();
 	}
 
 	/**
@@ -77,6 +85,65 @@ export default class Document {
 	 */
 	getRoot( name = 'main' ) {
 		return this.roots.get( name );
+	}
+
+	/**
+	 * TODO: update docs
+	 * Used to register a post-fixer callback. A post-fixer mechanism guarantees that the features that listen to
+	 * the {@link module:engine/model/model~Model#event:_change model's change event} will operate on a correct model state.
+	 *
+	 * An execution of a feature may lead to an incorrect document tree state. The callbacks are used to fix the document tree after
+	 * it has changed. Post-fixers are fired just after all changes from the outermost change block were applied but
+	 * before the {@link module:engine/model/document~Document#event:change change event} is fired. If a post-fixer callback made
+	 * a change, it should return `true`. When this happens, all post-fixers are fired again to check if something else should
+	 * not be fixed in the new document tree state.
+	 *
+	 * As a parameter, a post-fixer callback receives a {@link module:engine/model/writer~Writer writer} instance connected with the
+	 * executed changes block. Thanks to that, all changes done by the callback will be added to the same
+	 * {@link module:engine/model/batch~Batch batch} (and undo step) as the original changes. This makes post-fixer changes transparent
+	 * for the user.
+	 *
+	 * An example of a post-fixer is a callback that checks if all the data were removed from the editor. If so, the
+	 * callback should add an empty paragraph so that the editor is never empty:
+	 *
+	 *		document.registerPostFixer( writer => {
+	 *			const changes = document.differ.getChanges();
+	 *
+	 *			// Check if the changes lead to an empty root in the editor.
+	 *			for ( const entry of changes ) {
+	 *				if ( entry.type == 'remove' && entry.position.root.isEmpty ) {
+	 *					writer.insertElement( 'paragraph', entry.position.root, 0 );
+	 *
+	 *					// It is fine to return early, even if multiple roots would need to be fixed.
+	 *					// All post-fixers will be fired again, so if there are more empty roots, those will be fixed, too.
+	 *					return true;
+	 *				}
+	 *			}
+	 *		} );
+	 *
+	 * @param {Function} postFixer
+	 */
+	registerPostFixer( postFixer ) {
+		this._postFixers.add( postFixer );
+	}
+
+	/**
+	 * Performs post-fixer loops. Executes post-fixer callbacks as long as none of them has done any changes to the model.
+	 *
+	 * @protected
+	 */
+	_callPostFixers( writer ) {
+		let wasFixed = false;
+
+		do {
+			for ( const callback of this._postFixers ) {
+				wasFixed = callback( writer );
+
+				if ( wasFixed ) {
+					break;
+				}
+			}
+		} while ( wasFixed );
 	}
 }
 

--- a/src/view/placeholder.js
+++ b/src/view/placeholder.js
@@ -103,9 +103,11 @@ function updateSinglePlaceholder( view, element, checkFunction ) {
 
 	// If checkFunction is provided and returns false - remove placeholder.
 	if ( checkFunction && !checkFunction() ) {
-		view.change( writer => {
-			writer.removeClass( 'ck-placeholder', element );
-		} );
+		if ( element.hasClass( 'ck-placeholder' ) ) {
+			view.change( writer => {
+				writer.removeClass( 'ck-placeholder', element );
+			} );
+		}
 
 		return;
 	}
@@ -116,21 +118,27 @@ function updateSinglePlaceholder( view, element, checkFunction ) {
 
 	// If element is empty and editor is blurred.
 	if ( !document.isFocused && isEmptyish ) {
-		view.change( writer => {
-			writer.addClass( 'ck-placeholder', element );
-		} );
+		if ( !element.hasClass( 'ck-placeholder' ) ) {
+			view.change( writer => {
+				writer.addClass( 'ck-placeholder', element );
+			} );
+		}
 
 		return;
 	}
 
 	// It there are no child elements and selection is not placed inside element.
 	if ( isEmptyish && anchor && anchor.parent !== element ) {
-		view.change( writer => {
-			writer.addClass( 'ck-placeholder', element );
-		} );
+		if ( !element.hasClass( 'ck-placeholder' ) ) {
+			view.change( writer => {
+				writer.addClass( 'ck-placeholder', element );
+			} );
+		}
 	} else {
-		view.change( writer => {
-			writer.removeClass( 'ck-placeholder', element );
-		} );
+		if ( element.hasClass( 'ck-placeholder' ) ) {
+			view.change( writer => {
+				writer.removeClass( 'ck-placeholder', element );
+			} );
+		}
 	}
 }

--- a/src/view/placeholder.js
+++ b/src/view/placeholder.js
@@ -16,6 +16,7 @@ const documentPlaceholders = new WeakMap();
  * Attaches placeholder to provided element and updates it's visibility. To change placeholder simply call this method
  * once again with new parameters.
  *
+ * @param {module:engine/view/view~View} view View controller.
  * @param {module:engine/view/element~Element} element Element to attach placeholder to.
  * @param {String} placeholderText Placeholder text to use.
  * @param {Function} [checkFunction] If provided it will be called before checking if placeholder should be displayed.
@@ -61,7 +62,8 @@ export function detachPlaceholder( view, element ) {
 // Updates all placeholders of given document.
 //
 // @private
-// @param {module:engine/view/view~View} view
+// @param {module:engine/view/document~Document} view
+// @param {module:engine/view/writer~Writer} writer
 function updateAllPlaceholders( document, writer ) {
 	const placeholders = documentPlaceholders.get( document );
 	let changed = false;
@@ -78,9 +80,9 @@ function updateAllPlaceholders( document, writer ) {
 // Updates placeholder class of given element.
 //
 // @private
-// @param {module:engine/view/view~View} view
+// @param {module:engine/view/writer~Writer} writer
 // @param {module:engine/view/element~Element} element
-// @param {Function} checkFunction
+// @param {Object} info
 function updateSinglePlaceholder( writer, element, info ) {
 	const document = element.document;
 	const text = info.placeholderText;

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -319,7 +319,19 @@ export default class View {
 	change( callback ) {
 		if ( this._renderingInProgress || this._postFixersInProgress ) {
 			// TODO: better description
-			throw new CKEditorError( 'incorrect-view-change' );
+			/**
+			 * Thrown when there is an attempt to make changes to the view tree when it is in incorrect state. This may
+			 * cause some unexpected behaviour and inconsistency between the DOM and the view.
+			 * This may be caused by:
+			 *   * calling {@link #change} or {@link #render} during rendering process,
+			 *   * calling {@link #change} or {@link #render} inside of
+			 *   {@link module:engine/view/document~Document#registerPostFixer post fixer function}.
+			 */
+			throw new CKEditorError(
+				'cannot-change-view-tree: ' +
+				'Attempting to make changes to the view when it is in incorrect state: rendering or post fixers are in progress. ' +
+				'This may cause some unexpected behaviour and inconsistency between the DOM and the view.'
+			);
 		}
 
 		// Recursive call to view.change() method - execute listener immediately.
@@ -380,13 +392,14 @@ export default class View {
 	}
 
 	/**
-	 * TODO: fix description
-	 * Fired after a topmost {@link module:engine/view/view~View#change change block} is finished and the DOM rendering has
-	 * been executed.
+	 * Fired after a topmost {@link module:engine/view/view~View#change change block} and all
+	 * {@link module:engine/view/document~Document#registerPostFixer post fixers} are executed.
 	 *
-	 * Actual rendering is performed on 'low' priority. This means that all listeners on 'normal' and above priorities
-	 * will be executed after changes made to view tree but before rendering to the DOM. Use `low` priority for callbacks that
-	 * should be executed after rendering to the DOM.
+	 * Actual rendering is performed as a first listener on 'normal' priority.
+	 *
+	 *		view.on( 'render', () => {
+	 *			// Rendering to the DOM is complete.
+	 *		} );
 	 *
 	 * @event module:engine/view/view~View#event:render
 	 */

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -318,7 +318,6 @@ export default class View {
 	 */
 	change( callback ) {
 		if ( this._renderingInProgress || this._postFixersInProgress ) {
-			// TODO: better description
 			/**
 			 * Thrown when there is an attempt to make changes to the view tree when it is in incorrect state. This may
 			 * cause some unexpected behaviour and inconsistency between the DOM and the view.

--- a/tests/view/document.js
+++ b/tests/view/document.js
@@ -58,4 +58,37 @@ describe( 'Document', () => {
 			expect( viewDocument.getRoot( 'not-existing' ) ).to.null;
 		} );
 	} );
+
+	describe( 'post fixers', () => {
+		it( 'should add a callback that is called on _callPostFixers', () => {
+			const spy1 = sinon.spy();
+			const spy2 = sinon.spy();
+			const writerMock = {};
+
+			viewDocument.registerPostFixer( spy1 );
+			viewDocument.registerPostFixer( spy2 );
+
+			sinon.assert.notCalled( spy1 );
+			sinon.assert.notCalled( spy2 );
+			viewDocument._callPostFixers( writerMock );
+			sinon.assert.calledOnce( spy1 );
+			sinon.assert.calledOnce( spy2 );
+			sinon.assert.calledWithExactly( spy1, writerMock );
+			sinon.assert.calledWithExactly( spy2, writerMock );
+		} );
+
+		it( 'should call post fixer until all returns false', () => {
+			let calls = 0;
+
+			const spy1 = sinon.spy( () => calls++ < 2 );
+			const spy2 = sinon.spy( () => calls++ < 2 );
+
+			viewDocument.registerPostFixer( spy1 );
+			viewDocument.registerPostFixer( spy2 );
+
+			viewDocument._callPostFixers();
+
+			expect( calls ).to.equal( 4 );
+		} );
+	} );
 } );

--- a/tests/view/observer/focusobserver.js
+++ b/tests/view/observer/focusobserver.js
@@ -170,12 +170,12 @@ describe( 'FocusObserver', () => {
 			view.render();
 
 			viewDocument.on( 'selectionChange', selectionChangeSpy );
-			view.on( 'render', renderSpy, { priority: 'low' } );
+			view.on( 'render', renderSpy );
 
 			view.on( 'render', () => {
 				sinon.assert.callOrder( selectionChangeSpy, renderSpy );
 				done();
-			}, { priority: 'low' } );
+			} );
 
 			// Mock selectionchange event after focus event. Render called by focus observer should be fired after
 			// async selection change.
@@ -192,14 +192,14 @@ describe( 'FocusObserver', () => {
 			const domEditable = domRoot.childNodes[ 0 ];
 
 			viewDocument.on( 'selectionChange', selectionChangeSpy );
-			view.on( 'render', renderSpy, { priority: 'low' } );
+			view.on( 'render', renderSpy );
 
 			view.on( 'render', () => {
 				sinon.assert.notCalled( selectionChangeSpy );
 				sinon.assert.called( renderSpy );
 
 				done();
-			}, { priority: 'low' } );
+			} );
 
 			observer.onDomEvent( { type: 'focus', target: domEditable } );
 		} );

--- a/tests/view/placeholder.js
+++ b/tests/view/placeholder.js
@@ -74,12 +74,17 @@ describe( 'placeholder', () => {
 		it( 'use check function if one is provided', () => {
 			setData( view, '<div></div><div>{another div}</div>' );
 			const element = viewRoot.getChild( 0 );
-			const spy = sinon.spy( () => false );
+			let result = true;
+			const spy = sinon.spy( () => result );
 
 			attachPlaceholder( view, element, 'foo bar baz', spy );
 
 			sinon.assert.called( spy );
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
+
+			result = false;
+			view.render();
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -184,6 +189,16 @@ describe( 'placeholder', () => {
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
+
+			detachPlaceholder( view, element );
+
+			expect( element.hasAttribute( 'data-placeholder' ) ).to.be.false;
+			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
+		} );
+
+		it( 'should not blow up when called on element without placeholder', () => {
+			setData( view, '<div></div><div>{another div}</div>' );
+			const element = viewRoot.getChild( 0 );
 
 			detachPlaceholder( view, element );
 

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -584,6 +584,36 @@ describe( 'view', () => {
 				sinon.assert.calledTwice( spy );
 			} );
 
+			it( 'should call second render after the first is done', () => {
+				let called = false;
+				const order = [];
+
+				const lowSpy = sinon.spy( () => {
+					order.push( 'low1' );
+
+					// Prevent infinite loop.
+					if ( !called ) {
+						called = true;
+						view.render();
+					}
+
+					order.push( 'low2' );
+				} );
+
+				const lowestSpy = sinon.spy( () => {
+					order.push( 'lowest' );
+				} );
+
+				view.on( 'render', lowSpy, { priority: 'low' } );
+				view.on( 'render', lowestSpy, { priority: 'lowest' } );
+
+				view.render();
+				sinon.assert.calledTwice( lowSpy );
+				sinon.assert.calledTwice( lowestSpy );
+
+				expect( order ).to.deep.equal( [ 'low1', 'low2', 'lowest', 'low1', 'low2', 'lowest' ] );
+			} );
+
 			it( 'should NOT throw when someone tries to call change() before rendering', () => {
 				view.on( 'render', () => {
 					expect( () => view.change( () => {} ) ).not.to.throw( CKEditorError, /^applying-view-changes-on-rendering/ );

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -550,20 +550,38 @@ describe( 'view', () => {
 				domDiv.remove();
 			} );
 
-			it( 'should throw when someone tries to call change() after rendering is finished but still in change block', () => {
-				view.on( 'render', () => {
-					expect( () => view.change( () => {} ) ).to.throw( CKEditorError, /^applying-view-changes-on-rendering/ );
-				}, { priority: 'low' } );
+			it( 'should create separate render event when change() called on low priority', () => {
+				let called = false;
+
+				const spy = sinon.spy( () => {
+					// Prevent infinite loop.
+					if ( !called ) {
+						called = true;
+						view.change( () => {} );
+					}
+				} );
+
+				view.on( 'render', spy, { priority: 'low' } );
 
 				view.change( () => {} );
+				sinon.assert.calledTwice( spy );
 			} );
 
-			it( 'should throw when someone tries to call render() after rendering is finished but still in change block', () => {
-				view.on( 'render', () => {
-					expect( () => view.render() ).to.throw( CKEditorError, /^applying-view-changes-on-rendering/ );
-				}, { priority: 'low' } );
+			it( 'should create separate render event when render() called on low priority', () => {
+				let called = false;
 
-				view.change( () => {} );
+				const spy = sinon.spy( () => {
+					// Prevent infinite loop.
+					if ( !called ) {
+						called = true;
+						view.render();
+					}
+				} );
+
+				view.on( 'render', spy, { priority: 'low' } );
+
+				view.render();
+				sinon.assert.calledTwice( spy );
 			} );
 
 			it( 'should NOT throw when someone tries to call change() before rendering', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: View render() and change() methods create new change block when called after rendering.
 Closes #1312.

---
Please close together with depending branch: [ckeditor5-image:t/ckeditor5-engine/1312](https://github.com/ckeditor/ckeditor5-image/tree/t/ckeditor5-engine/1312).