### PR TITLE
`model.Range#getTransformedByDelta` should not crash for `MoveDelta` which moves no nodes

### DIFF
--- a/src/model/range.js
+++ b/src/model/range.js
@@ -399,13 +399,24 @@ export default class Range {
 		for ( const operation of delta.operations ) {
 			if ( supportedTypes.has( operation.type ) ) {
 				for ( let i = 0; i < ranges.length; i++ ) {
-					const result = ranges[ i ]._getTransformedByDocumentChange(
-						operation.type,
-						delta.type,
-						operation.targetPosition || operation.position,
-						operation.howMany || operation.nodes.maxOffset,
-						operation.sourcePosition
-					);
+					let result;
+
+					if ( operation.type == 'insert' ) {
+						result = ranges[ i ]._getTransformedByDocumentChange(
+							operation.type,
+							delta.type,
+							operation.position,
+							operation.nodes.maxOffset
+						);
+					} else {
+						result = ranges[ i ]._getTransformedByDocumentChange(
+							operation.type,
+							delta.type,
+							operation.targetPosition,
+							operation.howMany,
+							operation.sourcePosition
+						);
+					}
 
 					ranges.splice( i, 1, ...result );
 

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -933,6 +933,18 @@ describe( 'Range', () => {
 				expect( transformed[ 0 ].start.path ).to.deep.equal( [ 0, 1 ] );
 				expect( transformed[ 0 ].end.path ).to.deep.equal( [ 2, 1 ] );
 			} );
+
+			// #1358
+			it( 'should not crash and not transform the range if move delta moves 0 nodes', () => {
+				const range = new Range( new Position( root, [ 0, 2 ] ), new Position( root, [ 0, 4 ] ) );
+				const delta = getMoveDelta( new Position( root, [ 0, 1 ] ), 0, new Position( root, [ 0, 3 ] ), 1 );
+
+				const transformed = range.getTransformedByDelta( delta );
+
+				expect( transformed.length ).to.equal( 1 );
+				expect( transformed[ 0 ].start.path ).to.deep.equal( [ 0, 2 ] );
+				expect( transformed[ 0 ].end.path ).to.deep.equal( [ 0, 4 ] );
+			} );
 		} );
 
 		describe( 'by RemoveDelta', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `model.Range#getTransformedByDelta` should not crash for `MoveDelta` which moves no nodes. Closes #1358.