### PR TITLE
Prevent model.Writer from inserting empty text nodes

### DIFF
--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -156,6 +156,7 @@ export default class Writer {
 	insert( item, itemOrPosition, offset ) {
 		this._assertWriterUsedCorrectly();
 
+		// Empty text node should not be added to the model. See #1320.
 		if ( item instanceof Text && item.data == '' ) {
 			return;
 		}
@@ -226,10 +227,6 @@ export default class Writer {
 	 * third parameter is a {@link module:engine/model/item~Item model item}.
 	 */
 	insertText( text, attributes, itemOrPosition, offset ) {
-		if ( text == '' ) {
-			return;
-		}
-
 		if ( attributes instanceof DocumentFragment || attributes instanceof Element || attributes instanceof Position ) {
 			this.insert( this.createText( text ), attributes, itemOrPosition );
 		} else {

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -147,14 +147,18 @@ export default class Writer {
 	 * If you want to move {@link module:engine/model/range~Range range} instead of an
 	 * {@link module:engine/model/item~Item item} use {@link module:engine/model/writer~Writer#move move}.
 	 *
-	 * @param {module:engine/model/item~Item|module:engine/model/documentfragment~DocumentFragment} item Item or document
-	 * fragment to insert.
+	 * @param {module:engine/model/item~Item|module:engine/model/documentfragment~DocumentFragment|
+	 * Array.<module:engine/model/item~Item>} item Item, document fragment or an array of items to insert.
 	 * @param {module:engine/model/item~Item|module:engine/model/position~Position} itemOrPosition
 	 * @param {Number|'end'|'before'|'after'} [offset=0] Offset or one of the flags. Used only when
 	 * second parameter is a {@link module:engine/model/item~Item model item}.
 	 */
 	insert( item, itemOrPosition, offset ) {
 		this._assertWriterUsedCorrectly();
+
+		if ( item instanceof Text && item.data == '' ) {
+			return;
+		}
 
 		const position = Position.createAt( itemOrPosition, offset );
 
@@ -222,6 +226,10 @@ export default class Writer {
 	 * third parameter is a {@link module:engine/model/item~Item model item}.
 	 */
 	insertText( text, attributes, itemOrPosition, offset ) {
+		if ( text == '' ) {
+			return;
+		}
+
 		if ( attributes instanceof DocumentFragment || attributes instanceof Element || attributes instanceof Position ) {
 			this.insert( this.createText( text ), attributes, itemOrPosition );
 		} else {

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -159,6 +159,31 @@ describe( 'Writer', () => {
 			expect( Array.from( parent.getChildren() ) ).to.deep.equal( [ child1, child2, child3 ] );
 		} );
 
+		it( 'should insert an array of items', () => {
+			const parent = createDocumentFragment();
+			const child1 = createElement( 'child' );
+			const child2 = createElement( 'child' );
+			const child3 = createElement( 'child' );
+
+			const array = [ child2, child1, child3 ];
+
+			insert( array, parent );
+
+			expect( Array.from( parent.getChildren() ) ).to.deep.equal( array );
+		} );
+
+		it( 'should do nothing if empty text node is being inserted', () => {
+			const parent = createDocumentFragment();
+
+			model.enqueueChange( batch, writer => {
+				const text = writer.createText( '' );
+
+				writer.insert( text, parent );
+			} );
+
+			expect( parent.childCount ).to.equal( 0 );
+		} );
+
 		it( 'should create proper delta for inserting element', () => {
 			const parent = createDocumentFragment();
 			const element = createElement( 'child' );
@@ -439,6 +464,14 @@ describe( 'Writer', () => {
 			expect( parent.getChild( 0 ) ).to.instanceof( Element );
 			expect( parent.getChild( 1 ) ).to.instanceof( Text );
 			expect( parent.getChild( 2 ) ).to.instanceof( Element );
+		} );
+
+		it( 'should do nothing if text data is empty', () => {
+			const parent = createDocumentFragment();
+
+			insertText( '', parent );
+
+			expect( parent.childCount ).to.equal( 0 );
 		} );
 
 		it( 'should create proper delta', () => {

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -184,6 +184,37 @@ describe( 'Writer', () => {
 			expect( parent.childCount ).to.equal( 0 );
 		} );
 
+		it( 'should skip (normalize) an empty text node when inserting an array of text nodes', () => {
+			const parent = createDocumentFragment();
+
+			model.enqueueChange( batch, writer => {
+				const text1 = writer.createText( 'ab' );
+				const text2 = writer.createText( '' );
+				const text3 = writer.createText( 'cd' );
+
+				writer.insert( [ text1, text2, text3 ], parent );
+			} );
+
+			expect( parent.childCount ).to.equal( 1 );
+			expect( parent.getChild( 0 ).data ).to.equal( 'abcd' );
+		} );
+
+		it( 'should skip (normalize) an empty text node when inserting an array of text nodes (different attributes)', () => {
+			const parent = createDocumentFragment();
+
+			model.enqueueChange( batch, writer => {
+				const text1 = writer.createText( 'ab' );
+				const text2 = writer.createText( '' );
+				const text3 = writer.createText( 'cd', { bold: true } );
+
+				writer.insert( [ text1, text2, text3 ], parent );
+			} );
+
+			expect( parent.childCount ).to.equal( 2 );
+			expect( parent.getChild( 0 ).data ).to.equal( 'ab' );
+			expect( parent.getChild( 1 ).data ).to.equal( 'cd' );
+		} );
+
 		it( 'should create proper delta for inserting element', () => {
 			const parent = createDocumentFragment();
 			const element = createElement( 'child' );

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -215,6 +215,16 @@ describe( 'Writer', () => {
 			expect( parent.getChild( 1 ).data ).to.equal( 'cd' );
 		} );
 
+		it( 'should skip (normalize) an empty text node when inserting an array of text nodes (different attributes)', () => {
+			const parent = createDocumentFragment();
+
+			model.enqueueChange( batch, writer => {
+				writer.insert( [ writer.createText( '' ) ], parent );
+			} );
+
+			expect( parent.childCount ).to.equal( 0 );
+		} );
+
 		it( 'should create proper delta for inserting element', () => {
 			const parent = createDocumentFragment();
 			const element = createElement( 'child' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevent `model.Writer` from inserting empty text nodes. Closes #1320.

---

### Additional information

Alternative solution to: https://github.com/ckeditor/ckeditor5-engine/pull/1321