### PR TITLE
controller.DataController#init should return a resolved Promise

### DIFF
--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -184,6 +184,7 @@ export default class DataController {
 	 * @fires init
 	 * @param {String} data Input data.
 	 * @param {String} [rootName='main'] Root name.
+	 * @returns {Promise} Promise that is resolved after the data is set on the editor.
 	 */
 	init( data, rootName = 'main' ) {
 		if ( this.model.document.version ) {
@@ -202,6 +203,8 @@ export default class DataController {
 		this.model.enqueueChange( 'transparent', writer => {
 			writer.insert( this.parse( data, modelRoot ), modelRoot );
 		} );
+
+		return Promise.resolve();
 	}
 
 	/**

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -206,6 +206,14 @@ describe( 'DataController', () => {
 
 			expect( spy.calledOnce ).to.be.true;
 		} );
+
+		it( 'should return a resolved Promise', () => {
+			const promise = data.init( '<p>Foo</p>' );
+
+			expect( promise ).to.be.instanceof( Promise );
+
+			return promise;
+		} );
 	} );
 
 	describe( 'set()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `controller.DataController#init` now returns a resolved `Promise`. Closes #1382.