### PR TITLE
T/1299: Create writer#updateMarker() method.

### DIFF
--- a/src/model/delta/markerdelta.js
+++ b/src/model/delta/markerdelta.js
@@ -11,8 +11,8 @@ import Delta from './delta';
 import DeltaFactory from './deltafactory';
 
 /**
- * To provide specific OT behavior and better collisions solving, the {@link module:engine/model/writer~Writer#setMarker Batch#setMarker}
- * and {@link module:engine/model/writer~Writer#removeMarker Batch#removeMarker} methods use the `MarkerDelta` class which inherits
+ * To provide specific OT behavior and better collisions solving, the {@link module:engine/model/writer~Writer#addMarker Writer#addMarker}
+ * and {@link module:engine/model/writer~Writer#removeMarker Writer#removeMarker} methods use the `MarkerDelta` class which inherits
  * from the `Delta` class and may overwrite some methods.
  *
  * @extends module:engine/model/delta/delta~Delta

--- a/src/model/markercollection.js
+++ b/src/model/markercollection.js
@@ -20,7 +20,7 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
  * {@link module:engine/model/markercollection~MarkerCollection#event:update} event.
  *
  * To create, change or remove makers use {@link module:engine/model/writer~Writer model writers'} methods:
- * {@link module:engine/model/writer~Writer#setMarker} or {@link module:engine/model/writer~Writer#removeMarker}. Since
+ * {@link module:engine/model/writer~Writer#addMarker} or {@link module:engine/model/writer~Writer#removeMarker}. Since
  * the writer is the only proper way to change the data model it is not possible to change markers directly using this
  * collection. All markers created by the writer will be automatically added to this collection.
  *
@@ -275,11 +275,11 @@ mix( MarkerCollection, EmitterMixin );
  * Therefore, they are handled in the undo stack and synchronized between clients if the collaboration plugin is enabled.
  * This type of markers is useful for solutions like spell checking or comments.
  *
- * Both type of them should be added / updated by {@link module:engine/model/writer~Writer#setMarker}
+ * Both type of them should be added / updated by {@link module:engine/model/writer~Writer#addMarker}
  * and removed by {@link module:engine/model/writer~Writer#removeMarker} methods.
  *
  *		model.change( ( writer ) => {
- * 			const marker = writer.setMarker( name, { range, usingOperation: true } );
+ * 			const marker = writer.addMarker( name, { range, usingOperation: true } );
  *
  * 			// ...
  *
@@ -343,7 +343,7 @@ class Marker {
 	/**
 	 * Returns value of flag indicates if the marker is managed using operations or not.
 	 * See {@link ~Marker marker class description} to learn more about marker types.
-	 * See {@link module:engine/model/writer~Writer#setMarker}.
+	 * See {@link module:engine/model/writer~Writer#addMarker}.
 	 *
 	 * @returns {Boolean}
 	 */

