### PR TITLE
Introduced deep children text nodes rerendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@ckeditor/ckeditor5-typing": "^1.0.0-beta.1",
     "@ckeditor/ckeditor5-undo": "^1.0.0-beta.1",
     "@ckeditor/ckeditor5-widget": "^1.0.0-beta.1",
+    "@ckeditor/ckeditor5-link": "^1.0.0-beta.1",
     "eslint": "^4.15.0",
     "eslint-config-ckeditor5": "^1.0.7",
     "husky": "^0.14.3",

--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -206,7 +206,7 @@ export default class MutationObserver extends Observer {
 		for ( const viewElement of mutatedElements ) {
 			const domElement = domConverter.mapViewToDom( viewElement );
 			const viewChildren = Array.from( viewElement.getChildren() );
-			const newViewChildren = Array.from( domConverter.domChildrenToView( domElement ) );
+			const newViewChildren = Array.from( domConverter.domChildrenToView( domElement, { withChildren: false } ) );
 
 			// It may happen that as a result of many changes (sth was inserted and then removed),
 			// both elements haven't really changed. #1031

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -541,14 +541,16 @@ export default class Renderer {
 	 * @private
 	 * @param {module:engine/view/node~Node} viewNode View node to sync.
 	 */
-	_markDescendantTextToSync( viewElement ) {
-		if ( viewElement ) {
-			if ( viewElement.is( 'text' ) ) {
-				this.markedTexts.add( viewElement );
-			} else if ( viewElement.is( 'element' ) ) {
-				for ( const child of viewElement.getChildren() ) {
-					this._markDescendantTextToSync( child );
-				}
+	_markDescendantTextToSync( viewNode ) {
+		if ( !viewNode ) {
+			return;
+		}
+
+		if ( viewNode.is( 'text' ) ) {
+			this.markedTexts.add( viewNode );
+		} else if ( viewNode.is( 'element' ) ) {
+			for ( const child of viewNode.getChildren() ) {
+				this._markDescendantTextToSync( child );
 			}
 		}
 	}

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -498,7 +498,7 @@ export default class Renderer {
 				nodesToUnbind.add( actualDomChildren[ i ] );
 				remove( actualDomChildren[ i ] );
 			} else { // 'equal'
-				// Inserted nodes are already up to date, so we mark to sync those which was not rerendered (#1125).
+				// Force updating text nodes inside elements which did not change and do not need to be re-rendered (#1125).
 				this._markDescendantTextToSync( domConverter.domToView( expectedDomChildren[ i ] ) );
 				i++;
 			}
@@ -534,11 +534,12 @@ export default class Renderer {
 	}
 
 	/**
-	 * Marks all text nodes in a tree starting from passed element to be synced.
+	 * Marks text nodes to be synced.
+	 *
+	 * If a text node is passed, it will be marked. If an element is passed, all descendant text nodes inside it will be marked.
 	 *
 	 * @private
-	 * @param {module:engine/view/element~Element} viewElement View element whose all 'text' children should
-	 * be marked to sync. If element is 'text' itself it will be marked too.
+	 * @param {module:engine/view/node~Node} viewNode View node to sync.
 	 */
 	_markDescendantTextToSync( viewElement ) {
 		if ( viewElement ) {

--- a/tests/view/manual/deep-render.html
+++ b/tests/view/manual/deep-render.html
@@ -1,0 +1,9 @@
+<div id="editor">
+	<p>Foo<u> bar</u></p>
+	<p><u>Foo</u><i> buz</i></p>
+	<p>Foo<a href="#"><b> biz</b></a></p>
+	<p>Text <a href="#">Link <b>Bold</b></a> Text</p>
+</div>
+
+<p>Editor HTML preview:</p>
+<code id="preview"></code>

--- a/tests/view/manual/deep-render.js
+++ b/tests/view/manual/deep-render.js
@@ -1,0 +1,34 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global console, document, window */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import Link from '@ckeditor/ckeditor5-link/src/link';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ Essentials, Paragraph, Underline, Bold, Italic, Link ],
+		toolbar: [ 'undo', 'redo', '|', 'bold', 'underline', 'italic', 'link' ]
+	} )
+	.then( editor => {
+		window.editor = editor;
+
+		const preview = document.querySelector( '#preview' );
+
+		preview.innerText = editor.getData();
+
+		editor.editing.view.on( 'render', () => {
+			preview.innerText = editor.getData();
+		} );
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/tests/view/manual/deep-render.md
+++ b/tests/view/manual/deep-render.md
@@ -1,0 +1,15 @@
+## Text nodes deep rendering ([#1125](https://github.com/ckeditor/ckeditor5-engine/issues/1125))
+
+### Deep space rerender ([#1093](https://github.com/ckeditor/ckeditor5-engine/issues/1093))
+
+1. Put caret after each `Foo` text (`Foo^`).
+1. Press space.
+
+**Expected**: Inserted space is visible. Space on the beginning of the next text node is replaced with `&nbsp;`.
+
+### Link ending with styles ([ckeditor5-typing#120](https://github.com/ckeditor/ckeditor5-typing/issues/120))
+
+1. Put caret on the end of the link (`Link Bold^`).
+1. Insert some text.
+
+**Expected**: Bold text is inserted as a part of the link. No errors thrown in the browser dev console.

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1571,11 +1571,17 @@ describe( 'Renderer', () => {
 			renderer.markToSync( 'text', viewHeading.getChild( 0 ) );
 
 			// '<p>Ph <strong>Bold</strong> <i>It<strong>alic</strong></i> <a><strong>Lin</strong>k</a></p>'
-			// -> '<p>Ph <i><strong>Italic</strong></i> <a><strong>L</strong>ink 1</a></p>'
+			// ->
+			// '<p>Ph <i><strong>Italic</strong></i> <a><strong>L</strong>ink 1</a></p>'
 			const viewP = viewRoot.getChild( 1 );
 			viewP._removeChildren( 0, viewP.childCount );
-			viewP._insertChildren( 0, parse( 'Ph <attribute:i><attribute:strong>Italic</attribute:strong></attribute:i> ' +
-				'<attribute:a href="https://ckeditor.com"><attribute:strong>L</attribute:strong>ink 1</attribute:a>' ) );
+			viewP._insertChildren(
+				0,
+				parse(
+					'Ph <attribute:i><attribute:strong>Italic</attribute:strong></attribute:i> ' +
+					'<attribute:a href="https://ckeditor.com"><attribute:strong>L</attribute:strong>ink 1</attribute:a>'
+				)
+			);
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.markToSync( 'children', viewP );
@@ -1588,8 +1594,13 @@ describe( 'Renderer', () => {
 			// -> '<blockquote><p>Qu<strong>ote</strong></p><ul><li><strong>Quoted item 1</strong></li></ul></blockquote>'
 			const viewBq = viewRoot.getChild( 2 );
 			viewBq._removeChildren( 0, viewBq.childCount );
-			viewBq._insertChildren( 0, parse( '<container:p>Qu<attribute:strong>ote</attribute:strong></container:p>' +
-				'<container:ul><container:li><attribute:strong>Quoted item 1</attribute:strong></container:li></container:ul>' ) );
+			viewBq._insertChildren(
+				0,
+				parse(
+					'<container:p>Qu<attribute:strong>ote</attribute:strong></container:p>' +
+					'<container:ul><container:li><attribute:strong>Quoted item 1</attribute:strong></container:li></container:ul>'
+				)
+			);
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.markToSync( 'children', viewBq );
@@ -1598,9 +1609,11 @@ describe( 'Renderer', () => {
 
 			renderer.render();
 
-			expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<h2>Heading 2</h2>' +
+			expect( normalizeHtml( domRoot.innerHTML ) ).to.equal(
+				'<h2>Heading 2</h2>' +
 				'<p>Ph <i><strong>Italic</strong></i> <a href="https://ckeditor.com"><strong>L</strong>ink 1</a></p>' +
-				'<blockquote><p>Qu<strong>ote</strong></p><ul><li><strong>Quoted item 1</strong></li></ul></blockquote>' );
+				'<blockquote><p>Qu<strong>ote</strong></p><ul><li><strong>Quoted item 1</strong></li></ul></blockquote>'
+			);
 		} );
 
 		// #1125
@@ -1616,23 +1629,25 @@ describe( 'Renderer', () => {
 			//		<p>Not Quoted <strong>item 1</strong> and item 2</p>
 			//
 			// during one rerender to check if complex structure changes are rerendered correctly.
-			const viewContent = parse( '' +
+			const viewContent = parse(
 				'<container:h1>Header</container:h1>' +
 				'<container:blockquote>' +
 					'<container:ul>' +
 						'<container:li>Quoted <attribute:strong>item 1</attribute:strong></container:li>' +
 						'<container:li>Item 2</container:li>' +
 					'</container:ul>' +
-				'</container:blockquote>' );
+				'</container:blockquote>'
+			);
 
 			viewRoot._appendChildren( viewContent );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
 
-			const newViewContent = parse( '' +
+			const newViewContent = parse(
 				'<container:h2>Header</container:h2>' +
-				'<container:p>Not Quoted <attribute:strong>item 1</attribute:strong> and item 2</container:p>' );
+				'<container:p>Not Quoted <attribute:strong>item 1</attribute:strong> and item 2</container:p>'
+			);
 
 			viewRoot._removeChildren( 0, viewRoot.childCount );
 			viewRoot._appendChildren( newViewContent );
@@ -1640,7 +1655,9 @@ describe( 'Renderer', () => {
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
 
-			expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<h2>Header</h2><p>Not Quoted <strong>item 1</strong> and item 2</p>' );
+			expect( normalizeHtml( domRoot.innerHTML ) ).to.equal(
+				'<h2>Header</h2><p>Not Quoted <strong>item 1</strong> and item 2</p>'
+			);
 		} );
 
 		describe( 'fake selection', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Introduced deep children text nodes rerendering. Closes #1125. Closes #1093. Closes ckeditor/ckeditor5-typing#120. 

---

### Additional information

The proposed solution is very similar to what was initially proposed by @scofalik - https://github.com/ckeditor/ckeditor5-engine/issues/1125#issuecomment-332791847. The logic marking text nodes is placed in `renderer._updateChildren` as this is the place where element nodes are modified and based on that modifications we can decide which elements' text nodes should be considered for rerendered.

The mutation observer change is also described here - https://github.com/ckeditor/ckeditor5-engine/issues/1125#issuecomment-373376368.
