### PR TITLE
model.Writer#createText should throw when trying to create empty text node

### DIFF
--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -85,14 +85,25 @@ export default class Writer {
 	/**
 	 * Creates a new {@link module:engine/model/text~Text text node}.
 	 *
+	 * Throws `writer-create-text-empty-data` error, if `data` is not set or is an empty string.
+	 *
 	 *		writer.createText( 'foo' );
 	 *		writer.createText( 'foo', { 'bold': true } );
 	 *
-	 * @param {String} data Text data.
+	 * @param {String} data Text data. Cannot be an empty string.
 	 * @param {Object} [attributes] Text attributes.
 	 * @returns {module:engine/model/text~Text} Created text node.
 	 */
 	createText( data, attributes ) {
+		if ( !data || data == '' ) {
+			/**
+			 * Cannot create text node with empty data.
+			 *
+			 * @error writer-create-text-empty-data
+			 */
+			throw new CKEditorError( 'writer-create-text-empty-data: Cannot create text node with empty data.' );
+		}
+
 		return new Text( data, attributes );
 	}
 

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -60,6 +60,18 @@ describe( 'Writer', () => {
 
 			expect( Array.from( text.getAttributes() ) ).to.deep.equal( [ [ 'foo', 'bar' ], [ 'biz', 'baz' ] ] );
 		} );
+
+		it( 'should throw if data is not set', () => {
+			expect( () => {
+				createText();
+			} ).to.throw( CKEditorError, /writer-create-text-empty-data/ );
+		} );
+
+		it( 'should throw if data is empty', () => {
+			expect( () => {
+				createText( '' );
+			} ).to.throw( CKEditorError, /writer-create-text-empty-data/ );
+		} );
 	} );
 
 	describe( 'createElement()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `model.Writer#createText` should throw when trying to create empty text node. Closes #1320.

---

### Additional information

Related to https://github.com/ckeditor/ckeditor5-link/pull/170
