### PR TITLE
conversion.downcast-converters.changeAttribute should not consume if element creators returned null

### DIFF
--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -639,6 +639,13 @@ export function changeAttribute( attributeCreator ) {
 	attributeCreator = attributeCreator || ( ( value, data ) => ( { value, key: data.attributeKey } ) );
 
 	return ( evt, data, conversionApi ) => {
+		const oldAttribute = attributeCreator( data.attributeOldValue, data );
+		const newAttribute = attributeCreator( data.attributeNewValue, data );
+
+		if ( !oldAttribute && !newAttribute ) {
+			return;
+		}
+
 		if ( !conversionApi.consumable.consume( data.item, evt.name ) ) {
 			return;
 		}
@@ -647,8 +654,6 @@ export function changeAttribute( attributeCreator ) {
 		const viewWriter = conversionApi.writer;
 
 		// First remove the old attribute if there was one.
-		const oldAttribute = attributeCreator( data.attributeOldValue, data );
-
 		if ( data.attributeOldValue !== null && oldAttribute ) {
 			if ( oldAttribute.key == 'class' ) {
 				const classes = Array.isArray( oldAttribute.value ) ? oldAttribute.value : [ oldAttribute.value ];
@@ -667,9 +672,7 @@ export function changeAttribute( attributeCreator ) {
 			}
 		}
 
-		// Then, if conversion was successful, set the new attribute.
-		const newAttribute = attributeCreator( data.attributeNewValue, data );
-
+		// Then set the new attribute.
 		if ( data.attributeNewValue !== null && newAttribute ) {
 			if ( newAttribute.key == 'class' ) {
 				const classes = Array.isArray( newAttribute.value ) ? newAttribute.value : [ newAttribute.value ];

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -615,7 +615,7 @@ describe( 'downcast-converters', () => {
 		} );
 	} );
 
-	describe( 'setAttribute', () => {
+	describe( 'changeAttribute', () => {
 		it( 'should convert attribute insert/change/remove on a model node', () => {
 			const modelElement = new ModelElement( 'paragraph', { class: 'foo' }, new ModelText( 'foobar' ) );
 
@@ -685,6 +685,26 @@ describe( 'downcast-converters', () => {
 
 			// No attribute set.
 			expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
+		} );
+
+		it( 'should not convert or consume if element creator returned null', () => {
+			const spy = sinon.spy();
+
+			dispatcher.on( 'attribute:class', changeAttribute( () => {
+				spy();
+
+				return null;
+			} ) );
+
+			const modelElement = new ModelElement( 'paragraph', { class: 'foo' }, new ModelText( 'foobar' ) );
+
+			model.change( writer => {
+				writer.insert( modelElement, modelRootStart );
+			} );
+
+			expect( viewToString( viewRoot ) ).to.equal( '<div><p class="foo">foobar</p></div>' );
+
+			expect( spy.called ).to.be.true;
 		} );
 	} );
 

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -688,13 +688,9 @@ describe( 'downcast-converters', () => {
 		} );
 
 		it( 'should not convert or consume if element creator returned null', () => {
-			const spy = sinon.spy();
+			const callback = sinon.stub().returns( null );
 
-			dispatcher.on( 'attribute:class', changeAttribute( () => {
-				spy();
-
-				return null;
-			} ) );
+			dispatcher.on( 'attribute:class', changeAttribute( callback ) );
 
 			const modelElement = new ModelElement( 'paragraph', { class: 'foo' }, new ModelText( 'foobar' ) );
 
@@ -704,7 +700,7 @@ describe( 'downcast-converters', () => {
 
 			expect( viewToString( viewRoot ) ).to.equal( '<div><p class="foo">foobar</p></div>' );
 
-			expect( spy.called ).to.be.true;
+			sinon.assert.called( callback );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fixed: `conversion.downcast-converters.changeAttribute` should not consume if element creators returned `null.` Closes #1369.