--- a/src/model/markercollection.js
+++ b/src/model/markercollection.js
@@ -279,7 +279,7 @@ mix( MarkerCollection, EmitterMixin );
  * and removed by {@link module:engine/model/writer~Writer#removeMarker} methods.
  *
  *		model.change( ( writer ) => {
- * 			const marker = writer.setMarker( name, range, { usingOperation: true } );
+ * 			const marker = writer.setMarker( name, { range, usingOperation: true } );
  *
  * 			// ...
  *

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -903,16 +903,18 @@ export default class Writer {
 		}
 
 		const range = options && options.range;
-		const usingOperation = !!options && !!options.usingOperation;
+
+		const hasUsingOperationDefined = !!options && typeof options.usingOperation == 'boolean';
+		const usingOperation = !!options && !!options.usingOperation; // : currentMarker.managedUsingOperations;
 
 		if ( !usingOperation ) {
 			// If marker changes to a marker that do not use operations then we need to create additional operation
 			// that removes that marker first.
-			if ( currentMarker.managedUsingOperations ) {
+			if ( hasUsingOperationDefined && currentMarker.managedUsingOperations ) {
 				applyMarkerOperation( this, markerName, currentMarker.getRange(), null );
 			}
 
-			this.model.markers._set( markerName, range, usingOperation );
+			this.model.markers._set( markerName, range, hasUsingOperationDefined ? usingOperation : currentMarker.managedUsingOperations );
 
 			return;
 		}

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -834,16 +834,16 @@ export default class Writer {
 		if ( markerOrNameOrRange instanceof Range ) {
 			markerName = uid();
 			newRange = markerOrNameOrRange;
-			usingOperation = !!rangeOrOptions && !!rangeOrOptions.usingOperation;
+			usingOperation = _checkUsingOptionsIsDefined( rangeOrOptions );
 		} else {
 			markerName = typeof markerOrNameOrRange === 'string' ? markerOrNameOrRange : markerOrNameOrRange.name;
 
 			if ( rangeOrOptions instanceof Range ) {
 				newRange = rangeOrOptions;
-				usingOperation = !!options && !!options.usingOperation;
+				usingOperation = _checkUsingOptionsIsDefined( options );
 			} else {
 				newRange = null;
-				usingOperation = !!rangeOrOptions && !!rangeOrOptions.usingOperation;
+				usingOperation = _checkUsingOptionsIsDefined( rangeOrOptions );
 			}
 		}
 
@@ -884,6 +884,16 @@ export default class Writer {
 		}
 
 		return this.model.markers.get( markerName );
+
+		function _checkUsingOptionsIsDefined( options ) {
+			if ( !options || typeof options.usingOperation != 'boolean' ) {
+				throw new CKEditorError(
+					'writer-setMarker-no-usingOperations: The options.usingOperations parameter is required when adding a new marker.'
+				);
+			}
+
+			return options.usingOperation;
+		}
 	}
 
 	/**

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -804,8 +804,8 @@ export default class Writer {
 	 * @param {String} name Name of a marker to create - must be unique.
 	 * @param {Object} options
 	 * @param {Boolean} options.usingOperation Flag indicated whether the marker should be added by MarkerOperation.
-	 * @param {module:engine/model/range~Range} options.range Marker range.
 	 * See {@link module:engine/model/markercollection~Marker#managedUsingOperations}.
+	 * @param {module:engine/model/range~Range} options.range Marker range.
 	 * @returns {module:engine/model/markercollection~Marker} Marker that was set.
 	 */
 	setMarker( name, options ) {
@@ -867,12 +867,12 @@ export default class Writer {
 	 *
 	 * Update marker directly base on marker's name:
 	 *
-	 * 		setMarker( markerName, { range } );
+	 * 		updateMarker( markerName, { range } );
 	 *
 	 * Update marker using operation:
 	 *
-	 * 		setMarker( marker, { range, usingOperation: true } );
-	 * 		setMarker( markerName, { range, usingOperation: true } );
+	 * 		updateMarker( marker, { range, usingOperation: true } );
+	 * 		updateMarker( markerName, { range, usingOperation: true } );
 	 *
 	 * Change marker's option (start using operations to manage it):
 	 *

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -205,7 +205,7 @@ export default class Writer {
 					markerRange.end._getCombined( rangeRootPosition, position )
 				);
 
-				this.setMarker( markerName, { range, usingOperation: true } );
+				this.addMarker( markerName, { range, usingOperation: true } );
 			}
 		}
 	}
@@ -792,11 +792,11 @@ export default class Writer {
 	 *
 	 * Create marker directly base on marker's name:
 	 *
-	 * 		setMarker( markerName, { range, usingOperation: false } );
+	 * 		addMarker( markerName, { range, usingOperation: false } );
 	 *
 	 * Create marker using operation:
 	 *
-	 * 		setMarker( markerName, { range, usingOperation: true } );
+	 * 		addMarker( markerName, { range, usingOperation: true } );
 	 *
 	 * Note: For efficiency reasons, it's best to create and keep as little markers as possible.
 	 *
@@ -808,17 +808,17 @@ export default class Writer {
 	 * @param {module:engine/model/range~Range} options.range Marker range.
 	 * @returns {module:engine/model/markercollection~Marker} Marker that was set.
 	 */
-	setMarker( name, options ) {
+	addMarker( name, options ) {
 		this._assertWriterUsedCorrectly();
 
 		if ( !options || typeof options.usingOperation != 'boolean' ) {
 			/**
 			 * The options.usingOperations parameter is required when adding a new marker.
 			 *
-			 * @error writer-setMarker-no-usingOperations
+			 * @error writer-addMarker-no-usingOperations
 			 */
 			throw new CKEditorError(
-				'writer-setMarker-no-usingOperations: The options.usingOperations parameter is required when adding a new marker.'
+				'writer-addMarker-no-usingOperations: The options.usingOperations parameter is required when adding a new marker.'
 			);
 		}
 
@@ -829,18 +829,18 @@ export default class Writer {
 			/**
 			 * Marker with provided name already exists.
 			 *
-			 * @error writer-setMarker-marker-exists
+			 * @error writer-addMarker-marker-exists
 			 */
-			throw new CKEditorError( 'writer-setMarker-marker-exists: Marker with provided name already exists.' );
+			throw new CKEditorError( 'writer-addMarker-marker-exists: Marker with provided name already exists.' );
 		}
 
 		if ( !range ) {
 			/**
 			 * Range parameter is required when adding a new marker.
 			 *
-			 * @error writer-setMarker-no-range
+			 * @error writer-addMarker-no-range
 			 */
-			throw new CKEditorError( 'writer-setMarker-no-range: Range parameter is required when adding a new marker.' );
+			throw new CKEditorError( 'writer-addMarker-no-range: Range parameter is required when adding a new marker.' );
 		}
 
 		if ( !usingOperation ) {

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -781,47 +781,30 @@ export default class Writer {
 	}
 
 	/**
-	 * Adds or updates a {@link module:engine/model/markercollection~Marker marker}. Marker is a named range, which tracks
-	 * changes in the document and updates its range automatically, when model tree changes. Still, it is possible to change the
-	 * marker's range directly using this method.
+	 * Adds a {@link module:engine/model/markercollection~Marker marker}. Marker is a named range, which tracks
+	 * changes in the document and updates its range automatically, when model tree changes.
 	 *
-	 * As the first parameter you can set marker name or instance. If none of them is provided, new marker, with a unique
-	 * name is created and returned.
+	 * As the first parameter you can set marker name.
 	 *
-	 * The `options.usingOperation` parameter lets you decide if the marker should be managed by operations or not. See
+	 * The required `options.usingOperation` parameter lets you decide if the marker should be managed by operations or not. See
 	 * {@link module:engine/model/markercollection~Marker marker class description} to learn about the difference between
-	 * markers managed by operations and not-managed by operations. It is possible to change this option for an existing marker.
-	 * This is useful when a marker have been created earlier and then later, it needs to be added to the document history.
+	 * markers managed by operations and not-managed by operations.
 	 *
-	 * Create/update marker directly base on marker's name:
+	 * Create marker directly base on marker's name:
 	 *
-	 * 		setMarker( markerName, range );
+	 * 		setMarker( markerName, { range, usingOperation: false } );
 	 *
-	 * Update marker using operation:
+	 * Create marker using operation:
 	 *
-	 * 		setMarker( marker, range, { usingOperation: true } );
-	 * 		setMarker( markerName, range, { usingOperation: true } );
-	 *
-	 * Create marker with a unique id using operation:
-	 *
-	 * 		setMarker( range, { usingOperation: true } );
-	 *
-	 * Create marker directly without using operations:
-	 *
-	 * 		setMarker( range )
-	 *
-	 * Change marker's option (start using operations to manage it):
-	 *
-	 * 		setMarker( marker, { usingOperation: true } );
+	 * 		setMarker( markerName, { range, usingOperation: true } );
 	 *
 	 * Note: For efficiency reasons, it's best to create and keep as little markers as possible.
 	 *
 	 * @see module:engine/model/markercollection~Marker
-	 * @param {String} [name]
-	 * Name of a marker to create or update, or range for the marker with a unique name.
-	 * @param {module:engine/model/range~Range} range Marker range.
+	 * @param {String} name Name of a marker to create - must be unique.
 	 * @param {Object} options
 	 * @param {Boolean} options.usingOperation Flag indicated whether the marker should be added by MarkerOperation.
+	 * @param {module:engine/model/range~Range} options.range Marker range.
 	 * See {@link module:engine/model/markercollection~Marker#managedUsingOperations}.
 	 * @returns {module:engine/model/markercollection~Marker} Marker that was set.
 	 */
@@ -843,6 +826,11 @@ export default class Writer {
 		const range = options.range;
 
 		if ( this.model.markers.has( name ) ) {
+			/**
+			 * Marker with provided name already exists.
+			 *
+			 * @error writer-setMarker-marker-exists
+			 */
 			throw new CKEditorError( 'writer-setMarker-marker-exists: Marker with provided name already exists.' );
 		}
 
@@ -864,6 +852,40 @@ export default class Writer {
 		return this.model.markers.get( name );
 	}
 
+	/**
+	 * Adds or updates a {@link module:engine/model/markercollection~Marker marker}. Marker is a named range, which tracks
+	 * changes in the document and updates its range automatically, when model tree changes. Still, it is possible to change the
+	 * marker's range directly using this method.
+	 *
+	 * As the first parameter you can set marker name or instance. If none of them is provided, new marker, with a unique
+	 * name is created and returned.
+	 *
+	 * The `options.usingOperation` parameter lets you change if the marker should be managed by operations or not. See
+	 * {@link module:engine/model/markercollection~Marker marker class description} to learn about the difference between
+	 * markers managed by operations and not-managed by operations. It is possible to change this option for an existing marker.
+	 * This is useful when a marker have been created earlier and then later, it needs to be added to the document history.
+	 *
+	 * Update marker directly base on marker's name:
+	 *
+	 * 		setMarker( markerName, { range } );
+	 *
+	 * Update marker using operation:
+	 *
+	 * 		setMarker( marker, { range, usingOperation: true } );
+	 * 		setMarker( markerName, { range, usingOperation: true } );
+	 *
+	 * Change marker's option (start using operations to manage it):
+	 *
+	 * 		updateMarker( marker, { usingOperation: true } );
+	 *
+	 * @see module:engine/model/markercollection~Marker
+	 * @param {String} markerOrName Name of a marker to update, or a marker instance.
+	 * @param {Object} options
+	 * @param {module:engine/model/range~Range} [options.range] Marker range to update.
+	 * @param {Boolean} [options.usingOperation] Flag indicated whether the marker should be added by MarkerOperation.
+	 * See {@link module:engine/model/markercollection~Marker#managedUsingOperations}.
+	 * @returns {module:engine/model/markercollection~Marker} Marker that was set.
+	 */
 	updateMarker( markerOrName, options ) {
 		this._assertWriterUsedCorrectly();
 
@@ -872,6 +894,11 @@ export default class Writer {
 		const currentMarker = this.model.markers.get( markerName );
 
 		if ( !currentMarker ) {
+			/**
+			 * Marker with provided name does not exists.
+			 *
+			 * @error writer-updateMarker-marker-not-exists
+			 */
 			throw new CKEditorError( 'writer-updateMarker-marker-not-exists: Marker with provided name does not exists.' );
 		}
 

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -406,7 +406,8 @@ describe( 'DataController', () => {
 
 			model.change( writer => {
 				writer.insert( modelElement, modelRoot, 0 );
-				writer.setMarker( 'marker:a', Range.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 1 ), { usingOperation: true } );
+				const range = Range.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 1 );
+				writer.setMarker( 'marker:a', { range, usingOperation: true } );
 			} );
 
 			const viewDocumentFragment = data.toView( modelElement );
@@ -428,8 +429,11 @@ describe( 'DataController', () => {
 			model.change( writer => {
 				writer.insert( modelElement, modelRoot, 0 );
 
-				writer.setMarker( 'marker:a', Range.createFromParentsAndOffsets( modelP1, 1, modelP1, 3 ), { usingOperation: true } );
-				writer.setMarker( 'marker:b', Range.createFromParentsAndOffsets( modelP2, 0, modelP2, 2 ), { usingOperation: true } );
+				const rangeA = Range.createFromParentsAndOffsets( modelP1, 1, modelP1, 3 );
+				const rangeB = Range.createFromParentsAndOffsets( modelP2, 0, modelP2, 2 );
+
+				writer.setMarker( 'marker:a', { range: rangeA, usingOperation: true } );
+				writer.setMarker( 'marker:b', { range: rangeB, usingOperation: true } );
 			} );
 
 			const viewDocumentFragment = data.toView( modelP1 );

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -407,7 +407,7 @@ describe( 'DataController', () => {
 			model.change( writer => {
 				writer.insert( modelElement, modelRoot, 0 );
 				const range = Range.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 1 );
-				writer.setMarker( 'marker:a', { range, usingOperation: true } );
+				writer.addMarker( 'marker:a', { range, usingOperation: true } );
 			} );
 
 			const viewDocumentFragment = data.toView( modelElement );
@@ -432,8 +432,8 @@ describe( 'DataController', () => {
 				const rangeA = Range.createFromParentsAndOffsets( modelP1, 1, modelP1, 3 );
 				const rangeB = Range.createFromParentsAndOffsets( modelP2, 0, modelP2, 2 );
 
-				writer.setMarker( 'marker:a', { range: rangeA, usingOperation: true } );
-				writer.setMarker( 'marker:b', { range: rangeB, usingOperation: true } );
+				writer.addMarker( 'marker:a', { range: rangeA, usingOperation: true } );
+				writer.addMarker( 'marker:b', { range: rangeB, usingOperation: true } );
 			} );
 
 			const viewDocumentFragment = data.toView( modelP1 );

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -235,7 +235,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', { range, usingOperation: false } );
+				writer.addMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			expect( getViewData( editing.view, { withoutSelection: true } ) )
@@ -246,7 +246,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', { range, usingOperation: false } );
+				writer.addMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			model.change( writer => {
@@ -261,7 +261,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', { range, usingOperation: false } );
+				writer.addMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			const range2 = new ModelRange( new ModelPosition( modelRoot, [ 0, 0 ] ), new ModelPosition( modelRoot, [ 0, 2 ] ) );
@@ -278,7 +278,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', { range, usingOperation: false } );
+				writer.addMarker( 'marker', { range, usingOperation: false } );
 				writer.insertText( 'xyz', new ModelPosition( modelRoot, [ 1, 0 ] ) );
 			} );
 
@@ -290,7 +290,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', { range, usingOperation: false } );
+				writer.addMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			model.change( writer => {
@@ -308,7 +308,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', { range, usingOperation: false } );
+				writer.addMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			model.change( writer => {
@@ -326,7 +326,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 0, 3 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', { range, usingOperation: false } );
+				writer.addMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			model.change( writer => {

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -235,7 +235,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range, { usingOperation: false } );
+				writer.setMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			expect( getViewData( editing.view, { withoutSelection: true } ) )
@@ -246,7 +246,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range, { usingOperation: false } );
+				writer.setMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			model.change( writer => {
@@ -261,13 +261,13 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range, { usingOperation: false } );
+				writer.setMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			const range2 = new ModelRange( new ModelPosition( modelRoot, [ 0, 0 ] ), new ModelPosition( modelRoot, [ 0, 2 ] ) );
 
 			model.change( writer => {
-				writer.updateMarker( 'marker', range2 );
+				writer.updateMarker( 'marker', { range: range2 } );
 			} );
 
 			expect( getViewData( editing.view, { withoutSelection: true } ) )
@@ -278,7 +278,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range, { usingOperation: false } );
+				writer.setMarker( 'marker', { range, usingOperation: false } );
 				writer.insertText( 'xyz', new ModelPosition( modelRoot, [ 1, 0 ] ) );
 			} );
 
@@ -290,7 +290,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range, { usingOperation: false } );
+				writer.setMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			model.change( writer => {
@@ -308,7 +308,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range, { usingOperation: false } );
+				writer.setMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			model.change( writer => {
@@ -326,7 +326,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 0, 3 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range, { usingOperation: false } );
+				writer.setMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			model.change( writer => {

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -235,7 +235,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range );
+				writer.setMarker( 'marker', range, { usingOperation: false } );
 			} );
 
 			expect( getViewData( editing.view, { withoutSelection: true } ) )
@@ -246,7 +246,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range );
+				writer.setMarker( 'marker', range, { usingOperation: false } );
 			} );
 
 			model.change( writer => {
@@ -261,13 +261,13 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range );
+				writer.setMarker( 'marker', range, { usingOperation: false } );
 			} );
 
 			const range2 = new ModelRange( new ModelPosition( modelRoot, [ 0, 0 ] ), new ModelPosition( modelRoot, [ 0, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range2 );
+				writer.updateMarker( 'marker', range2 );
 			} );
 
 			expect( getViewData( editing.view, { withoutSelection: true } ) )
@@ -278,7 +278,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range );
+				writer.setMarker( 'marker', range, { usingOperation: false } );
 				writer.insertText( 'xyz', new ModelPosition( modelRoot, [ 1, 0 ] ) );
 			} );
 
@@ -290,7 +290,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range );
+				writer.setMarker( 'marker', range, { usingOperation: false } );
 			} );
 
 			model.change( writer => {
@@ -308,7 +308,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range );
+				writer.setMarker( 'marker', range, { usingOperation: false } );
 			} );
 
 			model.change( writer => {
@@ -326,7 +326,7 @@ describe( 'EditingController', () => {
 			const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 0, 3 ] ) );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', range );
+				writer.setMarker( 'marker', range, { usingOperation: false } );
 			} );
 
 			model.change( writer => {

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -451,7 +451,7 @@ describe( 'downcast-helpers', () => {
 				writer.insertText( 'foo', modelRoot, 0 );
 
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
-				writer.setMarker( 'search', { range, usingOperation: false } );
+				writer.addMarker( 'search', { range, usingOperation: false } );
 			} );
 
 			expectResult( 'f<marker-search></marker-search>o<marker-search></marker-search>o' );
@@ -466,7 +466,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
-				writer.setMarker( 'search', { range, usingOperation: false } );
+				writer.addMarker( 'search', { range, usingOperation: false } );
 			} );
 
 			expectResult( 'f<search></search>o<search></search>o' );
@@ -488,7 +488,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
-				writer.setMarker( 'search', { range, usingOperation: false } );
+				writer.addMarker( 'search', { range, usingOperation: false } );
 			} );
 
 			expectResult( 'f<span data-marker="search"></span>o<span data-marker="search"></span>o' );
@@ -507,7 +507,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
-				writer.setMarker( 'search', { range, usingOperation: false } );
+				writer.addMarker( 'search', { range, usingOperation: false } );
 			} );
 
 			expectResult( 'f<span data-marker="search" data-start="true"></span>o<span data-marker="search" data-start="false"></span>o' );
