### PR TITLE
Markers were not refreshed when a model element was renamed

### DIFF
--- a/src/model/differ.js
+++ b/src/model/differ.js
@@ -19,7 +19,20 @@ import Range from './range';
  * elements and new ones and returns a change set.
  */
 export default class Differ {
-	constructor() {
+	/**
+	 * Creates a `Differ` instance.
+	 *
+	 * @param {module:engine/model/markercollection~MarkerCollection} markerCollection Model's marker collection.
+	 */
+	constructor( markerCollection ) {
+		/**
+		 * Reference to the model's marker collection.
+		 *
+		 * @private
+		 * @type {module:engine/model/markercollection~MarkerCollection}
+		 */
+		this._markerCollection = markerCollection;
+
 		/**
 		 * A map that stores changes that happened in a given element.
 		 *
@@ -152,6 +165,14 @@ export default class Differ {
 
 				this._markRemove( operation.position.parent, operation.position.offset, 1 );
 				this._markInsert( operation.position.parent, operation.position.offset, 1 );
+
+				const range = Range.createFromPositionAndShift( operation.position, 1 );
+
+				for ( const marker of this._markerCollection.getMarkersIntersectingRange( range ) ) {
+					const markerRange = marker.getRange();
+
+					this.bufferMarkerChange( marker.name, markerRange, markerRange );
+				}
 
 				break;
 			}

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -87,7 +87,7 @@ export default class Document {
 		 * @readonly
 		 * @member {module:engine/model/differ~Differ}
 		 */
-		this.differ = new Differ();
+		this.differ = new Differ( model.markers );
 
 		/**
 		 * Post-fixer callbacks registered to the model document.

--- a/src/model/markercollection.js
+++ b/src/model/markercollection.js
@@ -163,6 +163,20 @@ export default class MarkerCollection {
 	}
 
 	/**
+	 * Returns iterator that iterates over all markers, which intersects with given {@link module:engine/model/range~Range range}.
+	 *
+	 * @param {module:engine/model/range~Range} range
+	 * @returns {Iterable.<module:engine/model/markercollection~Marker>}
+	 */
+	* getMarkersIntersectingRange( range ) {
+		for ( const marker of this ) {
+			if ( marker.getRange().getIntersection( range ) !== null ) {
+				yield marker;
+			}
+		}
+	}
+
+	/**
 	 * Destroys marker collection and all markers inside it.
 	 */
 	destroy() {

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -788,6 +788,13 @@ describe( 'Range', () => {
 			expect( common.start.path ).to.deep.equal( [ 3, 2 ] );
 			expect( common.end.path ).to.deep.equal( [ 4, 7 ] );
 		} );
+
+		it( 'should return a range equal to both ranges if both ranges are equal', () => {
+			const otherRange = Range.createFromRange( range );
+			const common = range.getIntersection( otherRange );
+
+			expect( common.isEqual( range ) ).to.be.true;
+		} );
 	} );
 
 	// Note: We don't create model element structure in these tests because this method


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Markers that were intersecting with a renamed element will not break, shrink or disappear anymore. Closes #1386.