### PR TITLE
Update model selection attributes after each change

### DIFF
--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -19,10 +19,6 @@ import toMap from '@ckeditor/ckeditor5-utils/src/tomap';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import log from '@ckeditor/ckeditor5-utils/src/log';
 
-const attrOpTypes = new Set(
-	[ 'addAttribute', 'removeAttribute', 'changeAttribute', 'addRootAttribute', 'removeRootAttribute', 'changeRootAttribute' ]
-);
-
 const storePrefix = 'selection:';
 
 /**
@@ -531,29 +527,13 @@ class LiveSelection extends Selection {
 			}
 		} );
 
-		this.listenTo( this._model, 'applyOperation', ( evt, args ) => {
-			const operation = args[ 0 ];
+		this.listenTo( this._document, 'change', ( evt, batch ) => {
+			// Update selection's attributes.
+			this._updateAttributes( false );
 
-			if ( !operation.isDocumentOperation ) {
-				return;
-			}
-
-			// Whenever attribute operation is performed on document, update selection attributes.
-			// This is not the most efficient way to update selection attributes, but should be okay for now.
-			if ( attrOpTypes.has( operation.type ) ) {
-				this._updateAttributes( false );
-			}
-
-			const batch = operation.delta.batch;
-
-			// Batch may not be passed to the document#change event in some tests.
-			// See https://github.com/ckeditor/ckeditor5-engine/issues/1001#issuecomment-314202352
-			if ( batch ) {
-				// Whenever element which had selection's attributes stored in it stops being empty,
-				// the attributes need to be removed.
-				clearAttributesStoredInElement( operation, this._model, batch );
-			}
-		}, { priority: 'low' } );
+			// Clear selection attributes from element if no longer empty,
+			clearAttributesStoredInElement( this._model, batch );
+		} );
 
 		this.listenTo( this._model, 'applyOperation', () => {
 			while ( this._fixGraveyardRangesData.length ) {
@@ -1019,24 +999,27 @@ function getAttrsIfCharacter( node ) {
 }
 
 // Removes selection attributes from element which is not empty anymore.
-function clearAttributesStoredInElement( operation, model, batch ) {
-	let changeParent = null;
+function clearAttributesStoredInElement( model, batch ) {
+	// Clear attributes stored in selection;
+	const differ = model.document.differ;
 
-	if ( operation.type == 'insert' ) {
-		changeParent = operation.position.parent;
-	} else if ( operation.type == 'move' || operation.type == 'reinsert' || operation.type == 'remove' ) {
-		changeParent = operation.getMovedRangeStart().parent;
-	}
-
-	if ( !changeParent || changeParent.isEmpty ) {
-		return;
-	}
-
-	model.enqueueChange( batch, writer => {
-		const storedAttributes = Array.from( changeParent.getAttributeKeys() ).filter( key => key.startsWith( storePrefix ) );
-
-		for ( const key of storedAttributes ) {
-			writer.removeAttribute( key, changeParent );
+	for ( const entry of differ.getChanges() ) {
+		if ( entry.type != 'insert' || !entry.position.parent ) {
+			continue;
 		}
-	} );
+
+		const changeParent = entry.position.parent;
+		const isNoLongerEmpty = entry.length === changeParent.maxOffset;
+
+		if ( isNoLongerEmpty ) {
+			model.enqueueChange( batch, writer => {
+				const storedAttributes = Array.from( changeParent.getAttributeKeys() )
+					.filter( key => key.startsWith( storePrefix ) );
+
+				for ( const key of storedAttributes ) {
+					writer.removeAttribute( key, changeParent );
+				}
+			} );
+		}
+	}
 }

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -801,6 +801,9 @@ class LiveSelection extends Selection {
 	// Internal method for removing `LiveSelection` attribute. Supports attribute priorities (through `directChange`
 	// parameter).
 	//
+	// NOTE: Even if attribute is not present in the selection but is provided to this method, it's priority will
+	// be changed according to `directChange` parameter.
+	//
 	// @private
 	// @param {String} key Attribute key.
 	// @param {Boolean} [directChange=true] `true` if the change is caused by `Selection` API, `false` if change
@@ -815,15 +818,15 @@ class LiveSelection extends Selection {
 			return false;
 		}
 
+		// Update priorities map.
+		this._attributePriority.set( key, priority );
+
 		// Don't do anything if value has not changed.
 		if ( !super.hasAttribute( key ) ) {
 			return false;
 		}
 
 		this._attrs.delete( key );
-
-		// Update priorities map.
-		this._attributePriority.set( key, priority );
 
 		return true;
 	}

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -1012,7 +1012,7 @@ function clearAttributesStoredInElement( model, batch ) {
 	const differ = model.document.differ;
 
 	for ( const entry of differ.getChanges() ) {
-		if ( entry.type != 'insert' || !entry.position.parent ) {
+		if ( entry.type != 'insert' ) {
 			continue;
 		}
 

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -999,8 +999,11 @@ function getAttrsIfCharacter( node ) {
 }
 
 // Removes selection attributes from element which is not empty anymore.
+//
+// @private
+// @param {module:engine/model/model~Model} model
+// @param {module:engine/model/batch~Batch} batch
 function clearAttributesStoredInElement( model, batch ) {
-	// Clear attributes stored in selection;
 	const differ = model.document.differ;
 
 	for ( const entry of differ.getChanges() ) {

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -531,7 +531,7 @@ class LiveSelection extends Selection {
 			// Update selection's attributes.
 			this._updateAttributes( false );
 
-			// Clear selection attributes from element if no longer empty,
+			// Clear selection attributes from element if no longer empty.
 			clearAttributesStoredInElement( this._model, batch );
 		} );
 

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -1056,15 +1056,10 @@ describe( 'DocumentSelection', () => {
 					expect( data.attributeKeys ).to.deep.equal( [ 'foo' ] );
 				} );
 
-				model.applyOperation( wrapInDelta(
-					new AttributeOperation(
-						new Range( new Position( root, [ 0, 1 ] ), new Position( root, [ 0, 5 ] ) ),
-						'foo',
-						null,
-						'bar',
-						doc.version
-					)
-				) );
+				model.change( writer => {
+					const range = new Range( new Position( root, [ 0, 1 ] ), new Position( root, [ 0, 5 ] ) );
+					writer.setAttribute( 'foo', 'bar', range );
+				} );
 
 				expect( selection.getAttribute( 'foo' ) ).to.equal( 'bar' );
 				expect( spyAttribute.calledOnce ).to.be.true;

--- a/tests/tickets/1267.js
+++ b/tests/tickets/1267.js
@@ -1,0 +1,75 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals document */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Position from '../../src/model/position';
+import Range from '../../src/model/range';
+import { setData as setModelData, getData as getModelData } from '../../src/dev-utils/model';
+
+describe( 'Bug ckeditor5-engine#1267', () => {
+	let element, editor, model;
+
+	beforeEach( () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		return ClassicTestEditor
+			.create( element, { plugins: [ Paragraph, Bold ] } )
+			.then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+			} );
+	} );
+
+	afterEach( () => {
+		element.remove();
+
+		return editor.destroy();
+	} );
+
+	it( 'selection should not retain attributes after external change removal', () => {
+		setModelData( model,
+			'<paragraph>foo bar baz</paragraph>' +
+			'<paragraph>foo <$text bold="true">bar{}</$text> baz</paragraph>'
+		);
+
+		// Remove second paragraph where selection is placed.
+		model.enqueueChange( 'transparent', writer => {
+			writer.remove( Range.createFromPositionAndShift( new Position( model.document.getRoot(), [ 1 ] ), 1 ) );
+		} );
+
+		expect( getModelData( model ) ).to.equal( '<paragraph>foo bar baz[]</paragraph>' );
+	} );
+
+	it( 'selection should retain attributes set manually', () => {
+		setModelData( model,
+			'<paragraph>foo bar baz</paragraph>' +
+			'<paragraph>foo bar baz</paragraph>' +
+			'<paragraph>[]</paragraph>'
+		);
+
+		// Execute bold command when selection is inside empty paragraph.
+		editor.execute( 'bold' );
+		expect( getModelData( model ) ).to.equal(
+			'<paragraph>foo bar baz</paragraph>' +
+			'<paragraph>foo bar baz</paragraph>' +
+			'<paragraph selection:bold="true"><$text bold="true">[]</$text></paragraph>'
+		);
+
+		// Remove second paragraph.
+		model.enqueueChange( 'transparent', writer => {
+			writer.remove( Range.createFromPositionAndShift( new Position( model.document.getRoot(), [ 1 ] ), 1 ) );
+		} );
+
+		// Selection attributes set by command should stay as they were.
+		expect( getModelData( model ) ).to.equal(
+			'<paragraph>foo bar baz</paragraph>' +
+			'<paragraph selection:bold="true"><$text bold="true">[]</$text></paragraph>' );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `model.DocumentSelection` should update it's attributes after each change, including external changes. Closes #1267.

---
Close together with: https://github.com/ckeditor/ckeditor5-undo/pull/83 and https://github.com/ckeditor/ckeditor5-autoformat/pull/52.