@@ -523,7 +523,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
-				writer.setMarker( 'comment', { range, usingOperation: false } );
+				writer.addMarker( 'comment', { range, usingOperation: false } );
 			} );
 
 			expectResult( '<span class="comment">foo</span>' );
@@ -538,7 +538,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
-				writer.setMarker( 'comment', { range, usingOperation: false } );
+				writer.addMarker( 'comment', { range, usingOperation: false } );
 			} );
 
 			expectResult( '<span class="new-comment">foo</span>' );
@@ -561,7 +561,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
-				writer.setMarker( 'comment:abc', { range, usingOperation: false } );
+				writer.addMarker( 'comment:abc', { range, usingOperation: false } );
 			} );
 
 			expectResult( '<span class="comment comment-abc">foo</span>' );
@@ -932,7 +932,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range, usingOperation: false } );
+					writer.addMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo<span class="marker"></span>bar</p></div>' );
@@ -956,7 +956,7 @@ describe( 'downcast-converters', () => {
 				}, { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range, usingOperation: false } );
+					writer.addMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
@@ -968,7 +968,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( () => null ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range, usingOperation: false } );
+					writer.addMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
@@ -993,7 +993,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range, usingOperation: false } );
+					writer.addMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) )
@@ -1013,7 +1013,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range, usingOperation: false } );
+					writer.addMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) )
@@ -1039,7 +1039,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range, usingOperation: false } );
+					writer.addMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1064,7 +1064,7 @@ describe( 'downcast-converters', () => {
 				}, { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range, usingOperation: false } );
