### PR TITLE
Moved consumable parameter to conversionApi parameter in downcast

### DIFF
--- a/src/conversion/downcast-selection-converters.js
+++ b/src/conversion/downcast-selection-converters.js
@@ -21,14 +21,14 @@
  * @returns {Function} Selection converter.
  */
 export function convertRangeSelection() {
-	return ( evt, data, consumable, conversionApi ) => {
+	return ( evt, data, conversionApi ) => {
 		const selection = data.selection;
 
 		if ( selection.isCollapsed ) {
 			return;
 		}
 
-		if ( !consumable.consume( selection, 'selection' ) ) {
+		if ( !conversionApi.consumable.consume( selection, 'selection' ) ) {
 			return;
 		}
 
@@ -66,14 +66,14 @@ export function convertRangeSelection() {
  * @returns {Function} Selection converter.
  */
 export function convertCollapsedSelection() {
-	return ( evt, data, consumable, conversionApi ) => {
+	return ( evt, data, conversionApi ) => {
 		const selection = data.selection;
 
 		if ( !selection.isCollapsed ) {
 			return;
 		}
 
-		if ( !consumable.consume( selection, 'selection' ) ) {
+		if ( !conversionApi.consumable.consume( selection, 'selection' ) ) {
 			return;
 		}
 
@@ -111,7 +111,7 @@ export function convertCollapsedSelection() {
  * @returns {Function} Selection converter.
  */
 export function clearAttributes() {
-	return ( evt, data, consumable, conversionApi ) => {
+	return ( evt, data, conversionApi ) => {
 		const viewWriter = conversionApi.writer;
 		const viewSelection = viewWriter.document.selection;
 
@@ -133,5 +133,5 @@ export function clearAttributes() {
  * {@link module:engine/model/selection~Selection model selection} conversion.
  */
 export function clearFakeSelection() {
-	return ( evt, data, consumable, conversionApi ) => conversionApi.writer.setFakeSelection( false );
+	return ( evt, data, conversionApi ) => conversionApi.writer.setFakeSelection( false );
 }

--- a/src/conversion/downcastdispatcher.js
+++ b/src/conversion/downcastdispatcher.js
@@ -156,7 +156,7 @@ export default class DowncastDispatcher {
 		this.conversionApi.writer = writer;
 
 		// Create a list of things that can be consumed, consisting of nodes and their attributes.
-		const consumable = this._createInsertConsumable( range );
+		this.conversionApi.consumable = this._createInsertConsumable( range );
 
 		// Fire a separate insert event for each node and text fragment contained in the range.
 		for ( const value of range ) {
@@ -167,7 +167,7 @@ export default class DowncastDispatcher {
 				range: itemRange
 			};
 
-			this._testAndFire( 'insert', data, consumable );
+			this._testAndFire( 'insert', data );
 
 			// Fire a separate addAttribute event for each attribute that was set on inserted items.
 			// This is important because most attributes converters will listen only to add/change/removeAttribute events.
@@ -177,7 +177,7 @@ export default class DowncastDispatcher {
 				data.attributeOldValue = null;
 				data.attributeNewValue = item.getAttribute( key );
 
-				this._testAndFire( `attribute:${ key }`, data, consumable );
+				this._testAndFire( `attribute:${ key }`, data );
 			}
 		}
 
@@ -216,7 +216,7 @@ export default class DowncastDispatcher {
 		this.conversionApi.writer = writer;
 
 		// Create a list with attributes to consume.
-		const consumable = this._createConsumableForRange( range, `attribute:${ key }` );
+		this.conversionApi.consumable = this._createConsumableForRange( range, `attribute:${ key }` );
 
 		// Create a separate attribute event for each node in the range.
 		for ( const value of range ) {
@@ -230,7 +230,7 @@ export default class DowncastDispatcher {
 				attributeNewValue: newValue
 			};
 
-			this._testAndFire( `attribute:${ key }`, data, consumable );
+			this._testAndFire( `attribute:${ key }`, data );
 		}
 
 		this._clearConversionApi();
@@ -441,17 +441,14 @@ export default class DowncastDispatcher {
 	 * @fires attribute
 	 * @param {String} type Event type.
 	 * @param {Object} data Event data.
-	 * @param {module:engine/conversion/modelconsumable~ModelConsumable} consumable Values to consume.
 	 */
-	_testAndFire( type, data, consumable ) {
-		if ( !consumable.test( data.item, type ) ) {
+	_testAndFire( type, data ) {
+		if ( !this.conversionApi.consumable.test( data.item, type ) ) {
 			// Do not fire event if the item was consumed.
 			return;
 		}
 
 		const name = data.item.name || '$text';
-
-		this.conversionApi.consumable = consumable;
 
 		this.fire( type + ':' + name, data, this.conversionApi );
 	}

--- a/src/conversion/modelconsumable.js
+++ b/src/conversion/modelconsumable.js
@@ -53,9 +53,9 @@ import TextProxy from '../model/textproxy';
  *		//   ├─ <img />
  *		//   └─ <caption>
  *		//       └─ foo
- *		modelConversionDispatcher.on( 'insert:image', ( evt, data, consumable, conversionApi ) => {
+ *		modelConversionDispatcher.on( 'insert:image', ( evt, data, conversionApi ) => {
  *			// First, consume the `image` element.
- *			consumable.consume( data.item, 'insert' );
+ *			conversionApi.consumable.consume( data.item, 'insert' );
  *
  *			// Just create normal image element for the view.
  *			// Maybe it will be "decorated" later.
@@ -69,7 +69,7 @@ import TextProxy from '../model/textproxy';
  *				// `modelCaption` insertion change is consumed from consumable values.
  *				// It will not be converted by other converters, but it's children (probably some text) will be.
  *				// Through mapping, converters for text will know where to insert contents of `modelCaption`.
- *				if ( consumable.consume( modelCaption, 'insert' ) ) {
+ *				if ( conversionApi.consumable.consume( modelCaption, 'insert' ) ) {
  *					const viewCaption = new ViewElement( 'figcaption' );
  *
  *					const viewImageHolder = new ViewElement( 'figure', null, [ viewImage, viewCaption ] );

--- a/src/dev-utils/model.js
+++ b/src/dev-utils/model.js
@@ -209,7 +209,7 @@ export function stringify( node, selectionOrPositionOrRange = null ) {
 	mapper.bindElements( node.root, viewRoot );
 
 	downcastDispatcher.on( 'insert:$text', insertText() );
-	downcastDispatcher.on( 'attribute', ( evt, data, consumable, conversionApi ) => {
+	downcastDispatcher.on( 'attribute', ( evt, data, conversionApi ) => {
 		if ( data.item instanceof ModelSelection || data.item instanceof DocumentSelection || data.item.is( 'textProxy' ) ) {
 			const converter = wrap( ( modelAttributeValue, viewWriter ) => {
 				return viewWriter.createAttributeElement(
@@ -218,7 +218,7 @@ export function stringify( node, selectionOrPositionOrRange = null ) {
 				);
 			} );
 
-			converter( evt, data, consumable, conversionApi );
+			converter( evt, data, conversionApi );
 		}
 	} );
 	downcastDispatcher.on( 'insert', insertElement( modelItem => {

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -579,8 +579,8 @@ describe( 'downcast-converters', () => {
 		} );
 
 		it( 'should be possible to override it', () => {
-			dispatcher.on( 'insert:$text', ( evt, data, consumable ) => {
-				consumable.consume( data.item, 'insert' );
+			dispatcher.on( 'insert:$text', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.item, 'insert' );
 			}, { priority: 'high' } );
 
 			model.change( writer => {
@@ -675,8 +675,8 @@ describe( 'downcast-converters', () => {
 		it( 'should be possible to override setAttribute', () => {
 			const modelElement = new ModelElement( 'paragraph', { class: 'foo' }, new ModelText( 'foobar' ) );
 
-			dispatcher.on( 'attribute:class', ( evt, data, consumable ) => {
-				consumable.consume( data.item, 'attribute:class' );
+			dispatcher.on( 'attribute:class', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.item, 'attribute:class' );
 			}, { priority: 'high' } );
 
 			model.change( writer => {
@@ -861,8 +861,8 @@ describe( 'downcast-converters', () => {
 					( data, viewWriter ) => viewWriter.createUIElement( 'span', { 'class': 'marker' } ) )
 				);
 
-				dispatcher.on( 'addMarker:marker', ( evt, data, consumable ) => {
-					consumable.consume( data.markerRange, 'addMarker:marker' );
+				dispatcher.on( 'addMarker:marker', ( evt, data, conversionApi ) => {
+					conversionApi.consumable.consume( data.markerRange, 'addMarker:marker' );
 				}, { priority: 'high' } );
 
 				model.change( writer => {
@@ -969,8 +969,8 @@ describe( 'downcast-converters', () => {
 				sinon.spy( dispatcher, 'fire' );
 
 				dispatcher.on( 'addMarker:marker', insertUIElement( creator ) );
-				dispatcher.on( 'addMarker:marker', ( evt, data, consumable ) => {
-					consumable.consume( data.item, 'addMarker:marker' );
+				dispatcher.on( 'addMarker:marker', ( evt, data, conversionApi ) => {
+					conversionApi.consumable.consume( data.item, 'addMarker:marker' );
 				}, { priority: 'high' } );
 
 				model.change( writer => {

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -152,8 +152,8 @@ describe( 'downcast-selection-converters', () => {
 			it( 'consumes consumable values properly', () => {
 				// Add callback that will fire before default ones.
 				// This should prevent default callback doing anything.
-				dispatcher.on( 'selection', ( evt, data, consumable ) => {
-					expect( consumable.consume( data.selection, 'selection' ) ).to.be.true;
+				dispatcher.on( 'selection', ( evt, data, conversionApi ) => {
+					expect( conversionApi.consumable.consume( data.selection, 'selection' ) ).to.be.true;
 				}, { priority: 'high' } );
 
 				// Similar test case as the first in this suite.
@@ -371,12 +371,12 @@ describe( 'downcast-selection-converters', () => {
 			it( 'consumes consumable values properly', () => {
 				// Add callbacks that will fire before default ones.
 				// This should prevent default callbacks doing anything.
-				dispatcher.on( 'selection', ( evt, data, consumable ) => {
-					expect( consumable.consume( data.selection, 'selection' ) ).to.be.true;
+				dispatcher.on( 'selection', ( evt, data, conversionApi ) => {
+					expect( conversionApi.consumable.consume( data.selection, 'selection' ) ).to.be.true;
 				}, { priority: 'high' } );
 
-				dispatcher.on( 'attribute:bold', ( evt, data, consumable ) => {
-					expect( consumable.consume( data.item, 'attribute:bold' ) ).to.be.true;
+				dispatcher.on( 'attribute:bold', ( evt, data, conversionApi ) => {
+					expect( conversionApi.consumable.consume( data.item, 'attribute:bold' ) ).to.be.true;
 				}, { priority: 'high' } );
 
 				// Similar test case as above.
@@ -509,10 +509,10 @@ describe( 'downcast-selection-converters', () => {
 			dispatcher.on( 'insert:td', tableConverter );
 
 			// Special converter for table cells.
-			dispatcher.on( 'selection', ( evt, data, consumable, conversionApi ) => {
+			dispatcher.on( 'selection', ( evt, data, conversionApi ) => {
 				const selection = data.selection;
 
-				if ( !consumable.test( selection, 'selection' ) || selection.isCollapsed ) {
+				if ( !conversionApi.consumable.test( selection, 'selection' ) || selection.isCollapsed ) {
 					return;
 				}
 
@@ -520,7 +520,7 @@ describe( 'downcast-selection-converters', () => {
 					const node = range.start.nodeAfter;
 
 					if ( node == range.end.nodeBefore && node instanceof ModelElement && node.name == 'td' ) {
-						consumable.consume( selection, 'selection' );
+						conversionApi.consumable.consume( selection, 'selection' );
 
 						const viewNode = conversionApi.mapper.toViewElement( node );
 						conversionApi.writer.addClass( 'selected', viewNode );

--- a/tests/conversion/downcastdispatcher.js
+++ b/tests/conversion/downcastdispatcher.js
@@ -163,7 +163,7 @@ describe( 'DowncastDispatcher', () => {
 			const loggedEvents = [];
 
 			// We will check everything connected with insert event:
-			dispatcher.on( 'insert', ( evt, data, consumable ) => {
+			dispatcher.on( 'insert', ( evt, data, conversionApi ) => {
 				// Check if the item is correct.
 				const itemId = data.item.name ? data.item.name : '$text:' + data.item.data;
 				// Check if the range is correct.
@@ -174,11 +174,11 @@ describe( 'DowncastDispatcher', () => {
 				// Check if the event name is correct.
 				expect( evt.name ).to.equal( 'insert:' + ( data.item.name || '$text' ) );
 				// Check if model consumable is correct.
-				expect( consumable.consume( data.item, 'insert' ) ).to.be.true;
+				expect( conversionApi.consumable.consume( data.item, 'insert' ) ).to.be.true;
 			} );
 
 			// Same here.
-			dispatcher.on( 'attribute', ( evt, data, consumable ) => {
+			dispatcher.on( 'attribute', ( evt, data, conversionApi ) => {
 				const itemId = data.item.name ? data.item.name : '$text:' + data.item.data;
 				const key = data.attributeKey;
 				const value = data.attributeNewValue;
@@ -187,7 +187,7 @@ describe( 'DowncastDispatcher', () => {
 				loggedEvents.push( log );
 
 				expect( evt.name ).to.equal( 'attribute:' + key + ':' + ( data.item.name || '$text' ) );
-				expect( consumable.consume( data.item, 'attribute:' + key ) ).to.be.true;
+				expect( conversionApi.consumable.consume( data.item, 'attribute:' + key ) ).to.be.true;
 			} );
 
 			dispatcher.convertInsert( range );
@@ -214,9 +214,9 @@ describe( 'DowncastDispatcher', () => {
 
 			sinon.spy( dispatcher, 'fire' );
 
-			dispatcher.on( 'insert:image', ( evt, data, consumable ) => {
-				consumable.consume( data.item.getChild( 0 ), 'insert' );
-				consumable.consume( data.item, 'attribute:bold' );
+			dispatcher.on( 'insert:image', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.item.getChild( 0 ), 'insert' );
+				conversionApi.consumable.consume( data.item, 'attribute:bold' );
 			} );
 
 			const range = ModelRange.createIn( root );
@@ -278,10 +278,10 @@ describe( 'DowncastDispatcher', () => {
 				writer.setAttribute( 'italic', true, ModelRange.createFromParentsAndOffsets( root, 4, root, 5 ) );
 			} );
 
-			dispatcher.on( 'selection', ( evt, data, consumable ) => {
-				expect( consumable.test( data.selection, 'selection' ) ).to.be.true;
-				expect( consumable.test( data.selection, 'attribute:bold' ) ).to.be.true;
-				expect( consumable.test( data.selection, 'attribute:italic' ) ).to.be.null;
+			dispatcher.on( 'selection', ( evt, data, conversionApi ) => {
+				expect( conversionApi.consumable.test( data.selection, 'selection' ) ).to.be.true;
+				expect( conversionApi.consumable.test( data.selection, 'attribute:bold' ) ).to.be.true;
+				expect( conversionApi.consumable.test( data.selection, 'attribute:italic' ) ).to.be.null;
 			} );
 
 			dispatcher.convertSelection( doc.selection, model.markers, [] );
@@ -331,8 +331,8 @@ describe( 'DowncastDispatcher', () => {
 				writer.setAttribute( 'italic', true, ModelRange.createFromParentsAndOffsets( root, 4, root, 5 ) );
 			} );
 
-			dispatcher.on( 'selection', ( evt, data, consumable ) => {
-				consumable.consume( data.selection, 'attribute:bold' );
+			dispatcher.on( 'selection', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.selection, 'attribute:bold' );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );
@@ -423,8 +423,8 @@ describe( 'DowncastDispatcher', () => {
 
 			sinon.spy( dispatcher, 'fire' );
 
-			dispatcher.on( 'addMarker:foo', ( evt, data, consumable ) => {
-				consumable.consume( data.item, 'addMarker:bar' );
+			dispatcher.on( 'addMarker:foo', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.item, 'addMarker:bar' );
 			} );
 
 			const markers = Array.from( model.markers.getMarkersAtPosition( doc.selection.getFirstPosition() ) );
@@ -478,10 +478,10 @@ describe( 'DowncastDispatcher', () => {
 
 			const items = [];
 
-			dispatcher.on( 'addMarker:name', ( evt, data, consumable ) => {
+			dispatcher.on( 'addMarker:name', ( evt, data, conversionApi ) => {
 				expect( data.markerName ).to.equal( 'name' );
 				expect( data.markerRange.isEqual( range ) ).to.be.true;
-				expect( consumable.test( data.item, 'addMarker:name' ) );
+				expect( conversionApi.consumable.test( data.item, 'addMarker:name' ) );
 
 				items.push( data.item );
 			} );

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -49,7 +49,7 @@ class FancyWidget extends Plugin {
 
 		conversion.for( 'editingDowncast' ).add( downcastElementToElement( {
 			model: 'fancywidget',
-			view: ( modelItem, consumable, conversionApi ) => {
+			view: ( modelItem, conversionApi ) => {
 				const viewWriter = conversionApi.writer;
 				const widgetElement = viewWriter.createContainerElement( 'figure', { class: 'fancy-widget' } );
 				viewWriter.insert( ViewPosition.createAt( widgetElement ), viewWriter.createText( 'widget' ) );

--- a/tests/manual/nestededitable.js
+++ b/tests/manual/nestededitable.js
@@ -58,7 +58,7 @@ class NestedEditable extends Plugin {
 
 		editor.conversion.for( 'downcast' ).add( downcastElementToElement( {
 			model: 'figcaption',
-			view: ( modelItem, consumable, conversionApi ) => {
+			view: ( modelItem, conversionApi ) => {
 				const viewWriter = conversionApi.writer;
 				const element = viewWriter.createEditableElement( 'figcaption', { contenteditable: 'true' } );
 

--- a/tests/manual/tickets/ckeditor5-721/1.js
+++ b/tests/manual/tickets/ckeditor5-721/1.js
@@ -43,7 +43,7 @@ ClassicEditor
 		editor.conversion.for( 'downcast' )
 			.add( downcastElementToElement( {
 				model: 'widget',
-				view: ( modelItem, consumable, conversionApi ) => {
+				view: ( modelItem, conversionApi ) => {
 					const writer = conversionApi.writer;
 					const b = writer.createAttributeElement( 'b' );
 					const div = writer.createContainerElement( 'div' );
@@ -55,7 +55,7 @@ ClassicEditor
 			} ) )
 			.add( downcastElementToElement( {
 				model: 'nested',
-				view: ( item, consumable, api ) => api.writer.createEditableElement( 'figcaption', { contenteditable: true } )
+				view: ( item, api ) => api.writer.createEditableElement( 'figcaption', { contenteditable: true } )
 			} ) );
 
 		setData( editor.model,

--- a/tests/view/manual/uielement.js
+++ b/tests/view/manual/uielement.js
@@ -45,7 +45,7 @@ class UIElementTestPlugin extends Plugin {
 		const editing = editor.editing;
 
 		// Add some UIElement to each paragraph.
-		editing.downcastDispatcher.on( 'insert:paragraph', ( evt, data, consumable, conversionApi ) => {
+		editing.downcastDispatcher.on( 'insert:paragraph', ( evt, data, conversionApi ) => {
 			const viewP = conversionApi.mapper.toViewElement( data.item );
 			viewP.appendChildren( createEndingUIElement( conversionApi.writer ) );
 		}, { priority: 'lowest' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Moved `consumable` parameter to `conversionApi` parameter in downcast. Closes #1294. Closes #1261.