### PR TITLE
Writer#setSelection and Selection#setTo improvements

### DIFF
--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -20,8 +20,7 @@ import { convertSelectionChange } from '../conversion/upcast-selection-converter
 import {
 	convertRangeSelection,
 	convertCollapsedSelection,
-	clearAttributes,
-	clearFakeSelection
+	clearAttributes
 } from '../conversion/downcast-selection-converters';
 
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
@@ -95,7 +94,6 @@ export default class EditingController {
 
 		// Attach default model selection converters.
 		this.downcastDispatcher.on( 'selection', clearAttributes(), { priority: 'low' } );
-		this.downcastDispatcher.on( 'selection', clearFakeSelection(), { priority: 'low' } );
 		this.downcastDispatcher.on( 'selection', convertRangeSelection(), { priority: 'low' } );
 		this.downcastDispatcher.on( 'selection', convertCollapsedSelection(), { priority: 'low' } );
 

--- a/src/conversion/downcast-selection-converters.js
+++ b/src/conversion/downcast-selection-converters.js
@@ -127,11 +127,3 @@ export function clearAttributes() {
 		viewWriter.setSelection( null );
 	};
 }
-
-/**
- * Function factory, creates a converter that clears fake selection marking after the previous
- * {@link module:engine/model/selection~Selection model selection} conversion.
- */
-export function clearFakeSelection() {
-	return ( evt, data, conversionApi ) => conversionApi.writer.setFakeSelection( false );
-}

--- a/src/conversion/downcast-selection-converters.js
+++ b/src/conversion/downcast-selection-converters.js
@@ -39,7 +39,7 @@ export function convertRangeSelection() {
 			viewRanges.push( viewRange );
 		}
 
-		conversionApi.writer.setSelection( viewRanges, selection.isBackward );
+		conversionApi.writer.setSelection( viewRanges, { backward: selection.isBackward } );
 	};
 }
 

--- a/src/conversion/upcast-selection-converters.js
+++ b/src/conversion/upcast-selection-converters.js
@@ -37,7 +37,7 @@ export function convertSelectionChange( model, mapper ) {
 			ranges.push( mapper.toModelRange( viewRange ) );
 		}
 