+					writer.addMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
@@ -1276,7 +1276,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( highlightDescriptor ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
+					writer.addMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1309,7 +1309,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( newDescriptor ), { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
+					writer.addMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1336,7 +1336,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( () => null ), { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
+					writer.addMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
@@ -1358,7 +1358,7 @@ describe( 'downcast-converters', () => {
 				markerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 0 );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
+					writer.addMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
@@ -1388,7 +1388,7 @@ describe( 'downcast-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( p1, 0, p1, 3 );
-					writer.setMarker( 'markerFoo', { range, usingOperation: false } );
+					writer.addMarker( 'markerFoo', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1402,7 +1402,7 @@ describe( 'downcast-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( p1, 1, p2, 2 );
-					writer.setMarker( 'markerBar', { range, usingOperation: false } );
+					writer.addMarker( 'markerBar', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1422,7 +1422,7 @@ describe( 'downcast-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( p1, 2, p2, 3 );
-					writer.setMarker( 'markerXyz', { range, usingOperation: false } );
+					writer.addMarker( 'markerXyz', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1496,7 +1496,7 @@ describe( 'downcast-converters', () => {
 				const markerRange = ModelRange.createFromParentsAndOffsets( p1, 3, p2, 0 );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
+					writer.addMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
@@ -1550,7 +1550,7 @@ describe( 'downcast-converters', () => {
 
 			it( 'should use addHighlight and removeHighlight on elements and not convert children nodes', () => {
 				model.change( writer => {
-					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
+					writer.addMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1576,7 +1576,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( newDescriptor ), { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
+					writer.addMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1611,7 +1611,7 @@ describe( 'downcast-converters', () => {
 				} );
 
 				model.change( writer => {
-					writer.setMarker( 'marker2', { range: markerRange, usingOperation: false } );
+					writer.addMarker( 'marker2', { range: markerRange, usingOperation: false } );
 				} );
 			} );
 
@@ -1621,7 +1621,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker2', removeHighlight( () => null ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker2', { range: markerRange, usingOperation: false } );
+					writer.addMarker( 'marker2', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><div>foo</div></div>' );

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -449,7 +449,9 @@ describe( 'downcast-helpers', () => {
 
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
-				writer.setMarker( 'search', ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 ) );
+
+				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
+				writer.setMarker( 'search', range, { usingOperation: false } );
 			} );
 
 			expectResult( 'f<marker-search></marker-search>o<marker-search></marker-search>o' );
@@ -463,7 +465,8 @@ describe( 'downcast-helpers', () => {
 
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
-				writer.setMarker( 'search', ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 ) );
+				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
+				writer.setMarker( 'search', range, { usingOperation: false } );
 			} );
 
 			expectResult( 'f<search></search>o<search></search>o' );
@@ -484,7 +487,8 @@ describe( 'downcast-helpers', () => {
 
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
-				writer.setMarker( 'search', ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 ) );
+				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
+				writer.setMarker( 'search', range, { usingOperation: false } );
 			} );
 
 			expectResult( 'f<span data-marker="search"></span>o<span data-marker="search"></span>o' );
@@ -502,7 +506,8 @@ describe( 'downcast-helpers', () => {
 
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
-				writer.setMarker( 'search', ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 ) );
+				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
+				writer.setMarker( 'search', range, { usingOperation: false } );
 			} );
 
 			expectResult( 'f<span data-marker="search" data-start="true"></span>o<span data-marker="search" data-start="false"></span>o' );
@@ -517,7 +522,8 @@ describe( 'downcast-helpers', () => {
 
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
-				writer.setMarker( 'comment', ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 ) );
+				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
+				writer.setMarker( 'comment', range, { usingOperation: false } );
 			} );
 
 			expectResult( '<span class="comment">foo</span>' );
@@ -531,7 +537,8 @@ describe( 'downcast-helpers', () => {
 
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
-				writer.setMarker( 'comment', ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 ) );
+				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
+				writer.setMarker( 'comment', range, { usingOperation: false } );
 			} );
 
 			expectResult( '<span class="new-comment">foo</span>' );
@@ -553,7 +560,8 @@ describe( 'downcast-helpers', () => {
 
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
-				writer.setMarker( 'comment:abc', ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 ) );
+				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
+				writer.setMarker( 'comment:abc', range, { usingOperation: false } );
 			} );
 
 			expectResult( '<span class="comment comment-abc">foo</span>' );
@@ -924,7 +932,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range );
+					writer.setMarker( 'marker', range, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo<span class="marker"></span>bar</p></div>' );
@@ -948,7 +956,7 @@ describe( 'downcast-converters', () => {
 				}, { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range );
+					writer.setMarker( 'marker', range, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
@@ -960,7 +968,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( () => null ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range );
+					writer.setMarker( 'marker', range, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
@@ -985,7 +993,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range );
+					writer.setMarker( 'marker', range, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) )
@@ -1005,7 +1013,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range );
+					writer.setMarker( 'marker', range, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) )
@@ -1031,7 +1039,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range );
+					writer.setMarker( 'marker', range, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1056,7 +1064,7 @@ describe( 'downcast-converters', () => {
 				}, { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range );
+					writer.setMarker( 'marker', range, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
@@ -1268,7 +1276,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( highlightDescriptor ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange );
+					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1301,7 +1309,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( newDescriptor ), { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange );
+					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1328,7 +1336,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( () => null ), { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange );
+					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
@@ -1350,7 +1358,7 @@ describe( 'downcast-converters', () => {
 				markerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 0 );
 
 				model.change( () => {
-					model.markers._set( 'marker', markerRange );
+					model.markers._set( 'marker', markerRange, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
@@ -1379,7 +1387,7 @@ describe( 'downcast-converters', () => {
 				const p2 = modelRoot.getChild( 1 );
 
 				model.change( writer => {
-					writer.setMarker( 'markerFoo', ModelRange.createFromParentsAndOffsets( p1, 0, p1, 3 ) );
+					writer.setMarker( 'markerFoo', ModelRange.createFromParentsAndOffsets( p1, 0, p1, 3 ), { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1392,7 +1400,7 @@ describe( 'downcast-converters', () => {
 				);
 
 				model.change( writer => {
-					writer.setMarker( 'markerBar', ModelRange.createFromParentsAndOffsets( p1, 1, p2, 2 ) );
+					writer.setMarker( 'markerBar', ModelRange.createFromParentsAndOffsets( p1, 1, p2, 2 ), { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1411,7 +1419,7 @@ describe( 'downcast-converters', () => {
 				);
 
 				model.change( writer => {
-					writer.setMarker( 'markerXyz', ModelRange.createFromParentsAndOffsets( p1, 2, p2, 3 ) );
+					writer.setMarker( 'markerXyz', ModelRange.createFromParentsAndOffsets( p1, 2, p2, 3 ), { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1485,13 +1493,13 @@ describe( 'downcast-converters', () => {
 				const markerRange = ModelRange.createFromParentsAndOffsets( p1, 3, p2, 0 );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange );
+					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
 
 				model.change( writer => {
-					writer.removeMarker( 'marker', markerRange );
+					writer.removeMarker( 'marker', markerRange, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
@@ -1539,7 +1547,7 @@ describe( 'downcast-converters', () => {
 
 			it( 'should use addHighlight and removeHighlight on elements and not convert children nodes', () => {
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange );
+					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1565,7 +1573,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( newDescriptor ), { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange );
+					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1600,7 +1608,7 @@ describe( 'downcast-converters', () => {
 				} );
 
 				model.change( writer => {
-					writer.setMarker( 'marker2', markerRange );
+					writer.setMarker( 'marker2', markerRange, { usingOperation: false } );
 				} );
 			} );
 
@@ -1610,7 +1618,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker2', removeHighlight( () => null ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker2', markerRange );
+					writer.setMarker( 'marker2', markerRange, { usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><div>foo</div></div>' );

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -451,7 +451,7 @@ describe( 'downcast-helpers', () => {
 				writer.insertText( 'foo', modelRoot, 0 );
 
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
-				writer.setMarker( 'search', range, { usingOperation: false } );
+				writer.setMarker( 'search', { range, usingOperation: false } );
 			} );
 
 			expectResult( 'f<marker-search></marker-search>o<marker-search></marker-search>o' );
@@ -466,7 +466,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
-				writer.setMarker( 'search', range, { usingOperation: false } );
+				writer.setMarker( 'search', { range, usingOperation: false } );
 			} );
 
 			expectResult( 'f<search></search>o<search></search>o' );
@@ -488,7 +488,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
-				writer.setMarker( 'search', range, { usingOperation: false } );
+				writer.setMarker( 'search', { range, usingOperation: false } );
 			} );
 
 			expectResult( 'f<span data-marker="search"></span>o<span data-marker="search"></span>o' );
@@ -507,7 +507,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 2 );
-				writer.setMarker( 'search', range, { usingOperation: false } );
+				writer.setMarker( 'search', { range, usingOperation: false } );
 			} );
 
 			expectResult( 'f<span data-marker="search" data-start="true"></span>o<span data-marker="search" data-start="false"></span>o' );
@@ -523,7 +523,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
-				writer.setMarker( 'comment', range, { usingOperation: false } );
+				writer.setMarker( 'comment', { range, usingOperation: false } );
 			} );
 
 			expectResult( '<span class="comment">foo</span>' );
@@ -538,7 +538,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
-				writer.setMarker( 'comment', range, { usingOperation: false } );
+				writer.setMarker( 'comment', { range, usingOperation: false } );
 			} );
 
 			expectResult( '<span class="new-comment">foo</span>' );
@@ -561,7 +561,7 @@ describe( 'downcast-helpers', () => {
 			model.change( writer => {
 				writer.insertText( 'foo', modelRoot, 0 );
 				const range = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 3 );
-				writer.setMarker( 'comment:abc', range, { usingOperation: false } );
+				writer.setMarker( 'comment:abc', { range, usingOperation: false } );
 			} );
 
 			expectResult( '<span class="comment comment-abc">foo</span>' );
@@ -932,7 +932,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range, { usingOperation: false } );
+					writer.setMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo<span class="marker"></span>bar</p></div>' );
@@ -956,7 +956,7 @@ describe( 'downcast-converters', () => {
 				}, { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range, { usingOperation: false } );
+					writer.setMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
@@ -968,7 +968,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( () => null ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range, { usingOperation: false } );
+					writer.setMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
@@ -993,7 +993,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range, { usingOperation: false } );
+					writer.setMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) )
@@ -1013,7 +1013,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range, { usingOperation: false } );
+					writer.setMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) )
@@ -1039,7 +1039,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeUIElement( creator ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range, { usingOperation: false } );
+					writer.setMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1064,7 +1064,7 @@ describe( 'downcast-converters', () => {
 				}, { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', range, { usingOperation: false } );
+					writer.setMarker( 'marker', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foobar</p></div>' );
@@ -1276,7 +1276,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( highlightDescriptor ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
+					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1309,7 +1309,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( newDescriptor ), { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
+					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1336,7 +1336,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( () => null ), { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
+					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
@@ -1357,8 +1357,8 @@ describe( 'downcast-converters', () => {
 
 				markerRange = ModelRange.createFromParentsAndOffsets( modelRoot, 0, modelRoot, 0 );
 
-				model.change( () => {
-					model.markers._set( 'marker', markerRange, { usingOperation: false } );
+				model.change( writer => {
+					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
@@ -1387,7 +1387,8 @@ describe( 'downcast-converters', () => {
 				const p2 = modelRoot.getChild( 1 );
 
 				model.change( writer => {
-					writer.setMarker( 'markerFoo', ModelRange.createFromParentsAndOffsets( p1, 0, p1, 3 ), { usingOperation: false } );
+					const range = ModelRange.createFromParentsAndOffsets( p1, 0, p1, 3 );
+					writer.setMarker( 'markerFoo', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1400,7 +1401,8 @@ describe( 'downcast-converters', () => {
 				);
 
 				model.change( writer => {
-					writer.setMarker( 'markerBar', ModelRange.createFromParentsAndOffsets( p1, 1, p2, 2 ), { usingOperation: false } );
+					const range = ModelRange.createFromParentsAndOffsets( p1, 1, p2, 2 );
+					writer.setMarker( 'markerBar', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1419,7 +1421,8 @@ describe( 'downcast-converters', () => {
 				);
 
 				model.change( writer => {
-					writer.setMarker( 'markerXyz', ModelRange.createFromParentsAndOffsets( p1, 2, p2, 3 ), { usingOperation: false } );
+					const range = ModelRange.createFromParentsAndOffsets( p1, 2, p2, 3 );
+					writer.setMarker( 'markerXyz', { range, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1493,13 +1496,13 @@ describe( 'downcast-converters', () => {
 				const markerRange = ModelRange.createFromParentsAndOffsets( p1, 3, p2, 0 );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
+					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
 
 				model.change( writer => {
-					writer.removeMarker( 'marker', markerRange, { usingOperation: false } );
+					writer.removeMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><p>foo</p><p>bar</p></div>' );
@@ -1547,7 +1550,7 @@ describe( 'downcast-converters', () => {
 
 			it( 'should use addHighlight and removeHighlight on elements and not convert children nodes', () => {
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
+					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1573,7 +1576,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker', removeHighlight( newDescriptor ), { priority: 'high' } );
 
 				model.change( writer => {
-					writer.setMarker( 'marker', markerRange, { usingOperation: false } );
+					writer.setMarker( 'marker', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal(
@@ -1608,7 +1611,7 @@ describe( 'downcast-converters', () => {
 				} );
 
 				model.change( writer => {
-					writer.setMarker( 'marker2', markerRange, { usingOperation: false } );
+					writer.setMarker( 'marker2', { range: markerRange, usingOperation: false } );
 				} );
 			} );
 
@@ -1618,7 +1621,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'removeMarker:marker2', removeHighlight( () => null ) );
 
 				model.change( writer => {
-					writer.setMarker( 'marker2', markerRange, { usingOperation: false } );
+					writer.setMarker( 'marker2', { range: markerRange, usingOperation: false } );
 				} );
 
 				expect( viewToString( viewRoot ) ).to.equal( '<div><div>foo</div></div>' );

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -198,7 +198,7 @@ describe( 'downcast-selection-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
-					marker = writer.setMarker( 'marker', { range, usingOperation: false } );
+					marker = writer.addMarker( 'marker', { range, usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 				} );
 
@@ -223,7 +223,7 @@ describe( 'downcast-selection-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
-					marker = writer.setMarker( 'marker', { range, usingOperation: false } );
+					marker = writer.addMarker( 'marker', { range, usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 					writer.removeSelectionAttribute( 'bold' );
 				} );
@@ -252,7 +252,7 @@ describe( 'downcast-selection-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
-					marker = writer.setMarker( 'marker2', { range, usingOperation: false } );
+					marker = writer.addMarker( 'marker2', { range, usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 				} );
 
@@ -278,7 +278,7 @@ describe( 'downcast-selection-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
-					marker = writer.setMarker( 'marker3', { range, usingOperation: false } );
+					marker = writer.addMarker( 'marker3', { range, usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 				} );
 

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -197,7 +197,8 @@ describe( 'downcast-selection-converters', () => {
 				setModelData( model, 'fo<$text bold="true">ob</$text>ar' );
 
 				model.change( writer => {
-					marker = writer.setMarker( 'marker', ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 ) );
+					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
+					marker = writer.setMarker( 'marker', range, { usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 				} );
 
@@ -221,7 +222,8 @@ describe( 'downcast-selection-converters', () => {
 				setModelData( model, 'fo<$text bold="true">ob</$text>ar' );
 
 				model.change( writer => {
-					marker = writer.setMarker( 'marker', ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 ) );
+					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
+					marker = writer.setMarker( 'marker', range, { usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 					writer.removeSelectionAttribute( 'bold' );
 				} );
@@ -249,7 +251,8 @@ describe( 'downcast-selection-converters', () => {
 				setModelData( model, 'foobar' );
 
 				model.change( writer => {
-					marker = writer.setMarker( 'marker2', ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 ) );
+					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
+					marker = writer.setMarker( 'marker2', range, { usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 				} );
 
@@ -274,7 +277,8 @@ describe( 'downcast-selection-converters', () => {
 				setModelData( model, 'foobar' );
 
 				model.change( writer => {
-					marker = writer.setMarker( 'marker3', ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 ) );
+					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
+					marker = writer.setMarker( 'marker3', range, { usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 				} );
 

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -198,7 +198,7 @@ describe( 'downcast-selection-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
-					marker = writer.setMarker( 'marker', range, { usingOperation: false } );
+					marker = writer.setMarker( 'marker', { range, usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 				} );
 
@@ -223,7 +223,7 @@ describe( 'downcast-selection-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
-					marker = writer.setMarker( 'marker', range, { usingOperation: false } );
+					marker = writer.setMarker( 'marker', { range, usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 					writer.removeSelectionAttribute( 'bold' );
 				} );
@@ -252,7 +252,7 @@ describe( 'downcast-selection-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
-					marker = writer.setMarker( 'marker2', range, { usingOperation: false } );
+					marker = writer.setMarker( 'marker2', { range, usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 				} );
 
@@ -278,7 +278,7 @@ describe( 'downcast-selection-converters', () => {
 
 				model.change( writer => {
 					const range = ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 5 );
-					marker = writer.setMarker( 'marker3', range, { usingOperation: false } );
+					marker = writer.setMarker( 'marker3', { range, usingOperation: false } );
 					writer.setSelection( new ModelRange( ModelPosition.createAt( modelRoot, 3 ) ) );
 				} );
 

--- a/tests/conversion/downcastdispatcher.js
+++ b/tests/conversion/downcastdispatcher.js
@@ -347,7 +347,8 @@ describe( 'DowncastDispatcher', () => {
 				writer.setSelection(
 					new ModelRange( new ModelPosition( root, [ 1 ] ), new ModelPosition( root, [ 1 ] ) )
 				);
-				writer.setMarker( 'name', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ), { usingOperation: false } );
+				const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 2 );
+				writer.setMarker( 'name', { range, usingOperation: false } );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );
@@ -360,7 +361,8 @@ describe( 'DowncastDispatcher', () => {
 
 		it( 'should not fire events for markers for non-collapsed selection', () => {
 			model.change( writer => {
-				writer.setMarker( 'name', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ), { usingOperation: false } );
+				const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 2 );
+				writer.setMarker( 'name', { range, usingOperation: false } );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );
@@ -400,7 +402,8 @@ describe( 'DowncastDispatcher', () => {
 			};
 
 			model.change( writer => {
-				writer.setMarker( 'name', ModelRange.createFromParentsAndOffsets( root, 0, root, 1 ), { usingOperation: false } );
+				const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 1 );
+				writer.setMarker( 'name', { range, usingOperation: false } );
 				writer.setSelection( ModelRange.createFromParentsAndOffsets( caption, 1, caption, 1 ) );
 			} );
 			sinon.spy( dispatcher, 'fire' );
@@ -417,8 +420,10 @@ describe( 'DowncastDispatcher', () => {
 				writer.setSelection(
 					new ModelRange( new ModelPosition( root, [ 1 ] ), new ModelPosition( root, [ 1 ] ) )
 				);
-				writer.setMarker( 'foo', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ), { usingOperation: false } );
-				writer.setMarker( 'bar', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ), { usingOperation: false } );
+
+				const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 2 );
+				writer.setMarker( 'foo', { range, usingOperation: false } );
+				writer.setMarker( 'bar', { range, usingOperation: false } );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );

--- a/tests/conversion/downcastdispatcher.js
+++ b/tests/conversion/downcastdispatcher.js
@@ -348,7 +348,7 @@ describe( 'DowncastDispatcher', () => {
 					new ModelRange( new ModelPosition( root, [ 1 ] ), new ModelPosition( root, [ 1 ] ) )
 				);
 				const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 2 );
-				writer.setMarker( 'name', { range, usingOperation: false } );
+				writer.addMarker( 'name', { range, usingOperation: false } );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );
@@ -362,7 +362,7 @@ describe( 'DowncastDispatcher', () => {
 		it( 'should not fire events for markers for non-collapsed selection', () => {
 			model.change( writer => {
 				const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 2 );
-				writer.setMarker( 'name', { range, usingOperation: false } );
+				writer.addMarker( 'name', { range, usingOperation: false } );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );
@@ -403,7 +403,7 @@ describe( 'DowncastDispatcher', () => {
 
 			model.change( writer => {
 				const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 1 );
-				writer.setMarker( 'name', { range, usingOperation: false } );
+				writer.addMarker( 'name', { range, usingOperation: false } );
 				writer.setSelection( ModelRange.createFromParentsAndOffsets( caption, 1, caption, 1 ) );
 			} );
 			sinon.spy( dispatcher, 'fire' );
@@ -422,8 +422,8 @@ describe( 'DowncastDispatcher', () => {
 				);
 
 				const range = ModelRange.createFromParentsAndOffsets( root, 0, root, 2 );
-				writer.setMarker( 'foo', { range, usingOperation: false } );
-				writer.setMarker( 'bar', { range, usingOperation: false } );
+				writer.addMarker( 'foo', { range, usingOperation: false } );
+				writer.addMarker( 'bar', { range, usingOperation: false } );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );

--- a/tests/conversion/downcastdispatcher.js
+++ b/tests/conversion/downcastdispatcher.js
@@ -347,7 +347,7 @@ describe( 'DowncastDispatcher', () => {
 				writer.setSelection(
 					new ModelRange( new ModelPosition( root, [ 1 ] ), new ModelPosition( root, [ 1 ] ) )
 				);
-				writer.setMarker( 'name', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ) );
+				writer.setMarker( 'name', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ), { usingOperation: false } );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );
@@ -360,7 +360,7 @@ describe( 'DowncastDispatcher', () => {
 
 		it( 'should not fire events for markers for non-collapsed selection', () => {
 			model.change( writer => {
-				writer.setMarker( 'name', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ) );
+				writer.setMarker( 'name', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ), { usingOperation: false } );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );
@@ -400,7 +400,7 @@ describe( 'DowncastDispatcher', () => {
 			};
 
 			model.change( writer => {
-				writer.setMarker( 'name', ModelRange.createFromParentsAndOffsets( root, 0, root, 1 ) );
+				writer.setMarker( 'name', ModelRange.createFromParentsAndOffsets( root, 0, root, 1 ), { usingOperation: false } );
 				writer.setSelection( ModelRange.createFromParentsAndOffsets( caption, 1, caption, 1 ) );
 			} );
 			sinon.spy( dispatcher, 'fire' );
@@ -417,8 +417,8 @@ describe( 'DowncastDispatcher', () => {
 				writer.setSelection(
 					new ModelRange( new ModelPosition( root, [ 1 ] ), new ModelPosition( root, [ 1 ] ) )
 				);
-				writer.setMarker( 'foo', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ) );
-				writer.setMarker( 'bar', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ) );
+				writer.setMarker( 'foo', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ), { usingOperation: false } );
+				writer.setMarker( 'bar', ModelRange.createFromParentsAndOffsets( root, 0, root, 2 ), { usingOperation: false } );
 			} );
 
 			sinon.spy( dispatcher, 'fire' );

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -128,7 +128,7 @@ ClassicEditor.create( global.document.querySelector( '#editor' ), {
 function addMarker( editor, color ) {
 	editor.model.change( writer => {
 		const range = ModelRange.createFromRange( editor.model.document.selection.getFirstRange() );
-		writer.setMarker( 'marker:' + color, { range, usingOperation: false } );
+		writer.addMarker( 'marker:' + color, { range, usingOperation: false } );
 	} );
 }
 

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -128,7 +128,7 @@ ClassicEditor.create( global.document.querySelector( '#editor' ), {
 function addMarker( editor, color ) {
 	editor.model.change( writer => {
 		const range = ModelRange.createFromRange( editor.model.document.selection.getFirstRange() );
-		writer.setMarker( 'marker:' + color, range );
+		writer.setMarker( 'marker:' + color, range, { usingOperation: false } );
 	} );
 }
 

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -128,7 +128,7 @@ ClassicEditor.create( global.document.querySelector( '#editor' ), {
 function addMarker( editor, color ) {
 	editor.model.change( writer => {
 		const range = ModelRange.createFromRange( editor.model.document.selection.getFirstRange() );
-		writer.setMarker( 'marker:' + color, range, { usingOperation: false } );
+		writer.setMarker( 'marker:' + color, { range, usingOperation: false } );
 	} );
 }
 

--- a/tests/manual/markers.js
+++ b/tests/manual/markers.js
@@ -83,7 +83,7 @@ ClassicEditor
 			const name = 'highlight:yellow:' + uid();
 
 			markerNames.push( name );
-			writer.setMarker( name, { range, usingOperation: false } );
+			writer.addMarker( name, { range, usingOperation: false } );
 		} );
 	} )
 	.catch( err => {
@@ -100,7 +100,7 @@ function addHighlight( color ) {
 		const name = 'highlight:' + color + ':' + uid();
 
 		markerNames.push( name );
-		writer.setMarker( name, { range, usingOperation: false } );
+		writer.addMarker( name, { range, usingOperation: false } );
 	} );
 }
 

--- a/tests/manual/markers.js
+++ b/tests/manual/markers.js
@@ -83,7 +83,7 @@ ClassicEditor
 			const name = 'highlight:yellow:' + uid();
 
 			markerNames.push( name );
-			writer.setMarker( name, range );
+			writer.setMarker( name, range, { usingOperation: false } );
 		} );
 	} )
 	.catch( err => {
@@ -100,7 +100,7 @@ function addHighlight( color ) {
 		const name = 'highlight:' + color + ':' + uid();
 
 		markerNames.push( name );
-		writer.setMarker( name, range );
+		writer.setMarker( name, range, { usingOperation: false } );
 	} );
 }
 

--- a/tests/manual/markers.js
+++ b/tests/manual/markers.js
@@ -83,7 +83,7 @@ ClassicEditor
 			const name = 'highlight:yellow:' + uid();
 
 			markerNames.push( name );
-			writer.setMarker( name, range, { usingOperation: false } );
+			writer.setMarker( name, { range, usingOperation: false } );
 		} );
 	} )
 	.catch( err => {
@@ -100,7 +100,7 @@ function addHighlight( color ) {
 		const name = 'highlight:' + color + ':' + uid();
 
 		markerNames.push( name );
-		writer.setMarker( name, range, { usingOperation: false } );
+		writer.setMarker( name, { range, usingOperation: false } );
 	} );
 }
 

--- a/tests/model/document.js
+++ b/tests/model/document.js
@@ -238,7 +238,8 @@ describe( 'Document', () => {
 			sinon.spy( doc.differ, 'bufferMarkerChange' );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', Range.createCollapsedAt( doc.getRoot(), 0 ), { usingOperation: false } );
+				const range = Range.createCollapsedAt( doc.getRoot(), 0 );
+				writer.setMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			expect( doc.differ.bufferMarkerChange.called ).to.be.true;
@@ -288,7 +289,8 @@ describe( 'Document', () => {
 
 		it( 'should call all already processed callbacks again if a callback returned true', () => {
 			const callA = sinon.spy();
-			const callB = sinon.stub().onFirstCall().returns( true ).onSecondCall().returns( false );
+			const callB = sinon.stub();
+			callB.onFirstCall().returns( true ).onSecondCall().returns( false );
 			const callC = sinon.spy();
 
 			doc.registerPostFixer( callA );
@@ -299,9 +301,9 @@ describe( 'Document', () => {
 				writer.insertText( 'foo', doc.getRoot(), 0 );
 			} );
 
-			expect( callA.calledTwice ).to.be.true;
-			expect( callB.calledTwice ).to.be.true;
-			expect( callC.calledOnce ).to.be.true;
+			sinon.assert.calledTwice( callA );
+			sinon.assert.calledTwice( callB );
+			sinon.assert.calledOnce( callC );
 		} );
 	} );
 

--- a/tests/model/document.js
+++ b/tests/model/document.js
@@ -238,7 +238,7 @@ describe( 'Document', () => {
 			sinon.spy( doc.differ, 'bufferMarkerChange' );
 
 			model.change( writer => {
-				writer.setMarker( 'marker', Range.createCollapsedAt( doc.getRoot(), 0 ) );
+				writer.setMarker( 'marker', Range.createCollapsedAt( doc.getRoot(), 0 ), { usingOperation: false } );
 			} );
 
 			expect( doc.differ.bufferMarkerChange.called ).to.be.true;

--- a/tests/model/document.js
+++ b/tests/model/document.js
@@ -235,7 +235,7 @@ describe( 'Document', () => {
 
 			model.change( writer => {
 				const range = Range.createCollapsedAt( doc.getRoot(), 0 );
-				writer.setMarker( 'marker', { range, usingOperation: false } );
+				writer.addMarker( 'marker', { range, usingOperation: false } );
 			} );
 
 			expect( doc.differ.bufferMarkerChange.called ).to.be.true;

--- a/tests/model/operation/markeroperation.js
+++ b/tests/model/operation/markeroperation.js
@@ -87,7 +87,7 @@ describe( 'MarkerOperation', () => {
 
 	it( 'should not fire document markers set event if newRange is same as current marker range', () => {
 		model.change( writer => {
-			writer.setMarker( 'name', { range, usingOperation: true } );
+			writer.addMarker( 'name', { range, usingOperation: true } );
 		} );
 
 		sinon.spy( model.markers, 'fire' );

--- a/tests/model/operation/markeroperation.js
+++ b/tests/model/operation/markeroperation.js
@@ -87,7 +87,7 @@ describe( 'MarkerOperation', () => {
 
 	it( 'should not fire document markers set event if newRange is same as current marker range', () => {
 		model.change( writer => {
-			writer.setMarker( 'name', range, { usingOperation: true } );
+			writer.setMarker( 'name', { range, usingOperation: true } );
 		} );
 
 		sinon.spy( model.markers, 'fire' );

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -1943,7 +1943,7 @@ describe( 'Writer', () => {
 		} );
 	} );
 
-	describe( 'setMarker()', () => {
+	describe( 'addMarker()', () => {
 		let root, range;
 
 		beforeEach( () => {
@@ -1954,54 +1954,54 @@ describe( 'Writer', () => {
 
 		it( 'should throw if options.usingOperations is not defined', () => {
 			expect( () => {
-				setMarker( 'name' );
-			} ).to.throw( CKEditorError, /^writer-setMarker-no-usingOperations/ );
+				addMarker( 'name' );
+			} ).to.throw( CKEditorError, /^writer-addMarker-no-usingOperations/ );
 		} );
 
 		it( 'should throw if name and range is defined but options.usingOperations is not defined', () => {
 			expect( () => {
-				setMarker( 'name', { range } );
-			} ).to.throw( CKEditorError, /^writer-setMarker-no-usingOperations/ );
+				addMarker( 'name', { range } );
+			} ).to.throw( CKEditorError, /^writer-addMarker-no-usingOperations/ );
 		} );
 
 		it( 'should add marker to the document marker collection', () => {
-			setMarker( 'name', { range, usingOperation: false } );
+			addMarker( 'name', { range, usingOperation: false } );
 
 			expect( model.markers.get( 'name' ).getRange().isEqual( range ) ).to.be.true;
 		} );
 
 		it( 'should return marker if that was set directly', () => {
-			const marker = setMarker( 'name', { range, usingOperation: false } );
+			const marker = addMarker( 'name', { range, usingOperation: false } );
 
 			expect( model.markers.get( 'name' ) ).to.equal( marker );
 		} );
 
 		it( 'should return marker if that was set using operation API', () => {
-			const marker = setMarker( 'name', { range, usingOperation: true } );
+			const marker = addMarker( 'name', { range, usingOperation: true } );
 
 			expect( model.markers.get( 'name' ) ).to.equal( marker );
 		} );
 
 		it( 'should return marker with properly set managedUsingOperations (to true)', () => {
-			const marker = setMarker( 'name', { range, usingOperation: true } );
+			const marker = addMarker( 'name', { range, usingOperation: true } );
 
 			expect( marker.managedUsingOperations ).to.equal( true );
 		} );
 
 		it( 'should return marker with properly set managedUsingOperations (to false)', () => {
-			const marker = setMarker( 'name', { range, usingOperation: false } );
+			const marker = addMarker( 'name', { range, usingOperation: false } );
 
 			expect( marker.managedUsingOperations ).to.equal( false );
 		} );
 
 		it( 'should throw when trying to update existing marker in the document marker collection', () => {
-			setMarker( 'name', { range, usingOperation: false } );
+			addMarker( 'name', { range, usingOperation: false } );
 
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
 
 			expect( () => {
-				setMarker( 'name', { range: range2, usingOperation: false } );
-			} ).to.throw( CKEditorError, /^writer-setMarker-marker-exists/ );
+				addMarker( 'name', { range: range2, usingOperation: false } );
+			} ).to.throw( CKEditorError, /^writer-addMarker-marker-exists/ );
 		} );
 
 		it( 'should use operations when having set usingOperation to true', () => {
@@ -2009,7 +2009,7 @@ describe( 'Writer', () => {
 
 			model.on( 'applyOperation', spy );
 
-			setMarker( 'name', { range, usingOperation: true } );
+			addMarker( 'name', { range, usingOperation: true } );
 			const op = batch.deltas[ 0 ].operations[ 0 ];
 
 			expect( spy.calledOnce ).to.be.true;
@@ -2020,22 +2020,22 @@ describe( 'Writer', () => {
 
 		it( 'should throw if marker with given name does not exist and range is not passed', () => {
 			expect( () => {
-				setMarker( 'name', { usingOperation: true } );
-			} ).to.throw( CKEditorError, /^writer-setMarker-no-range/ );
+				addMarker( 'name', { usingOperation: true } );
+			} ).to.throw( CKEditorError, /^writer-addMarker-no-range/ );
 		} );
 
 		it( 'should throw if marker is set directly and range is not passed', () => {
 			expect( () => {
-				setMarker( 'name', { usingOperation: false } );
-			} ).to.throw( CKEditorError, /^writer-setMarker-no-range/ );
+				addMarker( 'name', { usingOperation: false } );
+			} ).to.throw( CKEditorError, /^writer-addMarker-no-range/ );
 		} );
 
 		it( 'should throw when trying to use detached writer', () => {
-			const marker = setMarker( 'name', { range, usingOperation: false } );
+			const marker = addMarker( 'name', { range, usingOperation: false } );
 			const writer = new Writer( model, batch );
 
 			expect( () => {
-				writer.setMarker( marker, null, { usingOperation: true } );
+				writer.addMarker( marker, null, { usingOperation: true } );
 			} ).to.throw( CKEditorError, /^writer-incorrect-use/ );
 		} );
 	} );
@@ -2050,7 +2050,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should accept marker instance', () => {
-			const marker = setMarker( 'name', { range, usingOperation: true } );
+			const marker = addMarker( 'name', { range, usingOperation: true } );
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
 
 			updateMarker( marker, { range: range2, usingOperation: true } );
@@ -2068,7 +2068,7 @@ describe( 'Writer', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
-			const marker = setMarker( 'name', { range, usingOperation: false } );
+			const marker = addMarker( 'name', { range, usingOperation: false } );
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
 
 			updateMarker( marker, { range: range2, usingOperation: false } );
@@ -2077,7 +2077,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should accept empty range parameter if marker instance is passed and usingOperation is set to true', () => {
-			const marker = setMarker( 'name', { range, usingOperation: true } );
+			const marker = addMarker( 'name', { range, usingOperation: true } );
 			const spy = sinon.spy();
 
 			model.on( 'applyOperation', spy );
@@ -2096,7 +2096,7 @@ describe( 'Writer', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
-			setMarker( 'name', { range, usingOperation: true } );
+			addMarker( 'name', { range, usingOperation: true } );
 			updateMarker( 'name', { range } );
 
 			const marker = model.markers.get( 'name' );
@@ -2121,7 +2121,7 @@ describe( 'Writer', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
-			setMarker( 'name', { range, usingOperation: false } );
+			addMarker( 'name', { range, usingOperation: false } );
 			updateMarker( 'name', { range, usingOperation: true } );
 
 			const marker = model.markers.get( 'name' );
@@ -2136,7 +2136,7 @@ describe( 'Writer', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
-			setMarker( 'name', { range, usingOperation: true } );
+			addMarker( 'name', { range, usingOperation: true } );
 			updateMarker( 'name', { range, usingOperation: false } );
 
 			const marker = model.markers.get( 'name' );
@@ -2152,7 +2152,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should throw when trying to use detached writer', () => {
-			const marker = setMarker( 'name', { range, usingOperation: false } );
+			const marker = addMarker( 'name', { range, usingOperation: false } );
 			const writer = new Writer( model, batch );
 
 			expect( () => {
@@ -2171,7 +2171,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should remove marker from the document marker collection', () => {
-			setMarker( 'name', { range, usingOperation: false } );
+			addMarker( 'name', { range, usingOperation: false } );
 			removeMarker( 'name' );
 
 			expect( model.markers.get( 'name' ) ).to.be.null;
@@ -2192,7 +2192,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should accept marker instance', () => {
-			setMarker( 'name', { range, usingOperation: false } );
+			addMarker( 'name', { range, usingOperation: false } );
 			const marker = model.markers.get( 'name' );
 
 			removeMarker( marker );
@@ -2201,7 +2201,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should use MarkerOperation when marker was created using operation', () => {
-			setMarker( 'name', { range, usingOperation: true } );
+			addMarker( 'name', { range, usingOperation: true } );
 
 			const marker = model.markers.get( 'name' );
 			const spy = sinon.spy();
@@ -2596,11 +2596,11 @@ describe( 'Writer', () => {
 		} );
 	}
 
-	function setMarker( name, options ) {
+	function addMarker( name, options ) {
 		let marker;
 
 		model.enqueueChange( batch, writer => {
-			marker = writer.setMarker( name, options );
+			marker = writer.addMarker( name, options );
 		} );
 
 		return marker;

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -1952,14 +1952,32 @@ describe( 'Writer', () => {
 			range = Range.createIn( root );
 		} );
 
+		it( 'should throw if options.usingOperations is not defined', () => {
+			expect( () => {
+				setMarker( 'name' );
+			} ).to.throw( CKEditorError, /^writer-setMarker-no-usingOperations/ );
+		} );
+
+		it( 'should throw if name and range is defined but options.usingOperations is not defined', () => {
+			expect( () => {
+				setMarker( 'name', range );
+			} ).to.throw( CKEditorError, /^writer-setMarker-no-usingOperations/ );
+		} );
+
+		it( 'should throw range is defined but options.usingOperations is not defined', () => {
+			expect( () => {
+				setMarker( range );
+			} ).to.throw( CKEditorError, /^writer-setMarker-no-usingOperations/ );
+		} );
+
 		it( 'should add marker to the document marker collection', () => {
-			setMarker( 'name', range );
+			setMarker( 'name', range, { usingOperation: false } );
 
 			expect( model.markers.get( 'name' ).getRange().isEqual( range ) ).to.be.true;
 		} );
 
 		it( 'should return marker if that was set directly', () => {
-			const marker = setMarker( 'name', range );
+			const marker = setMarker( 'name', range, { usingOperation: false } );
 
 			expect( model.markers.get( 'name' ) ).to.equal( marker );
 		} );
@@ -1977,16 +1995,16 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should return marker with properly set managedUsingOperations (to false)', () => {
-			const marker = setMarker( 'name', range );
+			const marker = setMarker( 'name', range, { usingOperation: false } );
 
 			expect( marker.managedUsingOperations ).to.equal( false );
 		} );
 
 		it( 'should update marker in the document marker collection', () => {
-			const marker = setMarker( 'name', range );
+			const marker = setMarker( 'name', range, { usingOperation: false } );
 
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
-			setMarker( 'name', range2 );
+			setMarker( 'name', range2, { usingOperation: false } );
 
 			expect( marker.getRange().isEqual( range2 ) ).to.be.true;
 		} );
@@ -2023,7 +2041,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should create a unique id if the first param is type of range', () => {
-			const marker = setMarker( range );
+			const marker = setMarker( range, { usingOperation: false } );
 
 			expect( marker.name ).to.be.a( 'string' );
 		} );
@@ -2060,7 +2078,7 @@ describe( 'Writer', () => {
 
 		it( 'should throw if marker is set directly and range is not passed', () => {
 			expect( () => {
-				setMarker( 'name' );
+				setMarker( 'name', { usingOperation: false } );
 			} ).to.throw( CKEditorError, /^writer-setMarker-no-range/ );
 		} );
 
@@ -2069,7 +2087,7 @@ describe( 'Writer', () => {
 			model.on( 'applyOperation', spy );
 
 			setMarker( 'name', range, { usingOperation: true } );
-			const marker = setMarker( 'name', range );
+			const marker = setMarker( 'name', range, { usingOperation: false } );
 			const op1 = batch.deltas[ 0 ].operations[ 0 ];
 			const op2 = batch.deltas[ 1 ].operations[ 0 ];
 
@@ -2090,7 +2108,7 @@ describe( 'Writer', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
-			setMarker( 'name', range );
+			setMarker( 'name', range, { usingOperation: false } );
 			const marker = setMarker( 'name', range, { usingOperation: true } );
 
 			expect( spy.calledOnce ).to.be.true;
@@ -2100,7 +2118,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should throw when trying to use detached writer', () => {
-			const marker = setMarker( 'name', range );
+			const marker = setMarker( 'name', range, { usingOperation: false } );
 			const writer = new Writer( model, batch );
 
 			expect( () => {
@@ -2119,7 +2137,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should remove marker from the document marker collection', () => {
-			setMarker( 'name', range );
+			setMarker( 'name', range, { usingOperation: false } );
 			removeMarker( 'name' );
 
 			expect( model.markers.get( 'name' ) ).to.be.null;
@@ -2140,7 +2158,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should accept marker instance', () => {
-			setMarker( 'name', range );
+			setMarker( 'name', range, { usingOperation: false } );
 			const marker = model.markers.get( 'name' );
 
 			removeMarker( marker );

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -2606,9 +2606,9 @@ describe( 'Writer', () => {
 		return marker;
 	}
 
-	function updateMarker( markerOrNameOrRange, rangeOrManagedUsingOperations, options ) {
+	function updateMarker( markerOrName, options ) {
 		model.enqueueChange( batch, writer => {
-			writer.updateMarker( markerOrNameOrRange, rangeOrManagedUsingOperations, options );
+			writer.updateMarker( markerOrName, options );
 		} );
 	}
 

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -2000,16 +2000,18 @@ describe( 'Writer', () => {
 			expect( marker.managedUsingOperations ).to.equal( false );
 		} );
 
-		it( 'should update marker in the document marker collection', () => {
-			const marker = setMarker( 'name', range, { usingOperation: false } );
+		it( 'should throw when trying to update existing marker in the document marker collection', () => {
+			setMarker( 'name', range, { usingOperation: false } );
 
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
-			setMarker( 'name', range2, { usingOperation: false } );
 
-			expect( marker.getRange().isEqual( range2 ) ).to.be.true;
+			expect( () => {
+				setMarker( 'name', range2, { usingOperation: false } );
+			} ).to.throw( CKEditorError, /^writer-setMarker-marker-exists/ );
 		} );
 
-		it( 'should accept marker instance', () => {
+		// TODO: move to updateMarker
+		it.skip( 'should accept marker instance', () => {
 			const marker = setMarker( 'name', range, { usingOperation: true } );
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
 
@@ -2024,7 +2026,8 @@ describe( 'Writer', () => {
 			expect( op.newRange.isEqual( range2 ) ).to.be.true;
 		} );
 
-		it( 'should accept empty range parameter if marker instance is passed and usingOperation is set to true', () => {
+		// TODO: move to updateMarker
+		it.skip( 'should accept empty range parameter if marker instance is passed and usingOperation is set to true', () => {
 			const marker = setMarker( 'name', range, { usingOperation: true } );
 			const spy = sinon.spy();
 
@@ -2082,7 +2085,8 @@ describe( 'Writer', () => {
 			} ).to.throw( CKEditorError, /^writer-setMarker-no-range/ );
 		} );
 
-		it( 'should create additional operation when marker type changes to not managed using operation', () => {
+		// TODO: move to updateMarker
+		it.skip( 'should create additional operation when marker type changes to not managed using operation', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
@@ -2104,7 +2108,8 @@ describe( 'Writer', () => {
 			expect( marker.managedUsingOperations ).to.be.false;
 		} );
 
-		it( 'should enable changing marker to be not managed using operation', () => {
+		// TODO: move to updateMarker
+		it.skip( 'should enable changing marker to be not managed using operation', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -2012,7 +2012,7 @@ describe( 'Writer', () => {
 			addMarker( 'name', { range, usingOperation: true } );
 			const op = batch.deltas[ 0 ].operations[ 0 ];
 
-			expect( spy.calledOnce ).to.be.true;
+			sinon.assert.calledOnce( spy );
 			expect( spy.firstCall.args[ 1 ][ 0 ].type ).to.equal( 'marker' );
 			expect( op.oldRange ).to.be.null;
 			expect( op.newRange.isEqual( range ) ).to.be.true;
@@ -2086,7 +2086,7 @@ describe( 'Writer', () => {
 
 			const op = batch.deltas[ 0 ].operations[ 0 ];
 
-			expect( spy.calledOnce ).to.be.true;
+			sinon.assert.calledOnce( spy );
 			expect( spy.firstCall.args[ 1 ][ 0 ].type ).to.equal( 'marker' );
 			expect( op.oldRange ).to.be.null;
 			expect( op.newRange.isEqual( range ) ).to.be.true;
@@ -2097,14 +2097,14 @@ describe( 'Writer', () => {
 			model.on( 'applyOperation', spy );
 
 			addMarker( 'name', { range, usingOperation: true } );
-			updateMarker( 'name', { range } );
+			updateMarker( 'name', { range, usingOperation: false } );
 
 			const marker = model.markers.get( 'name' );
 
 			const op1 = batch.deltas[ 0 ].operations[ 0 ];
 			const op2 = batch.deltas[ 1 ].operations[ 0 ];
 
-			expect( spy.calledTwice ).to.be.true;
+			sinon.assert.calledTwice( spy );
 			expect( spy.firstCall.args[ 1 ][ 0 ].type ).to.equal( 'marker' );
 			expect( spy.secondCall.args[ 1 ][ 0 ].type ).to.equal( 'marker' );
 
@@ -2117,6 +2117,22 @@ describe( 'Writer', () => {
 			expect( marker.managedUsingOperations ).to.be.false;
 		} );
 
+		it( 'should not create additional operation when using operation is not specified', () => {
+			const spy = sinon.spy();
+			model.on( 'applyOperation', spy );
+
+			addMarker( 'name', { range, usingOperation: true } );
+
+			sinon.assert.calledOnce( spy );
+
+			updateMarker( 'name', { range } );
+
+			const marker = model.markers.get( 'name' );
+
+			sinon.assert.calledOnce( spy );
+			expect( marker.managedUsingOperations ).to.be.true;
+		} );
+
 		it( 'should enable changing marker to be managed using operation', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
@@ -2126,7 +2142,7 @@ describe( 'Writer', () => {
 
 			const marker = model.markers.get( 'name' );
 
-			expect( spy.calledOnce ).to.be.true;
+			sinon.assert.calledOnce( spy );
 			expect( spy.firstCall.args[ 1 ][ 0 ].type ).to.equal( 'marker' );
 
 			expect( marker.managedUsingOperations ).to.be.true;
@@ -2210,7 +2226,7 @@ describe( 'Writer', () => {
 
 			removeMarker( marker );
 
-			expect( spy.calledOnce ).to.be.true;
+			sinon.assert.calledOnce( spy );
 			expect( spy.firstCall.args[ 1 ][ 0 ].type ).to.equal( 'marker' );
 			expect( model.markers.get( 'name' ) ).to.be.null;
 		} );

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -1960,70 +1960,48 @@ describe( 'Writer', () => {
 
 		it( 'should throw if name and range is defined but options.usingOperations is not defined', () => {
 			expect( () => {
-				setMarker( 'name', range );
-			} ).to.throw( CKEditorError, /^writer-setMarker-no-usingOperations/ );
-		} );
-
-		it( 'should throw range is defined but options.usingOperations is not defined', () => {
-			expect( () => {
-				setMarker( range );
+				setMarker( 'name', { range } );
 			} ).to.throw( CKEditorError, /^writer-setMarker-no-usingOperations/ );
 		} );
 
 		it( 'should add marker to the document marker collection', () => {
-			setMarker( 'name', range, { usingOperation: false } );
+			setMarker( 'name', { range, usingOperation: false } );
 
 			expect( model.markers.get( 'name' ).getRange().isEqual( range ) ).to.be.true;
 		} );
 
 		it( 'should return marker if that was set directly', () => {
-			const marker = setMarker( 'name', range, { usingOperation: false } );
+			const marker = setMarker( 'name', { range, usingOperation: false } );
 
 			expect( model.markers.get( 'name' ) ).to.equal( marker );
 		} );
 
 		it( 'should return marker if that was set using operation API', () => {
-			const marker = setMarker( 'name', range, { usingOperation: true } );
+			const marker = setMarker( 'name', { range, usingOperation: true } );
 
 			expect( model.markers.get( 'name' ) ).to.equal( marker );
 		} );
 
 		it( 'should return marker with properly set managedUsingOperations (to true)', () => {
-			const marker = setMarker( 'name', range, { usingOperation: true } );
+			const marker = setMarker( 'name', { range, usingOperation: true } );
 
 			expect( marker.managedUsingOperations ).to.equal( true );
 		} );
 
 		it( 'should return marker with properly set managedUsingOperations (to false)', () => {
-			const marker = setMarker( 'name', range, { usingOperation: false } );
+			const marker = setMarker( 'name', { range, usingOperation: false } );
 
 			expect( marker.managedUsingOperations ).to.equal( false );
 		} );
 
 		it( 'should throw when trying to update existing marker in the document marker collection', () => {
-			setMarker( 'name', range, { usingOperation: false } );
+			setMarker( 'name', { range, usingOperation: false } );
 
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
 
 			expect( () => {
-				setMarker( 'name', range2, { usingOperation: false } );
+				setMarker( 'name', { range: range2, usingOperation: false } );
 			} ).to.throw( CKEditorError, /^writer-setMarker-marker-exists/ );
-		} );
-
-		it( 'should create a unique id if the first param is type of range', () => {
-			const marker = setMarker( range, { usingOperation: false } );
-
-			expect( marker.name ).to.be.a( 'string' );
-		} );
-
-		it( 'should create a unique id if the first param is type of range when usingOperation is set to true', () => {
-			const spy = sinon.spy();
-			model.on( 'applyOperation', spy );
-
-			const marker = setMarker( range, { usingOperation: true } );
-
-			expect( marker.name ).to.be.a( 'string' );
-			expect( spy.calledOnce ).to.be.true;
 		} );
 
 		it( 'should use operations when having set usingOperation to true', () => {
@@ -2031,7 +2009,7 @@ describe( 'Writer', () => {
 
 			model.on( 'applyOperation', spy );
 
-			setMarker( 'name', range, { usingOperation: true } );
+			setMarker( 'name', { range, usingOperation: true } );
 			const op = batch.deltas[ 0 ].operations[ 0 ];
 
 			expect( spy.calledOnce ).to.be.true;
@@ -2053,7 +2031,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should throw when trying to use detached writer', () => {
-			const marker = setMarker( 'name', range, { usingOperation: false } );
+			const marker = setMarker( 'name', { range, usingOperation: false } );
 			const writer = new Writer( model, batch );
 
 			expect( () => {
@@ -2072,10 +2050,10 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should accept marker instance', () => {
-			const marker = setMarker( 'name', range, { usingOperation: true } );
+			const marker = setMarker( 'name', { range, usingOperation: true } );
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
 
-			updateMarker( marker, range2, { usingOperation: true } );
+			updateMarker( marker, { range: range2, usingOperation: true } );
 
 			expect( batch.deltas.length ).to.equal( 2 );
 
@@ -2090,16 +2068,16 @@ describe( 'Writer', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
-			const marker = setMarker( 'name', range, { usingOperation: false } );
+			const marker = setMarker( 'name', { range, usingOperation: false } );
 			const range2 = Range.createFromParentsAndOffsets( root, 0, root, 0 );
 
-			updateMarker( marker, range2, { usingOperation: false } );
+			updateMarker( marker, { range: range2, usingOperation: false } );
 
 			sinon.assert.notCalled( spy );
 		} );
 
 		it( 'should accept empty range parameter if marker instance is passed and usingOperation is set to true', () => {
-			const marker = setMarker( 'name', range, { usingOperation: true } );
+			const marker = setMarker( 'name', { range, usingOperation: true } );
 			const spy = sinon.spy();
 
 			model.on( 'applyOperation', spy );
@@ -2118,8 +2096,8 @@ describe( 'Writer', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
-			setMarker( 'name', range, { usingOperation: true } );
-			updateMarker( 'name', range );
+			setMarker( 'name', { range, usingOperation: true } );
+			updateMarker( 'name', { range } );
 
 			const marker = model.markers.get( 'name' );
 
@@ -2143,8 +2121,8 @@ describe( 'Writer', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
-			setMarker( 'name', range, { usingOperation: false } );
-			updateMarker( 'name', range, { usingOperation: true } );
+			setMarker( 'name', { range, usingOperation: false } );
+			updateMarker( 'name', { range, usingOperation: true } );
 
 			const marker = model.markers.get( 'name' );
 
@@ -2158,8 +2136,8 @@ describe( 'Writer', () => {
 			const spy = sinon.spy();
 			model.on( 'applyOperation', spy );
 
-			setMarker( 'name', range, { usingOperation: true } );
-			updateMarker( 'name', range, { usingOperation: false } );
+			setMarker( 'name', { range, usingOperation: true } );
+			updateMarker( 'name', { range, usingOperation: false } );
 
 			const marker = model.markers.get( 'name' );
 
@@ -2174,7 +2152,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should throw when trying to use detached writer', () => {
-			const marker = setMarker( 'name', range, { usingOperation: false } );
+			const marker = setMarker( 'name', { range, usingOperation: false } );
 			const writer = new Writer( model, batch );
 
 			expect( () => {
@@ -2193,7 +2171,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should remove marker from the document marker collection', () => {
-			setMarker( 'name', range, { usingOperation: false } );
+			setMarker( 'name', { range, usingOperation: false } );
 			removeMarker( 'name' );
 
 			expect( model.markers.get( 'name' ) ).to.be.null;
@@ -2214,7 +2192,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should accept marker instance', () => {
-			setMarker( 'name', range, { usingOperation: false } );
+			setMarker( 'name', { range, usingOperation: false } );
 			const marker = model.markers.get( 'name' );
 
 			removeMarker( marker );
@@ -2223,7 +2201,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should use MarkerOperation when marker was created using operation', () => {
-			setMarker( 'name', range, { usingOperation: true } );
+			setMarker( 'name', { range, usingOperation: true } );
 
 			const marker = model.markers.get( 'name' );
 			const spy = sinon.spy();
@@ -2618,11 +2596,11 @@ describe( 'Writer', () => {
 		} );
 	}
 
-	function setMarker( markerOrNameOrRange, rangeOrManagedUsingOperations, options ) {
+	function setMarker( name, options ) {
 		let marker;
 
 		model.enqueueChange( batch, writer => {
-			marker = writer.setMarker( markerOrNameOrRange, rangeOrManagedUsingOperations, options );
+			marker = writer.setMarker( name, options );
 		} );
 
 		return marker;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduce `writer#updateMarker()` method. Closes #1299.

BREAKING CHANGE: The `writer#setMarker()` method is used only to create a new marker and it does not accept a `marker` instance as a parameter. To update existing marker use `writer#updateMarker()` method.
BREAKING CHANGE: The `options.usingOperation` option in `writer#setMarker()` is now a required one.
BREAKING CHANGE: The `range` parameter was removed. Use `options.range` instead.

---

### Additional information

Other repositories that required changes:
- ckeditor5-link: https://github.com/ckeditor/ckeditor5-link/tree/t/ckeditor5-engine/1299
- ckeditor5-undo: https://github.com/ckeditor/ckeditor5-undo/tree/t/ckeditor5-engine/1299

Suggested merge message for other repositores:
```
Aligned code to changes in writer#setMarker method.
```