-		modelSelection.setTo( ranges, viewSelection.isBackward );
+		modelSelection.setTo( ranges, { backward: viewSelection.isBackward } );
 
 		if ( !modelSelection.isEqual( model.document.selection ) ) {
 			model.change( writer => {

--- a/src/dev-utils/model.js
+++ b/src/dev-utils/model.js
@@ -131,7 +131,7 @@ export function setData( model, data, options = {} ) {
 				ranges.push( new ModelRange( start, end ) );
 			}
 
-			writer.setSelection( ranges, selection.isBackward );
+			writer.setSelection( ranges, { backward: selection.isBackward } );
 
 			if ( options.selectionAttributes ) {
 				writer.setSelectionAttribute( selection.getAttributes() );
@@ -326,7 +326,7 @@ export function parse( data, schema, options = {} ) {
 		}
 
 		// Create new selection.
-		selection = new ModelSelection( ranges, viewSelection.isBackward );
+		selection = new ModelSelection( ranges, { backward: viewSelection.isBackward } );
 
 		// Set attributes to selection if specified.
 		for ( const [ key, value ] of toMap( options.selectionAttributes || [] ) ) {

--- a/src/dev-utils/view.js
+++ b/src/dev-utils/view.js
@@ -340,7 +340,7 @@ export function parse( data, options = {} ) {
 
 	// When ranges are present - return object containing view, and selection.
 	if ( ranges.length ) {
-		const selection = new Selection( ranges, !!options.lastRangeBackward );
+		const selection = new Selection( ranges, { backward: !!options.lastRangeBackward } );
 
 		return {
 			view,

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -357,13 +357,12 @@ export default class DocumentSelection {
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|
 	 * module:engine/model/position~Position|module:engine/model/node~Node|
 	 * Iterable.<module:engine/model/range~Range>|module:engine/model/range~Range|null} selectable
-	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset]
-	 * @param {Boolean} [optionsOrPlaceOrOffset.backward]
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets place or offset of the selection.
 	 * @param {Object} [options]
-	 * @param {Boolean} [options.backward]
+	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 */
-	_setTo( selectable, optionsOrPlaceOrOffset, options ) {
-		this._selection.setTo( selectable, optionsOrPlaceOrOffset, options );
+	_setTo( selectable, placeOrOffset, options ) {
+		this._selection.setTo( selectable, placeOrOffset, options );
 	}
 
 	/**

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -348,19 +348,22 @@ export default class DocumentSelection {
 	/**
 	 * Sets this selection's ranges and direction to the specified location based on the given
 	 * {@link module:engine/model/selection~Selection selection}, {@link module:engine/model/position~Position position},
-	 * {@link module:engine/model/element~Element element}, {@link module:engine/model/position~Position position},
+	 * {@link module:engine/model/element~Node node}, {@link module:engine/model/position~Position position},
 	 * {@link module:engine/model/range~Range range}, an iterable of {@link module:engine/model/range~Range ranges} or null.
 	 * Should be used only within the {@link module:engine/model/writer~Writer#setSelection} method.
 	 *
 	 * @see module:engine/model/writer~Writer#setSelection
 	 * @protected
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|
-	 * module:engine/model/position~Position|module:engine/model/element~Element|
+	 * module:engine/model/position~Position|module:engine/model/node~Node|
 	 * Iterable.<module:engine/model/range~Range>|module:engine/model/range~Range|null} selectable
-	 * @param {Boolean|Number|'before'|'end'|'after'} [backwardSelectionOrOffset]
+	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset]
+	 * @param {Boolean} [optionsOrPlaceOrOffset.backward]
+	 * @param {Object} [options]
+	 * @param {Boolean} [options.backward]
 	 */
-	_setTo( selectable, backwardSelectionOrOffset ) {
-		this._selection.setTo( selectable, backwardSelectionOrOffset );
+	_setTo( selectable, optionsOrPlaceOrOffset, options ) {
+		this._selection.setTo( selectable, optionsOrPlaceOrOffset, options );
 	}
 
 	/**

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -634,8 +634,8 @@ class LiveSelection extends Selection {
 		return super.getLastRange() || this._document._getDefaultRange();
 	}
 
-	setTo( selectable, backwardSelectionOrOffset ) {
-		super.setTo( selectable, backwardSelectionOrOffset );
+	setTo( selectable, optionsOrPlaceOrOffset, options ) {
+		super.setTo( selectable, optionsOrPlaceOrOffset, options );
 		this._refreshAttributes();
 	}
 

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -36,11 +36,11 @@ export default class Selection {
 	 *
 	 *		// Creates selection at the given range.
 	 *		const range = new Range( start, end );
-	 *		const selection = new Selection( range, isBackwardSelection );
+	 *		const selection = new Selection( range, { backward } );
 	 *
 	 *		// Creates selection at the given ranges
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		const selection = new Selection( ranges, isBackwardSelection );
+	 *		const selection = new Selection( ranges, { backward } );
 	 *
 	 *		// Creates selection from the other selection.
 	 *		// Note: It doesn't copies selection attributes.
@@ -306,11 +306,11 @@ export default class Selection {
 	 *
 	 *		// Sets ranges from the given range.
 	 *		const range = new Range( start, end );
-	 *		selection.setTo( range, isBackwardSelection );
+	 *		selection.setTo( range, { backward } );
 	 *
 	 *		// Sets ranges from the iterable of ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		selection.setTo( ranges, isBackwardSelection );
+	 *		selection.setTo( ranges, { backward } );
 	 *
 	 *		// Sets ranges from the other selection.
 	 *		// Note: It doesn't copies selection attributes.
@@ -385,7 +385,7 @@ export default class Selection {
 			this._setRanges( [ range ], backward );
 		} else if ( isIterable( selectable ) ) {
 			// We assume that the selectable is an iterable of ranges.
-			this._setRanges( selectable, optionsOrPlaceOrOffset );
+			this._setRanges( selectable, optionsOrPlaceOrOffset && !!optionsOrPlaceOrOffset.backward );
 		} else {
 			/**
 			 * Cannot set selection to given place.

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -348,9 +348,9 @@ export default class Selection {
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|
 	 * module:engine/model/position~Position|module:engine/model/node~Node|
 	 * Iterable.<module:engine/model/range~Range>|module:engine/model/range~Range|null} selectable
-	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset]
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets place or offset of the selection.
 	 * @param {Object} [options]
-	 * @param {Boolean} [options.backward]
+	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 */
 	setTo( selectable, placeOrOffset, options ) {
 		if ( selectable === null ) {

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -56,20 +56,17 @@ export default class Selection {
 	 *		const position = new Position( root, path );
 	 *		const selection = new Selection( position );
 	 *
-	 * Creates a range inside an {@link module:engine/model/element~Element element} which starts before the first child of
- 	 * that element and ends after the last child of that element.
-	 *
-	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		const selection = new Selection( paragraph, 'in' );
-	 *
-	 * Creates a range on an {@link module:engine/model/item~Item item} which starts before the item and ends just after the item.
-	 *
-	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		const selection = new Selection( paragraph, 'on' );
-	 *
 	 * 		// Creates selection at the start position of the given element.
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		const selection = new Selection( paragraph, offset );
+	 *
+	 * 		// Creates a range inside an {@link module:engine/model/element~Element element} which starts before the
+	 * 		// first child of that element and ends after the last child of that element.
+	 *		const selection = new Selection( paragraph, 'in' );
+	 *
+	 * 		// Creates a range on an {@link module:engine/model/item~Item item} which starts before the item and ends
+	 * 		// just after the item.
+	 *		const selection = new Selection( paragraph, 'on' );
 	 *
 	 * `Selection`'s constructor allow passing additional options (`backward`) as the last argument.
 	 *

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -324,7 +324,7 @@ export default class Selection {
 	 *		const otherSelection = new Selection();
 	 *		selection.setTo( otherSelection );
 	 *
-	 * 		// Sets selection to the document selection.
+	 * 		// Sets selection to the given document selection.
 	 *		// Note: It doesn't copies selection attributes.
 	 *		const documentSelection = new DocumentSelection( doc );
 	 *		selection.setTo( documentSelection );
@@ -337,15 +337,15 @@ export default class Selection {
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, offset );
 	 *
-	 *		// Sets selection inside the node.
+	 *		// Sets selection inside the given  node.
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'in', { backward } );
 	 *
-	 *		// Sets selection on the node.
+	 *		// Sets selection on the given node.
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'on', { backward } );
 	 *
-	 * 		// Clears selection. Removes all ranges.
+	 * 		// Removes all selection's ranges.
 	 *		selection.setTo( null );
 	 *
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -333,16 +333,13 @@ export default class Selection {
 	 *		const position = new Position( root, path );
 	 *		selection.setTo( position );
 	 *
-	 * 		// Sets collapsed selection at the position of given node and offset.
-	 *		const paragraph = writer.createElement( 'paragraph' );
+	 * 		// Sets collapsed selection at the position of the given node and an offset.
 	 *		selection.setTo( paragraph, offset );
 	 *
 	 *		// Sets selection inside the given  node.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'in', { backward } );
 	 *
 	 *		// Sets selection on the given node.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'on', { backward } );
 	 *
 	 * 		// Removes all selection's ranges.

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -56,11 +56,11 @@ export default class Selection {
 	 *		const position = new Position( root, path );
 	 *		const selection = new Selection( position );
 	 *
-	 * 		// Creates selection inside the node.
+	 * 		// Creates selection inside the given node.
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'in', { backward } );
 	 *
-	 *		// Creates selection on the node.
+	 *		// Creates selection on the given node.
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'on', { backward } );
 	 *
@@ -71,9 +71,9 @@ export default class Selection {
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|
 	 * module:engine/model/position~Position|module:engine/model/element~Element|
 	 * Iterable.<module:engine/model/range~Range>|module:engine/model/range~Range|null} selectable
-	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset]
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets place or offset of the selection.
 	 * @param {Object} [options]
-	 * @param {Boolean} [options.backward]
+	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 */
 	constructor( selectable, placeOrOffset, options ) {
 		/**
@@ -336,7 +336,7 @@ export default class Selection {
 	 * 		// Sets collapsed selection at the position of the given node and an offset.
 	 *		selection.setTo( paragraph, offset );
 	 *
-	 *		// Sets selection inside the given  node.
+	 *		// Sets selection inside the given node.
 	 *		selection.setTo( paragraph, 'in', { backward } );
 	 *
 	 *		// Sets selection on the given node.

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -376,7 +376,7 @@ export default class Selection {
 				/**
 				 * Required second parameter when setting selection to node.
 				 *
-				 * @error
+				 * @error model-selection-setTo-required-second-parameter
 				 */
 				throw new CKEditorError(
 					'model-selection-setTo-required-second-parameter: Required second parameter when setting selection to node.' );

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -36,11 +36,11 @@ export default class Selection {
 	 *
 	 *		// Creates selection at the given range.
 	 *		const range = new Range( start, end );
-	 *		const selection = new Selection( range, { backward } );
+	 *		const selection = new Selection( range );
 	 *
 	 *		// Creates selection at the given ranges
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		const selection = new Selection( ranges, { backward } );
+	 *		const selection = new Selection( ranges );
 	 *
 	 *		// Creates selection from the other selection.
 	 *		// Note: It doesn't copies selection attributes.
@@ -56,17 +56,25 @@ export default class Selection {
 	 *		const position = new Position( root, path );
 	 *		const selection = new Selection( position );
 	 *
-	 * 		// Creates selection inside the given node.
-	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'in', { backward } );
+	 * Creates a range inside an {@link module:engine/model/element~Element element} which starts before the first child of
+ 	 * that element and ends after the last child of that element.
 	 *
-	 *		// Creates selection on the given node.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'on', { backward } );
+	 *		const selection = new Selection( paragraph, 'in' );
+	 *
+	 * Creates a range on an {@link module:engine/model/item~Item item} which starts before the item and ends just after the item.
+	 *
+	 *		const paragraph = writer.createElement( 'paragraph' );
+	 *		const selection = new Selection( paragraph, 'on' );
 	 *
 	 * 		// Creates selection at the start position of the given element.
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		const selection = new Selection( paragraph, offset );
+	 *
+	 * `Selection`'s constructor allow passing additional options (`backward`) as the last argument.
+	 *
+	 * 		// Creates backward selection.
+	 *		const selection = new Selection( range, { backward: true } );
 	 *
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|
 	 * module:engine/model/position~Position|module:engine/model/element~Element|
@@ -311,13 +319,16 @@ export default class Selection {
 	 * {@link module:engine/model/element~Element element}, {@link module:engine/model/position~Position position},
 	 * {@link module:engine/model/range~Range range}, an iterable of {@link module:engine/model/range~Range ranges} or null.
 	 *
+	 * 		// Removes all selection's ranges.
+	 *		selection.setTo( null );
+	 *
 	 *		// Sets selection to the given range.
 	 *		const range = new Range( start, end );
-	 *		selection.setTo( range, { backward } );
+	 *		selection.setTo( range );
 	 *
 	 *		// Sets selection to given ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		selection.setTo( ranges, { backward } );
+	 *		selection.setTo( ranges );
 	 *
 	 *		// Sets selection to other selection.
 	 *		// Note: It doesn't copies selection attributes.
@@ -336,14 +347,19 @@ export default class Selection {
 	 * 		// Sets collapsed selection at the position of the given node and an offset.
 	 *		selection.setTo( paragraph, offset );
 	 *
-	 *		// Sets selection inside the given node.
-	 *		selection.setTo( paragraph, 'in', { backward } );
+	 * Creates a range inside an {@link module:engine/model/element~Element element} which starts before the first child of
+ 	 * that element and ends after the last child of that element.
 	 *
-	 *		// Sets selection on the given node.
-	 *		selection.setTo( paragraph, 'on', { backward } );
+	 *		selection.setTo( paragraph, 'in' );
 	 *
-	 * 		// Removes all selection's ranges.
-	 *		selection.setTo( null );
+	 * Creates a range on an {@link module:engine/model/item~Item item} which starts before the item and ends just after the item.
+	 *
+	 *		selection.setTo( paragraph, 'on' );
+	 *
+	 * `Selection#setTo()`' method allow passing additional options (`backward`) as the last argument.
+	 *
+	 * 		// Sets backward selection.
+	 *		const selection = new Selection( range, { backward: true } );
 	 *
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|
 	 * module:engine/model/position~Position|module:engine/model/node~Node|

--- a/src/model/utils/deletecontent.js
+++ b/src/model/utils/deletecontent.js
@@ -194,9 +194,9 @@ function insertParagraph( writer, position, selection ) {
 	writer.insert( paragraph, position );
 
 	if ( selection instanceof DocumentSelection ) {
-		writer.setSelection( paragraph );
+		writer.setSelection( paragraph, 0 );
 	} else {
-		selection.setTo( paragraph );
+		selection.setTo( paragraph, 0 );
 	}
 }
 

--- a/src/model/utils/modifyselection.js
+++ b/src/model/utils/modifyselection.js
@@ -50,6 +50,7 @@ export default function modifySelection( model, selection, options = {} ) {
 	const unit = options.unit ? options.unit : 'character';
 
 	const focus = selection.focus;
+
 	const walker = new TreeWalker( {
 		boundaries: getSearchRange( focus, isForward ),
 		singleCharacters: true,

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -942,9 +942,9 @@ export default class Writer {
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|
 	 * module:engine/model/position~Position|module:engine/model/node~Node|
 	 * Iterable.<module:engine/model/range~Range>|module:engine/model/range~Range|null} selectable
-	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset]
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets place or offset of the selection.
 	 * @param {Object} [options]
-	 * @param {Boolean} [options.backward]
+	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 */
 	setSelection( selectable, placeOrOffset, options ) {
 		this._assertWriterUsedCorrectly();

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -907,11 +907,11 @@ export default class Writer {
 	 *
 	 *		// Sets selection to the given range.
 	 *		const range = new Range( start, end );
-	 *		writer.setSelection( range, { backward } );
+	 *		writer.setSelection( range );
 	 *
 	 *		// Sets selection to given ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		writer.setSelection( range, { backward } );
+	 *		writer.setSelection( range );
 	 *
 	 *		// Sets selection to other selection.
 	 *		const otherSelection = new Selection();
@@ -928,14 +928,22 @@ export default class Writer {
 	 * 		// Sets collapsed selection at the position of the given node and an offset.
 	 *		writer.setSelection( paragraph, offset );
 	 *
-	 *		// Sets selection inside the given node.
-	 *		writer.setSelection( paragraph, 'in', { backward } );
+	 * Creates a range inside an {@link module:engine/model/element~Element element} which starts before the first child of
+ 	 * that element and ends after the last child of that element.
 	 *
-	 *		// Sets selection on the given node.
-	 *		writer.setSelection( paragraph, 'on', { backward } );
+	 *		writer.setSelection( paragraph, 'in' );
+	 *
+	 * Creates a range on an {@link module:engine/model/item~Item item} which starts before the item and ends just after the item.
+	 *
+	 *		writer.setSelection( paragraph, 'on' );
 	 *
 	 * 		// Removes all selection's ranges.
 	 *		writer.setSelection( null );
+	 *
+	 * `Writer#setSelection()` allow passing additional options (`backward`) as the last argument.
+	 *
+	 * 		// Sets selection as backward.
+	 *		writer.setSelection( range, { backward: true } );
 	 *
 	 * Throws `writer-incorrect-use` error when the writer is used outside the `change()` block.
 	 *

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -926,15 +926,12 @@ export default class Writer {
 	 *		writer.setSelection( position );
 	 *
 	 * 		// Sets collapsed selection at the position of the given node and an offset.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		writer.setSelection( paragraph, offset );
 	 *
 	 *		// Sets selection inside the given node.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		writer.setSelection( paragraph, 'in', { backward } );
 	 *
 	 *		// Sets selection on the given node.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		writer.setSelection( paragraph, 'on', { backward } );
 	 *
 	 * 		// Removes all selection's ranges.

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -905,39 +905,39 @@ export default class Writer {
 	 * {@link module:engine/model/element~Node node}, {@link module:engine/model/position~Position position},
 	 * {@link module:engine/model/range~Range range}, an iterable of {@link module:engine/model/range~Range ranges} or null.
 	 *
-	 *		// Sets ranges from the given range.
+	 *		// Sets selection to the given range.
 	 *		const range = new Range( start, end );
 	 *		writer.setSelection( range, { backward } );
 	 *
-	 *		// Sets ranges from the iterable of ranges.
+	 *		// Sets selection to given ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
 	 *		writer.setSelection( range, { backward } );
 	 *
-	 *		// Sets ranges from the other selection.
+	 *		// Sets selection to other selection.
 	 *		const otherSelection = new Selection();
 	 *		writer.setSelection( otherSelection );
 	 *
-	 * 		// Sets ranges from the given document selection's ranges.
+	 * 		// Sets selection to the given document selection.
 	 *		const documentSelection = new DocumentSelection( doc );
 	 *		writer.setSelection( documentSelection );
 	 *
-	 * 		// Sets collapsed range at the given position.
+	 * 		// Sets collapsed selection at the given position.
 	 *		const position = new Position( root, path );
 	 *		writer.setSelection( position );
 	 *
-	 * 		// Sets range at the position of given node and offset.
+	 * 		// Sets collapsed selection at the position of the given node and an offset.
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		writer.setSelection( paragraph, offset );
 	 *
-	 *		// Sets range inside the node.
-	 *		const paragraph = writer.createElement( 'paragraph', { backward } );
-	 *		writer.setSelection( paragraph, 'in' );
+	 *		// Sets selection inside the given node.
+	 *		const paragraph = writer.createElement( 'paragraph' );
+	 *		writer.setSelection( paragraph, 'in', { backward } );
 	 *
-	 *		// Sets range on the node.
-	 *		const paragraph = writer.createElement( 'paragraph', { backward } );
-	 *		writer.setSelection( paragraph, 'on' );
+	 *		// Sets selection on the given node.
+	 *		const paragraph = writer.createElement( 'paragraph' );
+	 *		writer.setSelection( paragraph, 'on', { backward } );
 	 *
-	 * 		// Removes all ranges.
+	 * 		// Removes all selection's ranges.
 	 *		writer.setSelection( null );
 	 *
 	 * Throws `writer-incorrect-use` error when the writer is used outside the `change()` block.
@@ -945,15 +945,14 @@ export default class Writer {
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|
 	 * module:engine/model/position~Position|module:engine/model/node~Node|
 	 * Iterable.<module:engine/model/range~Range>|module:engine/model/range~Range|null} selectable
-	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset]
-	 * @param {Boolean} [optionsOrPlaceOrOffset.backward]
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset]
 	 * @param {Object} [options]
 	 * @param {Boolean} [options.backward]
 	 */
-	setSelection( selectable, optionsOrPlaceOrOffset, options ) {
+	setSelection( selectable, placeOrOffset, options ) {
 		this._assertWriterUsedCorrectly();
 
-		this.model.document.selection._setTo( selectable, optionsOrPlaceOrOffset, options );
+		this.model.document.selection._setTo( selectable, placeOrOffset, options );
 	}
 
 	/**

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -902,16 +902,16 @@ export default class Writer {
 	/**
 	 * Sets this selection's ranges and direction to the specified location based on the given
 	 * {@link module:engine/model/selection~Selection selection}, {@link module:engine/model/position~Position position},
-	 * {@link module:engine/model/element~Element element}, {@link module:engine/model/position~Position position},
+	 * {@link module:engine/model/element~Node node}, {@link module:engine/model/position~Position position},
 	 * {@link module:engine/model/range~Range range}, an iterable of {@link module:engine/model/range~Range ranges} or null.
 	 *
 	 *		// Sets ranges from the given range.
 	 *		const range = new Range( start, end );
-	 *		writer.setSelection( range, isBackwardSelection );
+	 *		writer.setSelection( range, { backward } );
 	 *
 	 *		// Sets ranges from the iterable of ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		writer.setSelection( range, isBackwardSelection );
+	 *		writer.setSelection( range, { backward } );
 	 *
 	 *		// Sets ranges from the other selection.
 	 *		const otherSelection = new Selection();
@@ -925,9 +925,17 @@ export default class Writer {
 	 *		const position = new Position( root, path );
 	 *		writer.setSelection( position );
 	 *
-	 * 		// Sets collapsed range at the given offset in element.
+	 * 		// Sets range at the position of given node and offset.
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		writer.setSelection( paragraph, offset );
+	 *
+	 *		// Sets range inside the node.
+	 *		const paragraph = writer.createElement( 'paragraph', { backward } );
+	 *		writer.setSelection( paragraph, 'in' );
+	 *
+	 *		// Sets range on the node.
+	 *		const paragraph = writer.createElement( 'paragraph', { backward } );
+	 *		writer.setSelection( paragraph, 'on' );
 	 *
 	 * 		// Removes all ranges.
 	 *		writer.setSelection( null );
@@ -935,14 +943,17 @@ export default class Writer {
 	 * Throws `writer-incorrect-use` error when the writer is used outside the `change()` block.
 	 *
 	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|
-	 * module:engine/model/position~Position|module:engine/model/element~Element|
+	 * module:engine/model/position~Position|module:engine/model/node~Node|
 	 * Iterable.<module:engine/model/range~Range>|module:engine/model/range~Range|null} selectable
-	 * @param {Boolean|Number|'before'|'end'|'after'} [backwardSelectionOrOffset]
+	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset]
+	 * @param {Boolean} [optionsOrPlaceOrOffset.backward]
+	 * @param {Object} [options]
+	 * @param {Boolean} [options.backward]
 	 */
-	setSelection( selectable, backwardSelectionOrOffset ) {
+	setSelection( selectable, optionsOrPlaceOrOffset, options ) {
 		this._assertWriterUsedCorrectly();
 
-		this.model.document.selection._setTo( selectable, backwardSelectionOrOffset );
+		this.model.document.selection._setTo( selectable, optionsOrPlaceOrOffset, options );
 	}
 
 	/**

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -486,7 +486,7 @@ export default class DomConverter {
 			}
 		}
 
-		return new ViewSelection( viewRanges, isBackward );
+		return new ViewSelection( viewRanges, { backward: isBackward } );
 	}
 
 	/**

--- a/src/view/observer/fakeselectionobserver.js
+++ b/src/view/observer/fakeselectionobserver.js
@@ -82,8 +82,7 @@ export default class FakeSelectionObserver extends Observer {
 	 */
 	_handleSelectionMove( keyCode ) {
 		const selection = this.document.selection;
-		const newSelection = new ViewSelection( selection );
-		newSelection._setFake( false );
+		const newSelection = new ViewSelection( selection.getRanges(), { backward: selection.isBackward, fake: false } );
 
 		// Left or up arrow pressed - move selection to start.
 		if ( keyCode == keyCodes.arrowleft || keyCode == keyCodes.arrowup ) {

--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -239,8 +239,7 @@ export default class MutationObserver extends Observer {
 
 			// Anchor and focus has to be properly mapped to view.
 			if ( viewSelectionAnchor && viewSelectionFocus ) {
-				viewSelection = new ViewSelection();
-				viewSelection._setTo( viewSelectionAnchor );
+				viewSelection = new ViewSelection( viewSelectionAnchor );
 				viewSelection._setFocus( viewSelectionFocus );
 			}
 		}

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -41,11 +41,11 @@ export default class Selection {
 	 *
 	 *		// Creates selection at the given range.
 	 *		const range = new Range( start, end );
-	 *		const selection = new Selection( range, { backward, fake, label } );
+	 *		const selection = new Selection( range );
 	 *
 	 *		// Creates selection at the given ranges
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		const selection = new Selection( ranges, { backward, fake, label } );
+	 *		const selection = new Selection( ranges );
 	 *
 	 *		// Creates selection from the other selection.
 	 *		const otherSelection = new Selection();
@@ -53,19 +53,34 @@ export default class Selection {
 	 *
 	 * 		// Creates selection at the given position.
 	 *		const position = new Position( root, path );
-	 *		const selection = new Selection( position, { fake, label } );
+	 *		const selection = new Selection( position );
 	 *
-	 * 		// Sets collapsed selection at the position of given item and offset.
+	 * 		// Creates collapsed selection at the position of given item and offset.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, offset, { fake, label } );
+	 *		const selection = new Selection( paragraph, offset );
 	 *
-	 *		// Sets selection inside the item.
+	 *		// Creates selection inside the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'in', { backward, fake, label } );
+	 *		const selection = new Selection( paragraph, 'in' );
 	 *
-	 *		// Sets selection on the item.
+	 *		// Creates selection on the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'on', { backward, fake, label } );
+	 *		const selection = new Selection( paragraph, 'on' );
+	 *
+	 * `Selection`'s constructor allow passing additional options (`backward`, `fake` and `label`) as the last argument.
+	 *
+	 *		// Creates backward selection.
+	 *		const selection = new Selection( range, { backward: true } );
+	 *
+	 *		// Creates fake selection.
+	 *		// Fake selection does not render as browser native selection over selected elements and is hidden to the user.
+	 * 		// This way, no native selection UI artifacts are displayed to the user and selection over elements can be
+	 * 		// represented in other way, for example by applying proper CSS class.
+	 *		const selection = new Selection( range, { fake: true } );
+	 *
+	 * 		// Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM
+	 * 		// (and be  properly handled by screen readers).
+	 *		const selection = new Selection( range, { fake: true, label: 'foo' } );
 	 *
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} [selectable=null]
@@ -404,18 +419,13 @@ export default class Selection {
 	 * {@link module:engine/view/item~Item item}, {@link module:engine/view/range~Range range},
 	 * an iterable of {@link module:engine/view/range~Range ranges} or null.
 	 *
-	 * This method provides option to create a fake selection.
-	 * Fake selection does not render as browser native selection over selected elements and is hidden to the user.
-	 * This way, no native selection UI artifacts are displayed to the user and selection over elements can be
-	 * represented in other way, for example by applying proper CSS class.
-	 *
 	 *		// Sets selection to the given range.
 	 *		const range = new Range( start, end );
-	 *		selection.setTo( range, { backward, fake, label } );
+	 *		selection.setTo( range );
 	 *
 	 *		// Sets selection to given ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		selection.setTo( range, { backward, fake, label } );
+	 *		selection.setTo( range );
 	 *
 	 *		// Sets selection to the other selection.
 	 *		const otherSelection = new Selection();
@@ -423,19 +433,34 @@ export default class Selection {
 	 *
 	 * 		// Sets collapsed selection at the given position.
 	 *		const position = new Position( root, path );
-	 *		selection.setTo( position, { fake, label } );
+	 *		selection.setTo( position );
 	 *
 	 * 		// Sets collapsed selection at the position of given item and offset.
-	 *		selection.setTo( paragraph, offset, { fake, label } );
+	 *		selection.setTo( paragraph, offset );
 	 *
 	 *		// Sets selection inside the item.
-	 *		selection.setTo( paragraph, 'in', { backward, fake, label } );
+	 *		selection.setTo( paragraph, 'in' );
 	 *
 	 *		// Sets selection on the item.
-	 *		selection.setTo( paragraph, 'on', { backward, fake, label } );
+	 *		selection.setTo( paragraph, 'on' );
 	 *
 	 * 		// Clears selection. Removes all ranges.
 	 *		selection.setTo( null );
+	 *
+	 * `Selection#setTo()` method allow passing additional options (`backward`, `fake` and `label`) as the last argument.
+	 *
+	 *		// Sets selection as backward.
+	 *		selection.setTo( range, { backward: true } );
+	 *
+	 *		// Sets selection as fake.
+	 8		// Fake selection does not render as browser native selection over selected elements and is hidden to the user.
+	 * 		// This way, no native selection UI artifacts are displayed to the user and selection over elements can be
+	 * 		// represented in other way, for example by applying proper CSS class.
+	 *		selection.setTo( range, { fake: true } );
+	 *
+	 * 		// Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM
+	 * 		// (and be  properly handled by screen readers).
+	 *		selection.setTo( range, { fake: true, label: 'foo' } );
 	 *
 	 * @protected
 	 * @fires change

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -55,19 +55,16 @@ export default class Selection {
 	 *		const position = new Position( root, path );
 	 *		const selection = new Selection( position );
 	 *
-	 * 		// Creates collapsed selection at the position of given item and offset.
+	 *		// Creates collapsed selection at the position of given item and offset.
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		const selection = new Selection( paragraph, offset );
 	 *
-	 * Creates a range inside an {@link module:engine/view/element~Element element} which starts before the first child of
- 	 * that element and ends after the last child of that element.
-	 *
-	 *		const paragraph = writer.createElement( 'paragraph' );
+	 *		// Creates a range inside an {@link module:engine/view/element~Element element} which starts before the
+	 *		// first child of that element and ends after the last child of that element.
 	 *		const selection = new Selection( paragraph, 'in' );
 	 *
-	 * Creates a range on an {@link module:engine/view/item~Item item} which starts before the item and ends just after the item.
-	 *
-	 *		const paragraph = writer.createElement( 'paragraph' );
+	 *		// Creates a range on an {@link module:engine/view/item~Item item} which starts before the item and ends
+	 *		// just after the item.
 	 *		const selection = new Selection( paragraph, 'on' );
 	 *
 	 * `Selection`'s constructor allow passing additional options (`backward`, `fake` and `label`) as the last argument.
@@ -75,14 +72,14 @@ export default class Selection {
 	 *		// Creates backward selection.
 	 *		const selection = new Selection( range, { backward: true } );
 	 *
-	 *		// Creates fake selection.
-	 *		// Fake selection does not render as browser native selection over selected elements and is hidden to the user.
-	 * 		// This way, no native selection UI artifacts are displayed to the user and selection over elements can be
-	 * 		// represented in other way, for example by applying proper CSS class.
-	 *		const selection = new Selection( range, { fake: true } );
+	 * Fake selection does not render as browser native selection over selected elements and is hidden to the user.
+	 * This way, no native selection UI artifacts are displayed to the user and selection over elements can be
+	 * represented in other way, for example by applying proper CSS class.
 	 *
-	 * 		// Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM
-	 * 		// (and be  properly handled by screen readers).
+	 * Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM
+	 * (and be  properly handled by screen readers).
+	 *
+	 *		// Creates fake selection with label.
 	 *		const selection = new Selection( range, { fake: true, label: 'foo' } );
 	 *
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
@@ -458,14 +455,14 @@ export default class Selection {
 	 *		// Sets selection as backward.
 	 *		selection.setTo( range, { backward: true } );
 	 *
-	 *		// Sets selection as fake.
-	 *		// Fake selection does not render as browser native selection over selected elements and is hidden to the user.
-	 * 		// This way, no native selection UI artifacts are displayed to the user and selection over elements can be
-	 * 		// represented in other way, for example by applying proper CSS class.
-	 *		selection.setTo( range, { fake: true } );
+	 * Fake selection does not render as browser native selection over selected elements and is hidden to the user.
+	 * This way, no native selection UI artifacts are displayed to the user and selection over elements can be
+	 * represented in other way, for example by applying proper CSS class.
 	 *
-	 * 		// Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM
-	 * 		// (and be  properly handled by screen readers).
+	 * Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM
+	 * (and be  properly handled by screen readers).
+	 *
+	 *		// Creates fake selection with label.
 	 *		selection.setTo( range, { fake: true, label: 'foo' } );
 	 *
 	 * @protected

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -59,11 +59,14 @@ export default class Selection {
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		const selection = new Selection( paragraph, offset );
 	 *
-	 *		// Creates selection inside the item.
+	 * Creates a range inside an {@link module:engine/view/element~Element element} which starts before the first child of
+ 	 * that element and ends after the last child of that element.
+	 *
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		const selection = new Selection( paragraph, 'in' );
 	 *
-	 *		// Creates selection on the item.
+	 * Creates a range on an {@link module:engine/view/item~Item item} which starts before the item and ends just after the item.
+	 *
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		const selection = new Selection( paragraph, 'on' );
 	 *
@@ -438,10 +441,13 @@ export default class Selection {
 	 * 		// Sets collapsed selection at the position of given item and offset.
 	 *		selection.setTo( paragraph, offset );
 	 *
-	 *		// Sets selection inside the item.
+	 * Creates a range inside an {@link module:engine/view/element~Element element} which starts before the first child of
+ 	 * that element and ends after the last child of that element.
+	 *
 	 *		selection.setTo( paragraph, 'in' );
 	 *
-	 *		// Sets selection on the item.
+	 * Creates a range on an {@link module:engine/view/item~Item item} which starts before the item and ends just after the item.
+	 *
 	 *		selection.setTo( paragraph, 'on' );
 	 *
 	 * 		// Clears selection. Removes all ranges.
@@ -453,7 +459,7 @@ export default class Selection {
 	 *		selection.setTo( range, { backward: true } );
 	 *
 	 *		// Sets selection as fake.
-	 8		// Fake selection does not render as browser native selection over selected elements and is hidden to the user.
+	 *		// Fake selection does not render as browser native selection over selected elements and is hidden to the user.
 	 * 		// This way, no native selection UI artifacts are displayed to the user and selection over elements can be
 	 * 		// represented in other way, for example by applying proper CSS class.
 	 *		selection.setTo( range, { fake: true } );

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -426,15 +426,12 @@ export default class Selection {
 	 *		selection.setTo( position, { fake, label } );
 	 *
 	 * 		// Sets collapsed selection at the position of given item and offset.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, offset, { fake, label } );
 	 *
 	 *		// Sets selection inside the item.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'in', { backward, fake, label } );
 	 *
 	 *		// Sets selection on the item.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'on', { backward, fake, label } );
 	 *
 	 * 		// Clears selection. Removes all ranges.

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -69,10 +69,15 @@ export default class Selection {
 	 *
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} [selectable=null]
-	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset]
-	 * @param {Boolean} [optionsOrPlaceOrOffset.backward]
-	 * @param {Object} [options]
-	 * @param {Boolean} [options.backward]
+	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset] Offset or place when selectable is an `Item`.
+	 * Options otherwise.
+	 * @param {Boolean} [optionsOrPlaceOrOffset.backward] Sets this selection instance to be backward.
+	 * @param {Boolean} [optionsOrPlaceOrOffset.fake] Sets this selection instance to be marked as `fake`.
+	 * @param {Boolean} [optionsOrPlaceOrOffset.label] Label for the fake selection.
+	 * @param {Object} [options] Options when selectable is an `Item`.
+	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
+	 * @param {Boolean} [options.fake] Sets this selection instance to be marked as `fake`.
+	 * @param {String} [options.label] Label for the fake selection.
 	 */
 	constructor( selectable = null, optionsOrPlaceOrOffset, options ) {
 		/**
@@ -437,12 +442,13 @@ export default class Selection {
 	 * @protected
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable
-	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset]
-	 * @param {Boolean} [optionsOrPlaceOrOffset.backward] Sets this selection as backward.
+	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset] Offset or place when selectable is an `Item`.
+	 * Options otherwise.
+	 * @param {Boolean} [optionsOrPlaceOrOffset.backward] Sets this selection instance to be backward.
 	 * @param {Boolean} [optionsOrPlaceOrOffset.fake] Sets this selection instance to be marked as `fake`.
-	 * @param {String} [optionsOrPlaceOrOffset.label] Label for the fake selection.
-	 * @param {Object} [options]
-	 * @param {Boolean} [options.backward] Sets this selection as backward.
+	 * @param {Boolean} [optionsOrPlaceOrOffset.label] Label for the fake selection.
+	 * @param {Object} [options] Options when selectable is an `Item`.
+	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 * @param {Boolean} [options.fake] Sets this selection instance to be marked as `fake`.
 	 * @param {String} [options.label] Label for the fake selection.
 	 */
@@ -463,20 +469,21 @@ export default class Selection {
 			const backward = !!options && !!options.backward;
 			let range;
 
-			if ( optionsOrPlaceOrOffset == 'in' ) {
-				range = Range.createIn( selectable );
-			} else if ( optionsOrPlaceOrOffset == 'on' ) {
-				range = Range.createOn( selectable );
-			} else if ( optionsOrPlaceOrOffset !== undefined ) {
-				range = Range.createCollapsedAt( selectable, optionsOrPlaceOrOffset );
-			} else {
+			if ( optionsOrPlaceOrOffset === undefined ) {
 				/**
 				 * Required second parameter when setting selection to node.
 				 *
 				 * @error view-selection-setTo-required-second-parameter
 				 */
 				throw new CKEditorError(
-					'view-selection-setTo-required-second-parameter: Required second parameter when setting selection to node.' );
+					'view-selection-setTo-required-second-parameter: Required second parameter when setting selection to node.'
+				);
+			} else if ( optionsOrPlaceOrOffset == 'in' ) {
+				range = Range.createIn( selectable );
+			} else if ( optionsOrPlaceOrOffset == 'on' ) {
+				range = Range.createOn( selectable );
+			} else {
+				range = Range.createCollapsedAt( selectable, optionsOrPlaceOrOffset );
 			}
 
 			this._setRanges( [ range ], backward );

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -404,11 +404,16 @@ export default class Selection {
 	 * {@link module:engine/view/item~Item item}, {@link module:engine/view/range~Range range},
 	 * an iterable of {@link module:engine/view/range~Range ranges} or null.
 	 *
+	 * This method provides option to create a fake selection.
+	 * Fake selection does not render as browser native selection over selected elements and is hidden to the user.
+	 * This way, no native selection UI artifacts are displayed to the user and selection over elements can be
+	 * represented in other way, for example by applying proper CSS class.
+	 *
 	 *		// Sets selection to the given range.
 	 *		const range = new Range( start, end );
 	 *		selection.setTo( range, { backward, fake, label } );
 	 *
-	 *		// Sets selection to the ranges.
+	 *		// Sets selection to given ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
 	 *		selection.setTo( range, { backward, fake, label } );
 	 *
@@ -432,14 +437,14 @@ export default class Selection {
 	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'on', { backward, fake, label } );
 	 *
-	 * 		// Clears selection. Removes all ranges and options
+	 * 		// Clears selection. Removes all ranges.
 	 *		selection.setTo( null );
 	 *
 	 * @protected
 	 * @fires change
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable
-	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Offset or place.
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets offset or place of the selection.
 	 * @param {Object} [options]
 	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 * @param {Boolean} [options.fake] Sets this selection instance to be marked as `fake`.

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -490,6 +490,7 @@ export default class Selection {
 			this._setFakeOptions( options );
 		} else if ( isIterable( selectable ) ) {
 			// We assume that the selectable is an iterable of ranges.
+			// Array.from() is used to prevent setting ranges to the old iterable
 			this._setRanges( selectable, optionsOrPlaceOrOffset && optionsOrPlaceOrOffset.backward );
 			this._setFakeOptions( optionsOrPlaceOrOffset );
 		} else {
@@ -515,6 +516,10 @@ export default class Selection {
 	 * (`false`) or backward - from end to start (`true`). Defaults to `false`.
 	 */
 	_setRanges( newRanges, isLastBackward = false ) {
+		// New ranges should be copied to prevent removing them by setting them to `[]` first.
+		// Only applies to situations when selection is set to the same selection or same selection's ranges.
+		newRanges = Array.from( newRanges );
+
 		this._ranges = [];
 
 		for ( const range of newRanges ) {

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -441,7 +441,7 @@ export default class Selection {
 	 * @fires change
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable
-	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets offset or place of the selection.
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets place or offset of the selection.
 	 * @param {Object} [options]
 	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 * @param {Boolean} [options.fake] Sets this selection instance to be marked as `fake`.

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -440,6 +440,7 @@ export default class Selection {
 	 *		selection.setTo( null );
 	 *
 	 * @protected
+	 * @fires change
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable
 	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset] Offset or place when selectable is an `Item`.

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -41,11 +41,11 @@ export default class Selection {
 	 *
 	 *		// Creates selection at the given range.
 	 *		const range = new Range( start, end );
-	 *		const selection = new Selection( range, isBackwardSelection );
+	 *		const selection = new Selection( range, { backward } );
 	 *
 	 *		// Creates selection at the given ranges
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		const selection = new Selection( ranges, isBackwardSelection );
+	 *		const selection = new Selection( ranges, { backward } );
 	 *
 	 *		// Creates selection from the other selection.
 	 *		const otherSelection = new Selection();
@@ -61,11 +61,11 @@ export default class Selection {
 	 *
 	 *		// Sets range inside the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'in' );
+	 *		selection.setTo( paragraph, 'in', { backward } );
 	 *
 	 *		// Sets range on the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'on' );
+	 *		selection.setTo( paragraph, 'on', { backward } );
 	 *
 	* @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -41,11 +41,11 @@ export default class Selection {
 	 *
 	 *		// Creates selection at the given range.
 	 *		const range = new Range( start, end );
-	 *		const selection = new Selection( range, { backward } );
+	 *		const selection = new Selection( range, { backward, fake, label } );
 	 *
 	 *		// Creates selection at the given ranges
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		const selection = new Selection( ranges, { backward } );
+	 *		const selection = new Selection( ranges, { backward, fake, label } );
 	 *
 	 *		// Creates selection from the other selection.
 	 *		const otherSelection = new Selection();
@@ -53,33 +53,29 @@ export default class Selection {
 	 *
 	 * 		// Creates selection at the given position.
 	 *		const position = new Position( root, path );
-	 *		const selection = new Selection( position );
+	 *		const selection = new Selection( position, { fake, label } );
 	 *
-	 * 		// Sets collapsed range at the position of given item and offset.
+	 * 		// Sets collapsed selection at the position of given item and offset.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, offset );
+	 *		selection.setTo( paragraph, offset, { fake, label } );
 	 *
-	 *		// Sets range inside the item.
+	 *		// Sets selection inside the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'in', { backward } );
+	 *		selection.setTo( paragraph, 'in', { backward, fake, label } );
 	 *
-	 *		// Sets range on the item.
+	 *		// Sets selection on the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'on', { backward } );
+	 *		selection.setTo( paragraph, 'on', { backward, fake, label } );
 	 *
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} [selectable=null]
-	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset] Offset or place when selectable is an `Item`.
-	 * Options otherwise.
-	 * @param {Boolean} [optionsOrPlaceOrOffset.backward] Sets this selection instance to be backward.
-	 * @param {Boolean} [optionsOrPlaceOrOffset.fake] Sets this selection instance to be marked as `fake`.
-	 * @param {Boolean} [optionsOrPlaceOrOffset.label] Label for the fake selection.
-	 * @param {Object} [options] Options when selectable is an `Item`.
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Offset or place when selectable is an `Item`.
+	 * @param {Object} [options]
 	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 * @param {Boolean} [options.fake] Sets this selection instance to be marked as `fake`.
 	 * @param {String} [options.label] Label for the fake selection.
 	 */
-	constructor( selectable = null, optionsOrPlaceOrOffset, options ) {
+	constructor( selectable = null, placeOrOffset, options ) {
 		/**
 		 * Stores all ranges that are selected.
 		 *
@@ -112,7 +108,7 @@ export default class Selection {
 		 */
 		this._fakeSelectionLabel = '';
 
-		this._setTo( selectable, optionsOrPlaceOrOffset, options );
+		this._setTo( selectable, placeOrOffset, options );
 	}
 
 	/**
@@ -408,83 +404,80 @@ export default class Selection {
 	 * {@link module:engine/view/item~Item item}, {@link module:engine/view/range~Range range},
 	 * an iterable of {@link module:engine/view/range~Range ranges} or null.
 	 *
-	 *		// Sets ranges from the given range.
+	 *		// Sets selection to the given range.
 	 *		const range = new Range( start, end );
-	 *		selection.setTo( range, isBackwardSelection );
+	 *		selection.setTo( range, { backward, fake, label } );
 	 *
-	 *		// Sets ranges from the iterable of ranges.
+	 *		// Sets selection to the ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		selection.setTo( range, isBackwardSelection );
+	 *		selection.setTo( range, { backward, fake, label } );
 	 *
-	 *		// Sets ranges from the other selection.
+	 *		// Sets selection to the other selection.
 	 *		const otherSelection = new Selection();
 	 *		selection.setTo( otherSelection );
 	 *
-	 * 		// Sets collapsed range at the given position.
+	 * 		// Sets collapsed selection at the given position.
 	 *		const position = new Position( root, path );
-	 *		selection.setTo( position );
+	 *		selection.setTo( position, { fake, label } );
 	 *
-	 * 		// Sets collapsed range at the position of given item and offset.
+	 * 		// Sets collapsed selection at the position of given item and offset.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, offset );
+	 *		selection.setTo( paragraph, offset, { fake, label } );
 	 *
-	 *		// Sets range inside the item.
+	 *		// Sets selection inside the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'in' );
+	 *		selection.setTo( paragraph, 'in', { backward, fake, label } );
 	 *
-	 *		// Sets range on the item.
+	 *		// Sets selection on the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'on' );
+	 *		selection.setTo( paragraph, 'on', { backward, fake, label } );
 	 *
-	 * 		// Removes all ranges.
+	 * 		// Clears selection. Removes all ranges and options
 	 *		selection.setTo( null );
 	 *
 	 * @protected
 	 * @fires change
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable
-	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset] Offset or place when selectable is an `Item`.
-	 * Options otherwise.
-	 * @param {Boolean} [optionsOrPlaceOrOffset.backward] Sets this selection instance to be backward.
-	 * @param {Boolean} [optionsOrPlaceOrOffset.fake] Sets this selection instance to be marked as `fake`.
-	 * @param {Boolean} [optionsOrPlaceOrOffset.label] Label for the fake selection.
-	 * @param {Object} [options] Options when selectable is an `Item`.
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Offset or place.
+	 * @param {Object} [options]
 	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 * @param {Boolean} [options.fake] Sets this selection instance to be marked as `fake`.
 	 * @param {String} [options.label] Label for the fake selection.
 	 */
-	_setTo( selectable, optionsOrPlaceOrOffset, options ) {
+	_setTo( selectable, placeOrOffset, options ) {
 		if ( selectable === null ) {
 			this._setRanges( [] );
-			this._setFakeOptions( optionsOrPlaceOrOffset );
+			this._setFakeOptions( placeOrOffset );
 		} else if ( selectable instanceof Selection ) {
 			this._setRanges( selectable.getRanges(), selectable.isBackward );
 			this._setFakeOptions( { fake: selectable.isFake, label: selectable.fakeSelectionLabel } );
 		} else if ( selectable instanceof Range ) {
-			this._setRanges( [ selectable ], optionsOrPlaceOrOffset && optionsOrPlaceOrOffset.backward );
-			this._setFakeOptions( optionsOrPlaceOrOffset );
+			this._setRanges( [ selectable ], placeOrOffset && placeOrOffset.backward );
+			this._setFakeOptions( placeOrOffset );
 		} else if ( selectable instanceof Position ) {
 			this._setRanges( [ new Range( selectable ) ] );
-			this._setFakeOptions( optionsOrPlaceOrOffset );
+			this._setFakeOptions( placeOrOffset );
 		} else if ( selectable instanceof Node ) {
 			const backward = !!options && !!options.backward;
 			let range;
 
-			if ( optionsOrPlaceOrOffset === undefined ) {
+			if ( placeOrOffset === undefined ) {
 				/**
-				 * Required second parameter when setting selection to node.
+				 * selection.setTo requires the second parameter when the first parameter is a node.
 				 *
 				 * @error view-selection-setTo-required-second-parameter
 				 */
 				throw new CKEditorError(
-					'view-selection-setTo-required-second-parameter: Required second parameter when setting selection to node.'
+					'view-selection-setTo-required-second-parameter: ' +
+					'selection.setTo requires the second parameter when the first parameter is a node.'
 				);
-			} else if ( optionsOrPlaceOrOffset == 'in' ) {
+			} else if ( placeOrOffset == 'in' ) {
 				range = Range.createIn( selectable );
-			} else if ( optionsOrPlaceOrOffset == 'on' ) {
+			} else if ( placeOrOffset == 'on' ) {
 				range = Range.createOn( selectable );
 			} else {
-				range = Range.createCollapsedAt( selectable, optionsOrPlaceOrOffset );
+				range = Range.createCollapsedAt( selectable, placeOrOffset );
 			}
 
 			this._setRanges( [ range ], backward );
@@ -492,8 +485,8 @@ export default class Selection {
 		} else if ( isIterable( selectable ) ) {
 			// We assume that the selectable is an iterable of ranges.
 			// Array.from() is used to prevent setting ranges to the old iterable
-			this._setRanges( selectable, optionsOrPlaceOrOffset && optionsOrPlaceOrOffset.backward );
-			this._setFakeOptions( optionsOrPlaceOrOffset );
+			this._setRanges( selectable, placeOrOffset && placeOrOffset.backward );
+			this._setFakeOptions( placeOrOffset );
 		} else {
 			/**
 			 * Cannot set selection to given place.

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -36,6 +36,16 @@ export default class Writer {
 	 * {@link module:engine/view/item~Item item}, {@link module:engine/view/range~Range range},
 	 * an iterable of {@link module:engine/view/range~Range ranges} or null.
 	 *
+	 * This method provides option to create a fake selection.
+	 * Fake selection does not render as browser native selection over selected elements and is hidden to the user.
+	 * This way, no native selection UI artifacts are displayed to the user and selection over elements can be
+	 * represented in other way, for example by applying proper CSS class.
+	 *
+	 * Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM (and be
+	 * properly handled by screen readers).
+	 *
+	 * Usage:
+	 *
 	 *		// Sets ranges from the given range.
 	 *		const range = new Range( start, end );
 	 *		writer.setSelection( range, isBackwardSelection );
@@ -69,10 +79,15 @@ export default class Writer {
 	 *
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable
-	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset]
-	 * @param {Boolean} [optionsOrPlaceOrOffset.backward]
-	 * @param {Object} [options]
-	 * @param {Boolean} [options.backward]
+	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset] Offset or place when selectable is an `Item`.
+	 * Options otherwise.
+	 * @param {Boolean} [optionsOrPlaceOrOffset.backward] Sets this selection instance to be backward.
+	 * @param {Boolean} [optionsOrPlaceOrOffset.fake] Sets this selection instance to be marked as `fake`.
+	 * @param {Boolean} [optionsOrPlaceOrOffset.label] Label for the fake selection.
+	 * @param {Object} [options] Options when selectable is an `Item`.
+	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
+	 * @param {Boolean} [options.fake] Sets this selection instance to be marked as `fake`.
+	 * @param {String} [options.label] Label for the fake selection.
 	 */
 	setSelection( selectable, optionsOrPlaceOrOffset, options ) {
 		this.document.selection._setTo( selectable, optionsOrPlaceOrOffset, options );
@@ -89,23 +104,6 @@ export default class Writer {
 	 */
 	setSelectionFocus( itemOrPosition, offset ) {
 		this.document.selection._setFocus( itemOrPosition, offset );
-	}
-
-	/**
-	 * Sets {@link module:engine/view/selection~Selection selection's} to be marked as `fake`. A fake selection does
-	 * not render as browser native selection over selected elements and is hidden to the user.
-	 * This way, no native selection UI artifacts are displayed to the user and selection over elements can be
-	 * represented in other way, for example by applying proper CSS class.
-	 *
-	 * Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM (and be
-	 * properly handled by screen readers).
-	 *
-	 * @param {Boolean} [value=true] If set to true selection will be marked as `fake`.
-	 * @param {Object} [options] Additional options.
-	 * @param {String} [options.label=''] Fake selection label.
-	 */
-	setFakeSelection( value, options ) {
-		this.document.selection._setFake( value, options );
 	}
 
 	/**

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -63,15 +63,12 @@ export default class Writer {
 	 *		writer.setSelection( position, { fake, label } );
 	 *
 	 * 		// Sets collapsed selection at the position of given item and offset.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, offset, { fake, label } );
 	 *
 	 *		// Sets selection inside the item.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'in', { backward, fake, label } );
 	 *
 	 *		// Sets selection on the item.
-	 *		const paragraph = writer.createElement( 'paragraph' );
 	 *		selection.setTo( paragraph, 'on', { backward, fake, label } );
 	 *
 	 * 		// Removes all ranges.

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -46,51 +46,47 @@ export default class Writer {
 	 *
 	 * Usage:
 	 *
-	 *		// Sets ranges from the given range.
+	 *		// Sets selection to the given range.
 	 *		const range = new Range( start, end );
-	 *		writer.setSelection( range, isBackwardSelection );
+	 *		writer.setSelection( range, { backward, fake, label } );
 	 *
-	 *		// Sets ranges from the iterable of ranges.
+	 *		// Sets selection to given ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		writer.setSelection( range, isBackwardSelection );
+	 *		writer.setSelection( range, { backward, fake, label } );
 	 *
-	 *		// Sets ranges from the other selection.
+	 *		// Sets selection to the other selection.
 	 *		const otherSelection = new Selection();
 	 *		writer.setSelection( otherSelection );
 	 *
-	 * 		// Sets collapsed range at the given position.
+	 * 		// Sets collapsed selection at the given position.
 	 *		const position = new Position( root, path );
-	 *		writer.setSelection( position );
+	 *		writer.setSelection( position, { fake, label } );
 	 *
-	 * 		// Sets collapsed range at the position of given item and offset.
+	 * 		// Sets collapsed selection at the position of given item and offset.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, offset );
+	 *		selection.setTo( paragraph, offset, { fake, label } );
 	 *
-	 *		// Sets range inside the item.
+	 *		// Sets selection inside the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'in' );
+	 *		selection.setTo( paragraph, 'in', { backward, fake, label } );
 	 *
-	 *		// Sets range on the item.
+	 *		// Sets selection on the item.
 	 *		const paragraph = writer.createElement( 'paragraph' );
-	 *		selection.setTo( paragraph, 'on' );
+	 *		selection.setTo( paragraph, 'on', { backward, fake, label } );
 	 *
 	 * 		// Removes all ranges.
 	 *		writer.setSelection( null );
 	 *
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable
-	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset] Offset or place when selectable is an `Item`.
-	 * Options otherwise.
-	 * @param {Boolean} [optionsOrPlaceOrOffset.backward] Sets this selection instance to be backward.
-	 * @param {Boolean} [optionsOrPlaceOrOffset.fake] Sets this selection instance to be marked as `fake`.
-	 * @param {Boolean} [optionsOrPlaceOrOffset.label] Label for the fake selection.
-	 * @param {Object} [options] Options when selectable is an `Item`.
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets offset or place of the selection.
+	 * @param {Object} [options]
 	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 * @param {Boolean} [options.fake] Sets this selection instance to be marked as `fake`.
 	 * @param {String} [options.label] Label for the fake selection.
 	 */
-	setSelection( selectable, optionsOrPlaceOrOffset, options ) {
-		this.document.selection._setTo( selectable, optionsOrPlaceOrOffset, options );
+	setSelection( selectable, placeOrOffset, options ) {
+		this.document.selection._setTo( selectable, placeOrOffset, options );
 	}
 
 	/**

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -36,23 +36,19 @@ export default class Writer {
 	 * {@link module:engine/view/item~Item item}, {@link module:engine/view/range~Range range},
 	 * an iterable of {@link module:engine/view/range~Range ranges} or null.
 	 *
-	 * This method provides option to create a fake selection.
-	 * Fake selection does not render as browser native selection over selected elements and is hidden to the user.
-	 * This way, no native selection UI artifacts are displayed to the user and selection over elements can be
-	 * represented in other way, for example by applying proper CSS class.
-	 *
-	 * Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM (and be
-	 * properly handled by screen readers).
-	 *
-	 * Usage:
+	 * ### Usage:
 	 *
 	 *		// Sets selection to the given range.
 	 *		const range = new Range( start, end );
-	 *		writer.setSelection( range, { backward, fake, label } );
+	 *		writer.setSelection( range );
+	 *
+	 *		// Sets backward selection to the given range.
+	 *		const range = new Range( start, end );
+	 *		writer.setSelection( range );
 	 *
 	 *		// Sets selection to given ranges.
 	 * 		const ranges = [ new Range( start1, end2 ), new Range( star2, end2 ) ];
-	 *		writer.setSelection( range, { backward, fake, label } );
+	 *		writer.setSelection( range );
 	 *
 	 *		// Sets selection to the other selection.
 	 *		const otherSelection = new Selection();
@@ -60,19 +56,34 @@ export default class Writer {
 	 *
 	 * 		// Sets collapsed selection at the given position.
 	 *		const position = new Position( root, path );
-	 *		writer.setSelection( position, { fake, label } );
+	 *		writer.setSelection( position );
 	 *
 	 * 		// Sets collapsed selection at the position of given item and offset.
-	 *		selection.setTo( paragraph, offset, { fake, label } );
+	 *		writer.setSelection( paragraph, offset );
 	 *
 	 *		// Sets selection inside the item.
-	 *		selection.setTo( paragraph, 'in', { backward, fake, label } );
+	 *		writer.setSelection( paragraph, 'in' );
 	 *
 	 *		// Sets selection on the item.
-	 *		selection.setTo( paragraph, 'on', { backward, fake, label } );
+	 *		writer.setSelection( paragraph, 'on' );
 	 *
 	 * 		// Removes all ranges.
 	 *		writer.setSelection( null );
+	 *
+	 *	`Writer#setSelection()` allow passing additional options (`backward`, `fake` and `label`) as the last argument.
+	 *
+	 *		// Sets selection as backward.
+	 *		writer.setSelection( range, { backward: true } );
+	 *
+	 *		// Sets selection as fake.
+	 *		// Fake selection does not render as browser native selection over selected elements and is hidden to the user.
+	 * 		// This way, no native selection UI artifacts are displayed to the user and selection over elements can be
+	 * 		// represented in other way, for example by applying proper CSS class.
+	 *		writer.setSelection( range, { fake: true } );
+	 *
+	 * 		// Additionally fake's selection label can be provided. It will be used to describe fake selection in DOM
+	 * 		// (and be  properly handled by screen readers).
+	 *		writer.setSelection( range, { fake: true, label: 'foo' } );
 	 *
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -61,16 +61,19 @@ export default class Writer {
 	 * 		// Sets collapsed selection at the position of given item and offset.
 	 *		writer.setSelection( paragraph, offset );
 	 *
-	 *		// Sets selection inside the item.
-	 *		writer.setSelection( paragraph, 'in' );
+	 * Creates a range inside an {@link module:engine/view/element~Element element} which starts before the first child of
+ 	 * that element and ends after the last child of that element.
 	 *
-	 *		// Sets selection on the item.
+	 * 		writer.setSelection( paragraph, 'in' );
+	 *
+	 * Creates a range on the {@link module:engine/view/item~Item item} which starts before the item and ends just after the item.
+	 *
 	 *		writer.setSelection( paragraph, 'on' );
 	 *
 	 * 		// Removes all ranges.
 	 *		writer.setSelection( null );
 	 *
-	 *	`Writer#setSelection()` allow passing additional options (`backward`, `fake` and `label`) as the last argument.
+	 * `Writer#setSelection()` allow passing additional options (`backward`, `fake` and `label`) as the last argument.
 	 *
 	 *		// Sets selection as backward.
 	 *		writer.setSelection( range, { backward: true } );

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -76,7 +76,7 @@ export default class Writer {
 	 *
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable
-	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets offset or place of the selection.
+	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets place or offset of the selection.
 	 * @param {Object} [options]
 	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.
 	 * @param {Boolean} [options.fake] Sets this selection instance to be marked as `fake`.

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -52,19 +52,30 @@ export default class Writer {
 	 *		const position = new Position( root, path );
 	 *		writer.setSelection( position );
 	 *
-	 * 		// Sets collapsed range on the given item.
-	 *		const paragraph = writer.createContainerElement( 'paragraph' );
-	 *		writer.setSelection( paragraph, offset );
+	 * 		// Sets collapsed range at the position of given item and offset.
+	 *		const paragraph = writer.createElement( 'paragraph' );
+	 *		selection.setTo( paragraph, offset );
+	 *
+	 *		// Sets range inside the item.
+	 *		const paragraph = writer.createElement( 'paragraph' );
+	 *		selection.setTo( paragraph, 'in' );
+	 *
+	 *		// Sets range on the item.
+	 *		const paragraph = writer.createElement( 'paragraph' );
+	 *		selection.setTo( paragraph, 'on' );
 	 *
 	 * 		// Removes all ranges.
 	 *		writer.setSelection( null );
 	 *
 	 * @param {module:engine/view/selection~Selection|module:engine/view/position~Position|
 	 * Iterable.<module:engine/view/range~Range>|module:engine/view/range~Range|module:engine/view/item~Item|null} selectable
-	 * @param {Boolean|Number|'before'|'end'|'after'} [backwardSelectionOrOffset]
+	 * @param {Object|Number|'before'|'end'|'after'|'on'|'in'} [optionsOrPlaceOrOffset]
+	 * @param {Boolean} [optionsOrPlaceOrOffset.backward]
+	 * @param {Object} [options]
+	 * @param {Boolean} [options.backward]
 	 */
-	setSelection( selectable, backwardSelectionOrOffset ) {
-		this.document.selection._setTo( selectable, backwardSelectionOrOffset );
+	setSelection( selectable, optionsOrPlaceOrOffset, options ) {
+		this.document.selection._setTo( selectable, optionsOrPlaceOrOffset, options );
 	}
 
 	/**

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -17,7 +17,6 @@ import {
 	convertRangeSelection,
 	convertCollapsedSelection,
 	clearAttributes,
-	clearFakeSelection
 } from '../../src/conversion/downcast-selection-converters';
 
 import {
@@ -475,14 +474,13 @@ describe( 'downcast-selection-converters', () => {
 				const viewString = stringifyView( viewRoot, viewSelection, { showType: false } );
 				expect( viewString ).to.equal( '<div>f{}oobar</div>' );
 			} );
-		} );
 
-		describe( 'clearFakeSelection', () => {
 			it( 'should clear fake selection', () => {
-				dispatcher.on( 'selection', clearFakeSelection() );
+				const modelRange = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 1 );
 
 				view.change( writer => {
-					writer.setFakeSelection( true );
+					writer.setSelection( modelRange, { fake: true } );
+
 					dispatcher.convertSelection( docSelection, model.markers, writer );
 				} );
 				expect( viewSelection.isFake ).to.be.false;

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -574,7 +574,7 @@ describe( 'downcast-selection-converters', () => {
 
 		const isBackward = selectionPaths[ 2 ] === 'backward';
 		model.change( writer => {
-			writer.setSelection( new ModelRange( startPos, endPos ), isBackward );
+			writer.setSelection( new ModelRange( startPos, endPos ), { backward: isBackward } );
 
 			// And add or remove passed attributes.
 			for ( const key in selectionAttributes ) {

--- a/tests/conversion/upcast-selection-converters.js
+++ b/tests/conversion/upcast-selection-converters.js
@@ -104,7 +104,7 @@ describe( 'convertSelectionChange', () => {
 				viewRoot.getChild( 0 ).getChild( 0 ), 1, viewRoot.getChild( 0 ).getChild( 0 ), 2 ),
 			ViewRange.createFromParentsAndOffsets(
 				viewRoot.getChild( 1 ).getChild( 0 ), 1, viewRoot.getChild( 1 ).getChild( 0 ), 2 )
-		], true );
+		], { backward: true } );
 
 		convertSelection( null, { newSelection: viewSelection } );
 

--- a/tests/dev-utils/model.js
+++ b/tests/dev-utils/model.js
@@ -283,7 +283,7 @@ describe( 'model test utils', () => {
 			it( 'writes selection in an empty root', () => {
 				const root = document.createRoot( '$root', 'empty' );
 				model.change( writer => {
-					writer.setSelection( root );
+					writer.setSelection( root, 0 );
 				} );
 
 				expect( stringify( root, selection ) ).to.equal(
@@ -293,7 +293,7 @@ describe( 'model test utils', () => {
 
 			it( 'writes selection collapsed in an element', () => {
 				model.change( writer => {
-					writer.setSelection( root );
+					writer.setSelection( root, 0 );
 				} );
 
 				expect( stringify( root, selection ) ).to.equal(
@@ -386,7 +386,7 @@ describe( 'model test utils', () => {
 
 			it( 'writes selection when is backward', () => {
 				model.change( writer => {
-					writer.setSelection( Range.createFromParentsAndOffsets( elA, 0, elB, 0 ), true );
+					writer.setSelection( Range.createFromParentsAndOffsets( elA, 0, elB, 0 ), { backward: true } );
 				} );
 
 				expect( stringify( root, selection ) ).to.equal(

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -250,7 +250,7 @@ describe( 'DocumentSelection', () => {
 			selection._setTo( [ range, liveRange ] );
 
 			const spy = testUtils.sinon.spy( LiveRange.prototype, 'detach' );
-			selection._setTo( root );
+			selection._setTo( root, 0 );
 
 			expect( spy.calledTwice ).to.be.true;
 		} );

--- a/tests/model/model.js
+++ b/tests/model/model.js
@@ -476,6 +476,8 @@ describe( 'Model', () => {
 
 			setData( model, '<paragraph>fo[ob]ar</paragraph>' );
 
+			expect( getData( model ) ).to.equal( '<paragraph>fo[ob]ar</paragraph>' );
+
 			model.modifySelection( model.document.selection, { direction: 'backward' } );
 
 			expect( getData( model ) ).to.equal( '<paragraph>fo[o]bar</paragraph>' );

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -320,6 +320,23 @@ describe( 'Selection', () => {
 			expect( ranges[ 0 ].end.offset ).to.deep.equal( 6 );
 		} );
 
+		it( 'should allow setting backward inside on the item', () => {
+			const textNode1 = new Text( 'foo' );
+			const textNode2 = new Text( 'bar' );
+			const textNode3 = new Text( 'baz' );
+			const element = new Element( 'p', null, [ textNode1, textNode2, textNode3 ] );
+
+			selection.setTo( textNode2, 'on', { backward: true } );
+
+			const ranges = Array.from( selection.getRanges() );
+			expect( ranges.length ).to.equal( 1 );
+			expect( ranges[ 0 ].start.parent ).to.equal( element );
+			expect( ranges[ 0 ].start.offset ).to.deep.equal( 3 );
+			expect( ranges[ 0 ].end.parent ).to.equal( element );
+			expect( ranges[ 0 ].end.offset ).to.deep.equal( 6 );
+			expect( selection.isBackward ).to.equal( true );
+		} );
+
 		// TODO - backward
 		// TODO - throwing
 

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -291,7 +291,7 @@ describe( 'Selection', () => {
 			} ).to.throw( /model-selection-setTo-not-selectable/ );
 		} );
 
-		it( 'should allow setting selection inside the element', () => {
+		it( 'should allow setting selection inside an element', () => {
 			const element = new Element( 'p', null, [ new Text( 'foo' ), new Text( 'bar' ) ] );
 
 			selection.setTo( element, 'in' );
@@ -304,7 +304,7 @@ describe( 'Selection', () => {
 			expect( ranges[ 0 ].end.offset ).to.deep.equal( 6 );
 		} );
 
-		it( 'should allow setting selection on the item', () => {
+		it( 'should allow setting selection on an item', () => {
 			const textNode1 = new Text( 'foo' );
 			const textNode2 = new Text( 'bar' );
 			const textNode3 = new Text( 'baz' );
@@ -320,7 +320,7 @@ describe( 'Selection', () => {
 			expect( ranges[ 0 ].end.offset ).to.deep.equal( 6 );
 		} );
 
-		it( 'should allow setting backward inside on the item', () => {
+		it( 'should allow setting backward selection on an item', () => {
 			const textNode1 = new Text( 'foo' );
 			const textNode2 = new Text( 'bar' );
 			const textNode3 = new Text( 'baz' );
@@ -334,7 +334,7 @@ describe( 'Selection', () => {
 			expect( ranges[ 0 ].start.offset ).to.deep.equal( 3 );
 			expect( ranges[ 0 ].end.parent ).to.equal( element );
 			expect( ranges[ 0 ].end.offset ).to.deep.equal( 6 );
-			expect( selection.isBackward ).to.equal( true );
+			expect( selection.isBackward ).to.be.true;
 		} );
 
 		// TODO - backward

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -2195,7 +2195,7 @@ describe( 'Writer', () => {
 			const firstParagraph = root.getNodeByPath( [ 1 ] );
 
 			const setToSpy = sinon.spy( DocumentSelection.prototype, '_setTo' );
-			setSelection( firstParagraph );
+			setSelection( firstParagraph, 0 );
 
 			expect( setToSpy.calledOnce ).to.be.true;
 			setToSpy.restore();
@@ -2204,7 +2204,7 @@ describe( 'Writer', () => {
 		it( 'should change document selection ranges', () => {
 			const range = new Range( new Position( root, [ 1 ] ), new Position( root, [ 2, 2 ] ) );
 
-			setSelection( range, true );
+			setSelection( range, { backward: true } );
 
 			expect( model.document.selection._ranges.length ).to.equal( 1 );
 			expect( model.document.selection._ranges[ 0 ].start.path ).to.deep.equal( [ 1 ] );
@@ -2566,9 +2566,9 @@ describe( 'Writer', () => {
 		} );
 	}
 
-	function setSelection( selectable, backwardSelectionOrOffset ) {
+	function setSelection( selectable, optionsOrPlaceOrOffset, options ) {
 		model.enqueueChange( batch, writer => {
-			writer.setSelection( selectable, backwardSelectionOrOffset );
+			writer.setSelection( selectable, optionsOrPlaceOrOffset, options );
 		} );
 	}
 

--- a/tests/view/domconverter/binding.js
+++ b/tests/view/domconverter/binding.js
@@ -7,7 +7,6 @@
 
 import ViewElement from '../../../src/view/element';
 import ViewSelection from '../../../src/view/selection';
-import ViewRange from '../../../src/view/range';
 import DomConverter from '../../../src/view/domconverter';
 import ViewDocumentFragment from '../../../src/view/documentfragment';
 import { INLINE_FILLER } from '../../../src/view/filler';
@@ -270,7 +269,7 @@ describe( 'DomConverter', () => {
 		beforeEach( () => {
 			viewElement = new ViewElement();
 			domEl = document.createElement( 'div' );
-			selection = new ViewSelection( ViewRange.createIn( viewElement ) );
+			selection = new ViewSelection( viewElement, 'in' );
 			converter.bindFakeSelection( domEl, selection );
 		} );
 
@@ -283,7 +282,7 @@ describe( 'DomConverter', () => {
 		it( 'should keep a copy of selection', () => {
 			const selectionCopy = new ViewSelection( selection );
 
-			selection._setTo( ViewRange.createIn( new ViewElement() ), true );
+			selection._setTo( new ViewElement(), 'in', { backward: true } );
 			const bindSelection = converter.fakeSelectionToView( domEl );
 
 			expect( bindSelection ).to.not.equal( selection );

--- a/tests/view/domconverter/dom-to-view.js
+++ b/tests/view/domconverter/dom-to-view.js
@@ -6,7 +6,6 @@
 /* globals document */
 
 import ViewElement from '../../../src/view/element';
-import ViewRange from '../../../src/view/range';
 import ViewSelection from '../../../src/view/selection';
 import DomConverter from '../../../src/view/domconverter';
 import ViewDocumentFragment from '../../../src/view/documentfragment';
@@ -859,7 +858,7 @@ describe( 'DomConverter', () => {
 			domContainer.innerHTML = 'fake selection container';
 			document.body.appendChild( domContainer );
 
-			const viewSelection = new ViewSelection( ViewRange.createIn( new ViewElement() ) );
+			const viewSelection = new ViewSelection( new ViewElement(), 'in' );
 			converter.bindFakeSelection( domContainer, viewSelection );
 
 			const domRange = document.createRange();
@@ -880,7 +879,7 @@ describe( 'DomConverter', () => {
 			domContainer.innerHTML = 'fake selection container';
 			document.body.appendChild( domContainer );
 
-			const viewSelection = new ViewSelection( ViewRange.createIn( new ViewElement() ) );
+			const viewSelection = new ViewSelection( new ViewElement(), 'in' );
 			converter.bindFakeSelection( domContainer, viewSelection );
 
 			const domRange = document.createRange();

--- a/tests/view/manual/fakeselection.js
+++ b/tests/view/manual/fakeselection.js
@@ -41,8 +41,7 @@ viewDocument.on( 'mouseup', ( evt, data ) => {
 		console.log( 'Making selection around the <strong>.' );
 
 		view.change( writer => {
-			writer.setSelection( ViewRange.createOn( viewStrong ) );
-			writer.setFakeSelection( true, { label: 'fake selection over bar' } );
+			writer.setSelection( ViewRange.createOn( viewStrong ), { fake: true, label: 'fake selection over bar' } );
 		} );
 
 		data.preventDefault();

--- a/tests/view/observer/fakeselectionobserver.js
+++ b/tests/view/observer/fakeselectionobserver.js
@@ -41,7 +41,7 @@ describe( 'FakeSelectionObserver', () => {
 	} );
 
 	it( 'should do nothing if selection is not fake', () => {
-		viewDocument.selection._setTo( null, { fake: true } );
+		viewDocument.selection._setTo( null, { fake: false } );
 
 		return checkEventPrevention( keyCodes.arrowleft, false );
 	} );

--- a/tests/view/observer/fakeselectionobserver.js
+++ b/tests/view/observer/fakeselectionobserver.js
@@ -33,7 +33,7 @@ describe( 'FakeSelectionObserver', () => {
 		root = createViewRoot( viewDocument );
 		view.attachDomRoot( domRoot );
 		observer = view.getObserver( FakeSelectionObserver );
-		viewDocument.selection._setFake();
+		viewDocument.selection._setTo( null, { fake: true } );
 	} );
 
 	afterEach( () => {
@@ -41,7 +41,7 @@ describe( 'FakeSelectionObserver', () => {
 	} );
 
 	it( 'should do nothing if selection is not fake', () => {
-		viewDocument.selection._setFake( false );
+		viewDocument.selection._setTo( null, { fake: true } );
 
 		return checkEventPrevention( keyCodes.arrowleft, false );
 	} );
@@ -200,7 +200,10 @@ describe( 'FakeSelectionObserver', () => {
 	//
 	// @param {Number} keyCode
 	function changeFakeSelectionPressing( keyCode ) {
-		viewDocument.selection._setFake();
+		viewDocument.selection._setTo( viewDocument.selection.getRanges(), {
+			backward: viewDocument.selection.isBackward,
+			fake: true
+		} );
 
 		const data = {
 			keyCode,

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -122,7 +122,6 @@ describe( 'Renderer', () => {
 			renderer.markedChildren.clear();
 
 			selection._setTo( null );
-			selection._setFake( false );
 
 			selectionEditable = viewRoot;
 
@@ -1369,7 +1368,7 @@ describe( 'Renderer', () => {
 
 			it( 'should render fake selection', () => {
 				const label = 'fake selection label';
-				selection._setFake( true, { label } );
+				selection._setTo( selection.getRanges(), { fake: true, label } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
@@ -1386,7 +1385,7 @@ describe( 'Renderer', () => {
 			} );
 
 			it( 'should render &nbsp; if no selection label is provided', () => {
-				selection._setFake( true );
+				selection._setTo( selection.getRanges(), { fake: true } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
@@ -1402,10 +1401,10 @@ describe( 'Renderer', () => {
 			} );
 
 			it( 'should remove fake selection container when selection is no longer fake', () => {
-				selection._setFake( true );
+				selection._setTo( selection.getRanges(), { fake: true } );
 				renderer.render();
 
-				selection._setFake( false );
+				selection._setTo( selection.getRanges(), { fake: false } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 1 );
@@ -1421,14 +1420,14 @@ describe( 'Renderer', () => {
 			it( 'should reuse fake selection container #1', () => {
 				const label = 'fake selection label';
 
-				selection._setFake( true, { label } );
+				selection._setTo( selection.getRanges(), { fake: true, label } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
 
 				const container = domRoot.childNodes[ 1 ];
 
-				selection._setFake( true, { label } );
+				selection._setTo( selection.getRanges(), { fake: true, label } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
@@ -1442,19 +1441,19 @@ describe( 'Renderer', () => {
 			} );
 
 			it( 'should reuse fake selection container #2', () => {
-				selection._setFake( true, { label: 'label 1' } );
+				selection._setTo( selection.getRanges(), { fake: true, label: 'label 1' } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
 
 				const container = domRoot.childNodes[ 1 ];
 
-				selection._setFake( false );
+				selection._setTo( selection.getRanges(), { fake: false } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 1 );
 
-				selection._setFake( true, { label: 'label 2' } );
+				selection._setTo( selection.getRanges(), { fake: true, label: 'label 2' } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
@@ -1468,14 +1467,14 @@ describe( 'Renderer', () => {
 			} );
 
 			it( 'should reuse fake selection container #3', () => {
-				selection._setFake( true, { label: 'label 1' } );
+				selection._setTo( selection.getRanges(), { fake: true, label: 'label 1' } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
 
 				const container = domRoot.childNodes[ 1 ];
 
-				selection._setFake( true, { label: 'label 2' } );
+				selection._setTo( selection.getRanges(), { fake: true, label: 'label 2' } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
@@ -1489,7 +1488,7 @@ describe( 'Renderer', () => {
 			} );
 
 			it( 'should style fake selection container properly', () => {
-				selection._setFake( true, { label: 'fake selection' } );
+				selection._setTo( selection.getRanges(), { fake: true, label: 'fake selection' } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );
@@ -1502,7 +1501,7 @@ describe( 'Renderer', () => {
 			} );
 
 			it( 'should bind fake selection container to view selection', () => {
-				selection._setFake( true, { label: 'fake selection' } );
+				selection._setTo( selection.getRanges(), { fake: true, label: 'fake selection' } );
 				renderer.render();
 
 				expect( domRoot.childNodes.length ).to.equal( 2 );

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -764,15 +764,6 @@ describe( 'Selection', () => {
 
 				selection._setTo( selection.getFirstPosition() );
 			} );
-
-			it( 'should do nothing if no ranges present', () => {
-				const fireSpy = sinon.spy( selection, 'fire' );
-
-				selection._setTo( selection.getFirstPosition() );
-
-				fireSpy.restore();
-				expect( fireSpy.notCalled ).to.be.true;
-			} );
 		} );
 
 		describe( 'setting collapsed selection to end', () => {
@@ -787,15 +778,6 @@ describe( 'Selection', () => {
 
 				selection._setTo( selection.getLastPosition() );
 			} );
-
-			it( 'should do nothing if no ranges present', () => {
-				const fireSpy = sinon.spy( selection, 'fire' );
-
-				selection._setTo( selection.getLastPosition() );
-
-				fireSpy.restore();
-				expect( fireSpy.notCalled ).to.be.true;
-			} );
 		} );
 
 		describe( 'removing all ranges', () => {
@@ -808,14 +790,6 @@ describe( 'Selection', () => {
 				} );
 
 				selection._setTo( null );
-			} );
-
-			it( 'should do nothing when no ranges are present', () => {
-				const fireSpy = sinon.spy( selection, 'fire' );
-				selection._setTo( null );
-
-				fireSpy.restore();
-				expect( fireSpy.notCalled ).to.be.true;
 			} );
 		} );
 
@@ -864,6 +838,30 @@ describe( 'Selection', () => {
 
 				expect( selection.fakeSelectionLabel ).to.equal( 'foo bar baz' );
 				expect( selection.isFake ).to.be.true;
+			} );
+		} );
+
+		describe( 'setting selection to itself', () => {
+			it( 'should correctly set ranges when setting to the same selection', () => {
+				selection._setTo( [ range1, range2 ] );
+				selection._setTo( selection );
+
+				const ranges = Array.from( selection.getRanges() );
+				expect( ranges.length ).to.equal( 2 );
+
+				expect( ranges[ 0 ].isEqual( range1 ) ).to.be.true;
+				expect( ranges[ 1 ].isEqual( range2 ) ).to.be.true;
+			} );
+
+			it( 'should correctly set ranges when setting to the same selection\'s ranges', () => {
+				selection._setTo( [ range1, range2 ] );
+				selection._setTo( selection.getRanges() );
+
+				const ranges = Array.from( selection.getRanges() );
+				expect( ranges.length ).to.equal( 2 );
+
+				expect( ranges[ 0 ].isEqual( range1 ) ).to.be.true;
+				expect( ranges[ 1 ].isEqual( range2 ) ).to.be.true;
 			} );
 		} );
 

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -881,6 +881,49 @@ describe( 'Selection', () => {
 				} ).to.throw( CKEditorError, 'view-selection-range-intersects' );
 			} );
 		} );
+
+		it( 'should allow setting selection on an item', () => {
+			const textNode1 = new Text( 'foo' );
+			const textNode2 = new Text( 'bar' );
+			const textNode3 = new Text( 'baz' );
+			const element = new Element( 'p', null, [ textNode1, textNode2, textNode3 ] );
+
+			selection._setTo( textNode2, 'on' );
+
+			const ranges = Array.from( selection.getRanges() );
+			expect( ranges.length ).to.equal( 1 );
+			expect( ranges[ 0 ].start.parent ).to.equal( element );
+			expect( ranges[ 0 ].start.offset ).to.deep.equal( 1 );
+			expect( ranges[ 0 ].end.parent ).to.equal( element );
+			expect( ranges[ 0 ].end.offset ).to.deep.equal( 2 );
+		} );
+
+		it( 'should allow setting selection inside an element', () => {
+			const element = new Element( 'p', null, [ new Text( 'foo' ), new Text( 'bar' ) ] );
+
+			selection._setTo( element, 'in' );
+
+			const ranges = Array.from( selection.getRanges() );
+			expect( ranges.length ).to.equal( 1 );
+			expect( ranges[ 0 ].start.parent ).to.equal( element );
+			expect( ranges[ 0 ].start.offset ).to.deep.equal( 0 );
+			expect( ranges[ 0 ].end.parent ).to.equal( element );
+			expect( ranges[ 0 ].end.offset ).to.deep.equal( 2 );
+		} );
+
+		it( 'should allow setting backward selection inside an element', () => {
+			const element = new Element( 'p', null, [ new Text( 'foo' ), new Text( 'bar' ) ] );
+
+			selection._setTo( element, 'in', { backward: true } );
+
+			const ranges = Array.from( selection.getRanges() );
+			expect( ranges.length ).to.equal( 1 );
+			expect( ranges[ 0 ].start.parent ).to.equal( element );
+			expect( ranges[ 0 ].start.offset ).to.deep.equal( 0 );
+			expect( ranges[ 0 ].end.parent ).to.equal( element );
+			expect( ranges[ 0 ].end.offset ).to.deep.equal( 2 );
+			expect( selection.isBackward ).to.be.true;
+		} );
 	} );
 
 	describe( 'getEditableElement()', () => {

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -44,13 +44,13 @@ describe( 'Selection', () => {
 
 		it( 'should be able to create a selection from the given ranges and isLastBackward flag', () => {
 			const ranges = [ range1, range2, range3 ];
-			const selection = new Selection( ranges, true );
+			const selection = new Selection( ranges, { backward: true } );
 
 			expect( selection.isBackward ).to.be.true;
 		} );
 
 		it( 'should be able to create a selection from the given range and isLastBackward flag', () => {
-			const selection = new Selection( range1, true );
+			const selection = new Selection( range1, { backward: true } );
 
 			expect( Array.from( selection.getRanges() ) ).to.deep.equal( [ range1 ] );
 			expect( selection.isBackward ).to.be.true;
@@ -58,7 +58,7 @@ describe( 'Selection', () => {
 
 		it( 'should be able to create a selection from the given iterable of ranges and isLastBackward flag', () => {
 			const ranges = new Set( [ range1, range2, range3 ] );
-			const selection = new Selection( ranges, false );
+			const selection = new Selection( ranges, { backward: false } );
 
 			expect( Array.from( selection.getRanges() ) ).to.deep.equal( [ range1, range2, range3 ] );
 			expect( selection.isBackward ).to.be.false;
@@ -85,7 +85,7 @@ describe( 'Selection', () => {
 		} );
 
 		it( 'should be able to create a selection from the other selection', () => {
-			const otherSelection = new Selection( [ range2, range3 ], true );
+			const otherSelection = new Selection( [ range2, range3 ], { backward: true } );
 			const selection = new Selection( otherSelection );
 
 			expect( Array.from( selection.getRanges() ) ).to.deep.equal( [ range2, range3 ] );
@@ -140,7 +140,7 @@ describe( 'Selection', () => {
 		} );
 
 		it( 'should return end of single range in selection when added as backward', () => {
-			selection._setTo( range1, true );
+			selection._setTo( range1, { backward: true } );
 			const anchor = selection.anchor;
 
 			expect( anchor.isEqual( range1.end ) ).to.be.true;
@@ -167,7 +167,7 @@ describe( 'Selection', () => {
 		} );
 
 		it( 'should return start of single range in selection when added as backward', () => {
-			selection._setTo( range1, true );
+			selection._setTo( range1, { backward: true } );
 			const focus = selection.focus;
 
 			expect( focus.isEqual( range1.start ) ).to.be.true;
@@ -254,7 +254,7 @@ describe( 'Selection', () => {
 			const endPos = Position.createAt( el, 2 );
 			const newEndPos = Position.createAt( el, 3 );
 
-			selection._setTo( new Range( startPos, endPos ), true );
+			selection._setTo( new Range( startPos, endPos ), { backward: true } );
 
 			selection._setFocus( newEndPos );
 
@@ -268,7 +268,7 @@ describe( 'Selection', () => {
 			const endPos = Position.createAt( el, 2 );
 			const newEndPos = Position.createAt( el, 0 );
 
-			selection._setTo( new Range( startPos, endPos ), true );
+			selection._setTo( new Range( startPos, endPos ), { backward: true } );
 
 			selection._setFocus( newEndPos );
 
@@ -376,7 +376,7 @@ describe( 'Selection', () => {
 			const range1 = Range.createFromParentsAndOffsets( el, 5, el, 10 );
 			const range2 = Range.createFromParentsAndOffsets( el, 15, el, 16 );
 
-			selection._setTo( range1, true );
+			selection._setTo( range1, { backward: true } );
 			expect( selection ).to.have.property( 'isBackward', true );
 
 			selection._setTo( [ range1, range2 ] );
@@ -386,7 +386,7 @@ describe( 'Selection', () => {
 		it( 'is false when last range is collapsed', () => {
 			const range = Range.createFromParentsAndOffsets( el, 5, el, 5 );
 
-			selection._setTo( range, true );
+			selection._setTo( range, { backward: true } );
 
 			expect( selection.isBackward ).to.be.false;
 		} );
@@ -478,9 +478,9 @@ describe( 'Selection', () => {
 		} );
 
 		it( 'should return true if backward selections equal', () => {
-			selection._setTo( range1, true );
+			selection._setTo( range1, { backward: true } );
 
-			const otherSelection = new Selection( [ range1 ], true );
+			const otherSelection = new Selection( [ range1 ], { backward: true } );
 
 			expect( selection.isEqual( otherSelection ) ).to.be.true;
 		} );
@@ -504,7 +504,7 @@ describe( 'Selection', () => {
 		it( 'should return false if directions do not equal', () => {
 			selection._setTo( range1 );
 
-			const otherSelection = new Selection( [ range1 ], true );
+			const otherSelection = new Selection( [ range1 ], { backward: true } );
 
 			expect( selection.isEqual( otherSelection ) ).to.be.false;
 		} );
@@ -569,7 +569,7 @@ describe( 'Selection', () => {
 		it( 'should return false if directions are not equal', () => {
 			selection._setTo( range1 );
 
-			const otherSelection = new Selection( [ range1 ], true );
+			const otherSelection = new Selection( [ range1 ], { backward: true } );
 
 			expect( selection.isSimilar( otherSelection ) ).to.be.false;
 		} );
@@ -646,7 +646,7 @@ describe( 'Selection', () => {
 			it( 'should set selection ranges from the given selection', () => {
 				selection._setTo( range1 );
 
-				const otherSelection = new Selection( [ range2, range3 ], true );
+				const otherSelection = new Selection( [ range2, range3 ], { backward: true } );
 
 				selection._setTo( otherSelection );
 
@@ -753,7 +753,7 @@ describe( 'Selection', () => {
 				const foo = new Text( 'foo' );
 				const p = new Element( 'p', null, foo );
 
-				selection._setTo( foo );
+				selection._setTo( foo, 0 );
 				let range = selection.getFirstRange();
 
 				expect( range.start.parent ).to.equal( foo );
@@ -766,6 +766,14 @@ describe( 'Selection', () => {
 				expect( range.start.parent ).to.equal( p );
 				expect( range.start.offset ).to.equal( 1 );
 				expect( range.start.isEqual( range.end ) ).to.be.true;
+			} );
+
+			it( 'should throw an error when the second parameter is not passed and first is an item', () => {
+				const foo = new Text( 'foo' );
+
+				expect( () => {
+					selection._setTo( foo );
+				} ).to.throw( CKEditorError, /view-selection-setTo-required-second-parameter/ );
 			} );
 
 			it( 'should collapse selection at node and flag', () => {

--- a/tests/view/writer/writer.js
+++ b/tests/view/writer/writer.js
@@ -10,23 +10,33 @@ import ViewPosition from '../../../src/view/position';
 import createViewRoot from '../_utils/createroot';
 
 describe( 'Writer', () => {
-	let writer, attributes, root;
+	let writer, attributes, root, doc;
 
 	before( () => {
 		attributes = { foo: 'bar', baz: 'quz' };
-		const document = new Document();
-		root = createViewRoot( document );
-		writer = new Writer( document );
+		doc = new Document();
+		root = createViewRoot( doc );
+		writer = new Writer( doc );
 	} );
 
 	describe( 'setSelection()', () => {
-		it( 'should use selection._setTo method internally', () => {
-			const spy = sinon.spy( writer.document.selection, '_setTo' );
+		it( 'should set document view selection', () => {
 			const position = ViewPosition.createAt( root );
 			writer.setSelection( position );
 
-			sinon.assert.calledWith( spy, position );
-			spy.restore();
+			const ranges = Array.from( doc.selection.getRanges() );
+
+			expect( ranges.length ).to.equal( 1 );
+			expect( ranges[ 0 ].start.compareWith( position ) ).to.equal( 'same' );
+			expect( ranges[ 0 ].end.compareWith( position ) ).to.equal( 'same' );
+		} );
+
+		it( 'should be able to set fake selection', () => {
+			const position = ViewPosition.createAt( root );
+			writer.setSelection( position, { fake: true, label: 'foo' } );
+
+			expect( doc.selection.isFake ).to.be.true;
+			expect( doc.selection.fakeSelectionLabel ).to.equal( 'foo' );
 		} );
 	} );
 
@@ -36,17 +46,6 @@ describe( 'Writer', () => {
 			writer.setSelectionFocus( root, 0 );
 
 			sinon.assert.calledWithExactly( spy, root, 0 );
-			spy.restore();
-		} );
-	} );
-
-	describe( 'setFakeSelection()', () => {
-		it( 'should use selection._setFake method internally', () => {
-			const spy = sinon.spy( writer.document.selection, '_setFake' );
-			const options = {};
-			writer.setFakeSelection( true, options );
-
-			sinon.assert.calledWithExactly( spy, true, options );
 			spy.restore();
 		} );
 	} );

--- a/tests/view/writer/writer.js
+++ b/tests/view/writer/writer.js
@@ -23,9 +23,9 @@ describe( 'Writer', () => {
 		it( 'should use selection._setTo method internally', () => {
 			const spy = sinon.spy( writer.document.selection, '_setTo' );
 			const position = ViewPosition.createAt( root );
-			writer.setSelection( position, true );
+			writer.setSelection( position );
 
-			sinon.assert.calledWithExactly( spy, position, true );
+			sinon.assert.calledWith( spy, position );
 			spy.restore();
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Improved `Writer#setSelection()` and `Selection#setTo()` methods. Closes #1308.

---

### Additional information

BREAKING CHANGE: `Writer#setFakeSelection()` method is removed. You should use `Writer#setSelection()` method with additional options (`fake` and `label`) to achieve the same effect.
BREAKING CHANGE: `Writer#setSelection( item )` now requires second parameter. It can be offset or `in` / `on` to create selection in / on the item.

Affected repos:
* https://github.com/ckeditor/ckeditor5-typing/tree/t/ckeditor5-engine/1308
* https://github.com/ckeditor/ckeditor5-link/tree/t/ckeditor5-engine/1308
* https://github.com/ckeditor/ckeditor5-list/tree/t/ckeditor5-engine/1308
* https://github.com/ckeditor/ckeditor5-paragraph/tree/t/ckeditor5-engine/1308
* https://github.com/ckeditor/ckeditor5-undo/tree/t/ckeditor5-engine/1308
* https://github.com/ckeditor/ckeditor5-widget/tree/t/ckeditor5-engine/1308
* https://github.com/ckeditor/ckeditor5-enter/tree/t/ckeditor5-engine/1308
* https://github.com/ckeditor/ckeditor5-clipboard/tree/t/ckeditor5-engine/1308