### PR TITLE
Rename attribute names from singular to plural

### DIFF
--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -133,7 +133,7 @@ export default class Conversion {
 	 *			model: 'fancyParagraph',
 	 *			view: {
 	 *				name: 'p',
-	 *				class: 'fancy'
+	 *				classes: 'fancy'
 	 *			}
 	 *		} );
 	 *
@@ -145,7 +145,7 @@ export default class Conversion {
 	 *				'div',
 	 *				{
 	 *					// Any element with `display: block` style.
-	 *					style: {
+	 *					styles: {
 	 *						display: 'block'
 	 *					}
 	 *				}
@@ -177,7 +177,7 @@ export default class Conversion {
 	 *					// Those properties will be "consumed" during conversion.
 	 *					// See `engine.view.Matcher~MatcherPattern` and `engine.view.Matcher#match` for more.
 	 *
-	 *					return { name: true, style: [ 'font-size' ] };
+	 *					return { name: true, styles: [ 'font-size' ] };
 	 *				}
 	 *
 	 *				return null;
@@ -220,7 +220,7 @@ export default class Conversion {
 	 *			model: 'bold',
 	 *			view: {
 	 *				name: 'span',
-	 *				class: 'bold'
+	 *				classes: 'bold'
 	 *			}
 	 *		} );
 	 *
@@ -235,13 +235,13 @@ export default class Conversion {
 	 *			view: {
 	 *				underline: {
 	 *					name: 'span',
-	 *					style: {
+	 *					styles: {
 	 *						'text-decoration': 'underline'
 	 *					}
 	 *				},
 	 *				lineThrough: {
 	 *					name: 'span',
-	 *					style: {
+	 *					styles: {
 	 *						'text-decoration': 'line-through'
 	 *					}
 	 *				}
@@ -256,11 +256,11 @@ export default class Conversion {
 	 *				'b',
 	 *				{
 	 *					name: 'span',
-	 *					class: 'bold'
+	 *					classes: 'bold'
 	 *				},
 	 *				{
 	 *					name: 'span',
-	 *					style: {
+	 *					styles: {
 	 *						'font-weight': 'bold'
 	 *					}
 	 *				},
@@ -274,7 +274,7 @@ export default class Conversion {
 	 *
 	 *						return {
 	 *							name: true,
-	 *							style: [ 'font-weight' ]
+	 *							styles: [ 'font-weight' ]
 	 *						};
 	 *					}
 	 *				}
@@ -291,13 +291,13 @@ export default class Conversion {
 	 *			view: {
 	 *				big: {
 	 *					name: 'span',
-	 *					style: {
+	 *					styles: {
 	 *						'font-size': '1.2em'
 	 *					}
 	 *				},
 	 *				small: {
 	 *					name: 'span',
-	 *					style: {
+	 *					styles: {
 	 *						'font-size': '0.8em'
 	 *					}
 	 *				}
@@ -323,7 +323,7 @@ export default class Conversion {
 	 *						// Those properties will be "consumed" during conversion.
 	 *						// See `engine.view.Matcher~MatcherPattern` and `engine.view.Matcher#match` for more.
 	 *
-	 *						return { name: true, style: [ 'font-size' ] };
+	 *						return { name: true, styles: [ 'font-size' ] };
 	 *					}
 	 *
 	 *					return null;
@@ -348,7 +348,7 @@ export default class Conversion {
 	 *						// Those properties will be "consumed" during conversion.
 	 *						// See `engine.view.Matcher~MatcherPattern` and `engine.view.Matcher#match` for more.
 	 *
-	 *						return { name: true, style: [ 'font-size' ] };
+	 *						return { name: true, styles: [ 'font-size' ] };
 	 *					}
 	 *
 	 *					return null;
@@ -440,12 +440,12 @@ export default class Conversion {
 	 *			},
 	 *			upcastAlso: {
 	 *				right: {
-	 *					style: {
+	 *					styles: {
 	 *						'text-align': 'right'
 	 *					}
 	 *				},
 	 *				center: {
-	 *					style: {
+	 *					styles: {
 	 *						'text-align': 'center'
 	 *					}
 	 *				}

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -638,7 +638,7 @@ export function removeUIElement() {
  * The converter automatically consumes corresponding value from consumables list and stops the event (see
  * {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher}).
  *
- *		modelDispatcher.on( 'attributes:customAttr:myElem', changeAttribute( ( value, data ) => {
+ *		modelDispatcher.on( 'attribute:customAttr:myElem', changeAttribute( ( value, data ) => {
  *			// Change attribute key from `customAttr` to `class` in view.
  *			const key = 'class';
  *			let value = data.attributeNewValue;
@@ -738,7 +738,7 @@ export function changeAttribute( attributeCreator ) {
  * The converter automatically consumes corresponding value from consumables list, stops the event (see
  * {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher}).
  *
- *		modelDispatcher.on( 'attributes:bold', wrapItem( ( modelAttributeValue, viewWriter ) => {
+ *		modelDispatcher.on( 'attribute:bold', wrapItem( ( modelAttributeValue, viewWriter ) => {
  *			return viewWriter.createAttributeElement( 'strong' );
  *		} );
  *

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -32,7 +32,7 @@ import cloneDeep from '@ckeditor/ckeditor5-utils/src/lib/lodash/cloneDeep';
  *			model: 'fancyParagraph',
  *			view: {
  *				name: 'p',
- *				class: 'fancy'
+ *				classes: 'fancy'
  *			}
  *		} );
  *
@@ -73,7 +73,7 @@ export function downcastElementToElement( config ) {
  *			model: 'invert',
  *			view: {
  *				name: 'span',
- *				class: [ 'font-light', 'bg-dark' ]
+ *				classes: [ 'font-light', 'bg-dark' ]
  *			}
  *		} );
  *
@@ -85,13 +85,13 @@ export function downcastElementToElement( config ) {
  *			view: {
  *				big: {
  *					name: 'span',
- *					style: {
+ *					styles: {
  *						'font-size': '1.2em'
  *					}
  *				},
  *				small: {
  *					name: 'span',
- *					style: {
+ *					styles: {
  *						'font-size': '0.8em'
  *					}
  *				}
@@ -244,7 +244,7 @@ export function downcastAttributeToAttribute( config ) {
  *			model: 'search',
  *			view: {
  *				name: 'span',
- *				attribute: {
+ *				attributes: {
  *					'data-marker': 'search'
  *				}
  *			}
@@ -305,9 +305,9 @@ export function downcastMarkerToElement( config ) {
  * to a container element, it is the container element instance itself which applies values from highlight descriptor.
  * So, in a sense, converter takes care of stating what should be applied on what, while element decides how to apply that.
  *
- *		downcastMarkerToHighlight( { model: 'comment', view: { class: 'comment' } } );
+ *		downcastMarkerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
  *
- *		downcastMarkerToHighlight( { model: 'comment', view: { class: 'new-comment' }, priority: 'high' } );
+ *		downcastMarkerToHighlight( { model: 'comment', view: { classes: 'new-comment' }, priority: 'high' } );
  *
  * 		downcastMarkerToHighlight( {
  * 			model: 'comment',
@@ -316,7 +316,7 @@ export function downcastMarkerToElement( config ) {
  *	 			const commentType = data.markerName.split( ':' )[ 1 ];
  *
  *	 			return {
- *	 				class: [ 'comment', 'comment-' + commentType ]
+ *	 				classes: [ 'comment', 'comment-' + commentType ]
  *	 			};
  * 			}
  * 		} );
@@ -372,24 +372,24 @@ function _createViewElementFromDefinition( viewElementDefinition, viewWriter, vi
 	let element;
 
 	if ( viewElementType == 'container' ) {
-		element = viewWriter.createContainerElement( viewElementDefinition.name, Object.assign( {}, viewElementDefinition.attribute ) );
+		element = viewWriter.createContainerElement( viewElementDefinition.name, Object.assign( {}, viewElementDefinition.attributes ) );
 	} else if ( viewElementType == 'attribute' ) {
-		element = viewWriter.createAttributeElement( viewElementDefinition.name, Object.assign( {}, viewElementDefinition.attribute ) );
+		element = viewWriter.createAttributeElement( viewElementDefinition.name, Object.assign( {}, viewElementDefinition.attributes ) );
 	} else {
 		// 'ui'.
-		element = viewWriter.createUIElement( viewElementDefinition.name, Object.assign( {}, viewElementDefinition.attribute ) );
+		element = viewWriter.createUIElement( viewElementDefinition.name, Object.assign( {}, viewElementDefinition.attributes ) );
 	}
 
-	if ( viewElementDefinition.style ) {
-		const keys = Object.keys( viewElementDefinition.style );
+	if ( viewElementDefinition.styles ) {
+		const keys = Object.keys( viewElementDefinition.styles );
 
 		for ( const key of keys ) {
-			viewWriter.setStyle( key, viewElementDefinition.style[ key ], element );
+			viewWriter.setStyle( key, viewElementDefinition.styles[ key ], element );
 		}
 	}
 
-	if ( viewElementDefinition.class ) {
-		const classes = viewElementDefinition.class;
+	if ( viewElementDefinition.classes ) {
+		const classes = viewElementDefinition.classes;
 
 		if ( typeof classes == 'string' ) {
 			viewWriter.addClass( classes, element );
@@ -638,7 +638,7 @@ export function removeUIElement() {
  * The converter automatically consumes corresponding value from consumables list and stops the event (see
  * {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher}).
  *
- *		modelDispatcher.on( 'attribute:customAttr:myElem', changeAttribute( ( value, data ) => {
+ *		modelDispatcher.on( 'attributes:customAttr:myElem', changeAttribute( ( value, data ) => {
  *			// Change attribute key from `customAttr` to `class` in view.
  *			const key = 'class';
  *			let value = data.attributeNewValue;
@@ -738,7 +738,7 @@ export function changeAttribute( attributeCreator ) {
  * The converter automatically consumes corresponding value from consumables list, stops the event (see
  * {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher}).
  *
- *		modelDispatcher.on( 'attribute:bold', wrapItem( ( modelAttributeValue, viewWriter ) => {
+ *		modelDispatcher.on( 'attributes:bold', wrapItem( ( modelAttributeValue, viewWriter ) => {
  *			return viewWriter.createAttributeElement( 'strong' );
  *		} );
  *
@@ -1000,8 +1000,8 @@ function _prepareDescriptor( highlightDescriptor, data, conversionApi ) {
 export function createViewElementFromHighlightDescriptor( descriptor ) {
 	const viewElement = new ViewAttributeElement( 'span', descriptor.attributes );
 
-	if ( descriptor.class ) {
-		viewElement._addClass( descriptor.class );
+	if ( descriptor.classes ) {
+		viewElement._addClass( descriptor.classes );
 	}
 
 	if ( descriptor.priority ) {

--- a/src/conversion/modelconsumable.js
+++ b/src/conversion/modelconsumable.js
@@ -21,7 +21,7 @@ import TextProxy from '../model/textproxy';
  * during conversion, when given part of model item is converted (i.e. the view element has been inserted into the view,
  * but without attributes), consumable value is removed from `ModelConsumable`.
  *
- * For model items, `ModelConsumable` stores consumable values of one of following types: `insert`, `addattributes:<attributeKey>`,
+ * For model items, `ModelConsumable` stores consumable values of one of following types: `insert`, `addattribute:<attributeKey>`,
  * `changeattributes:<attributeKey>`, `removeattributes:<attributeKey>`.
  *
  * In most cases, it is enough to let {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher}
@@ -312,7 +312,7 @@ export default class ModelConsumable {
 
 // Returns a normalized consumable type name from given string. A normalized consumable type name is a string that has
 // at most one colon, for example: `insert` or `addMarker:highlight`. If string to normalize has more "parts" (more colons),
-// the other parts are dropped, for example: `addattributes:bold:$text` -> `addattributes:bold`.
+// the other parts are dropped, for example: `addattribute:bold:$text` -> `addattributes:bold`.
 //
 // @param {String} type Consumable type.
 // @returns {String} Normalized consumable type.

--- a/src/conversion/modelconsumable.js
+++ b/src/conversion/modelconsumable.js
@@ -21,8 +21,8 @@ import TextProxy from '../model/textproxy';
  * during conversion, when given part of model item is converted (i.e. the view element has been inserted into the view,
  * but without attributes), consumable value is removed from `ModelConsumable`.
  *
- * For model items, `ModelConsumable` stores consumable values of one of following types: `insert`, `addAttribute:<attributeKey>`,
- * `changeAttribute:<attributeKey>`, `removeAttribute:<attributeKey>`.
+ * For model items, `ModelConsumable` stores consumable values of one of following types: `insert`, `addattributes:<attributeKey>`,
+ * `changeattributes:<attributeKey>`, `removeattributes:<attributeKey>`.
  *
  * In most cases, it is enough to let {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher}
  * gather consumable values, so there is no need to use
@@ -312,7 +312,7 @@ export default class ModelConsumable {
 
 // Returns a normalized consumable type name from given string. A normalized consumable type name is a string that has
 // at most one colon, for example: `insert` or `addMarker:highlight`. If string to normalize has more "parts" (more colons),
-// the other parts are dropped, for example: `addAttribute:bold:$text` -> `addAttribute:bold`.
+// the other parts are dropped, for example: `addattributes:bold:$text` -> `addattributes:bold`.
 //
 // @param {String} type Consumable type.
 // @returns {String} Normalized consumable type.

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -31,7 +31,7 @@ import cloneDeep from '@ckeditor/ckeditor5-utils/src/lib/lodash/cloneDeep';
  *		upcastElementToElement( {
  *			view: {
  *				name: 'p',
- *				class: 'fancy'
+ *				classes: 'fancy'
  *			},
  *			model: 'fancyParagraph'
  *		} );
@@ -39,7 +39,7 @@ import cloneDeep from '@ckeditor/ckeditor5-utils/src/lib/lodash/cloneDeep';
  *		upcastElementToElement( {
  * 			view: {
  *				name: 'p',
- *				class: 'heading'
+ *				classes: 'heading'
  * 			},
  * 			model: ( viewElement, modelWriter ) => {
  * 				return modelWriter.createElement( 'heading', { level: viewElement.getAttribute( 'data-level' ) } );
@@ -83,7 +83,7 @@ export function upcastElementToElement( config ) {
  *		upcastElementToAttribute( {
  *			view: {
  *				name: 'span',
- *				class: 'bold'
+ *				classes: 'bold'
  *			},
  *			model: 'bold'
  *		} );
@@ -91,7 +91,7 @@ export function upcastElementToElement( config ) {
  *		upcastElementToAttribute( {
  *			view: {
  *				name: 'span',
- *				class: [ 'styled', 'styled-dark' ]
+ *				classes: [ 'styled', 'styled-dark' ]
  *			},
  *			model: {
  *				key: 'styled',
@@ -102,7 +102,7 @@ export function upcastElementToElement( config ) {
  * 		upcastElementToAttribute( {
  *			view: {
  *				name: 'span',
- *				style: {
+ *				styles: {
  *					'font-size': /[\s\S]+/
  *				}
  *			},
@@ -250,7 +250,7 @@ export function upcastAttributeToAttribute( config ) {
  *		upcastElementToMarker( {
  *			view: {
  *				name: 'span',
- *				attribute: {
+ *				attributes: {
  *					'data-marker': 'search'
  *				}
  *			},
@@ -397,14 +397,16 @@ function _normalizeViewAttributeKeyValueConfig( config ) {
 	let normalized;
 
 	if ( key == 'class' || key == 'style' ) {
+		const keyName = key == 'class' ? 'classes' : 'styles';
+
 		normalized = {
-			[ key ]: config.view.value
+			[ keyName ]: config.view.value
 		};
 	} else {
 		const value = typeof config.view.value == 'undefined' ? /[\s\S]*/ : config.view.value;
 
 		normalized = {
-			attribute: {
+			attributes: {
 				[ key ]: value
 			}
 		};
@@ -498,7 +500,7 @@ function _onlyViewNameIsDefined( config ) {
 		return false;
 	}
 
-	return !config.view.class && !config.view.attribute && !config.view.style;
+	return !config.view.classes && !config.view.attributes && !config.view.styles;
 }
 
 // Helper function for to-model-attribute converter. Sets model attribute on given range. Checks {@link module:engine/model/schema~Schema}

--- a/src/conversion/viewconsumable.js
+++ b/src/conversion/viewconsumable.js
@@ -55,26 +55,26 @@ export default class ViewConsumable {
 	 * {@link module:engine/view/documentfragment~DocumentFragment document fragment} as ready to be consumed.
 	 *
 	 *		viewConsumable.add( p, { name: true } ); // Adds element's name to consume.
-	 *		viewConsumable.add( p, { attribute: 'name' } ); // Adds element's attribute.
-	 *		viewConsumable.add( p, { class: 'foobar' } ); // Adds element's class.
-	 *		viewConsumable.add( p, { style: 'color' } ); // Adds element's style
-	 *		viewConsumable.add( p, { attribute: 'name', style: 'color' } ); // Adds attribute and style.
-	 *		viewConsumable.add( p, { class: [ 'baz', 'bar' ] } ); // Multiple consumables can be provided.
+	 *		viewConsumable.add( p, { attributes: 'name' } ); // Adds element's attribute.
+	 *		viewConsumable.add( p, { classes: 'foobar' } ); // Adds element's class.
+	 *		viewConsumable.add( p, { styles: 'color' } ); // Adds element's style
+	 *		viewConsumable.add( p, { attributes: 'name', styles: 'color' } ); // Adds attribute and style.
+	 *		viewConsumable.add( p, { classes: [ 'baz', 'bar' ] } ); // Multiple consumables can be provided.
 	 *		viewConsumable.add( textNode ); // Adds text node to consume.
 	 *		viewConsumable.add( docFragment ); // Adds document fragment to consume.
 	 *
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `viewconsumable-invalid-attribute` when `class` or `style`
 	 * attribute is provided - it should be handled separately by providing actual style/class.
 	 *
-	 *		viewConsumable.add( p, { attribute: 'style' } ); // This call will throw an exception.
-	 *		viewConsumable.add( p, { style: 'color' } ); // This is properly handled style.
+	 *		viewConsumable.add( p, { attributes: 'style' } ); // This call will throw an exception.
+	 *		viewConsumable.add( p, { styles: 'color' } ); // This is properly handled style.
 	 *
 	 * @param {module:engine/view/element~Element|module:engine/view/text~Text|module:engine/view/documentfragment~DocumentFragment} element
 	 * @param {Object} [consumables] Used only if first parameter is {@link module:engine/view/element~Element view element} instance.
 	 * @param {Boolean} consumables.name If set to true element's name will be included.
-	 * @param {String|Array.<String>} consumables.attribute Attribute name or array of attribute names.
-	 * @param {String|Array.<String>} consumables.class Class name or array of class names.
-	 * @param {String|Array.<String>} consumables.style Style name or array of style names.
+	 * @param {String|Array.<String>} consumables.attributes Attribute name or array of attribute names.
+	 * @param {String|Array.<String>} consumables.classes Class name or array of class names.
+	 * @param {String|Array.<String>} consumables.styles Style name or array of style names.
 	 */
 	add( element, consumables ) {
 		let elementConsumables;
@@ -104,25 +104,25 @@ export default class ViewConsumable {
 	 * first already consumed item is found and `null` when first non-consumable item is found.
 	 *
 	 *		viewConsumable.test( p, { name: true } ); // Tests element's name.
-	 *		viewConsumable.test( p, { attribute: 'name' } ); // Tests attribute.
-	 *		viewConsumable.test( p, { class: 'foobar' } ); // Tests class.
-	 *		viewConsumable.test( p, { style: 'color' } ); // Tests style.
-	 *		viewConsumable.test( p, { attribute: 'name', style: 'color' } ); // Tests attribute and style.
-	 *		viewConsumable.test( p, { class: [ 'baz', 'bar' ] } ); // Multiple consumables can be tested.
+	 *		viewConsumable.test( p, { attributes: 'name' } ); // Tests attribute.
+	 *		viewConsumable.test( p, { classes: 'foobar' } ); // Tests class.
+	 *		viewConsumable.test( p, { styles: 'color' } ); // Tests style.
+	 *		viewConsumable.test( p, { attributes: 'name', styles: 'color' } ); // Tests attribute and style.
+	 *		viewConsumable.test( p, { classes: [ 'baz', 'bar' ] } ); // Multiple consumables can be tested.
 	 *		viewConsumable.test( textNode ); // Tests text node.
 	 *		viewConsumable.test( docFragment ); // Tests document fragment.
 	 *
 	 * Testing classes and styles as attribute will test if all added classes/styles can be consumed.
 	 *
-	 *		viewConsumable.test( p, { attribute: 'class' } ); // Tests if all added classes can be consumed.
-	 *		viewConsumable.test( p, { attribute: 'style' } ); // Tests if all added styles can be consumed.
+	 *		viewConsumable.test( p, { attributes: 'class' } ); // Tests if all added classes can be consumed.
+	 *		viewConsumable.test( p, { attributes: 'style' } ); // Tests if all added styles can be consumed.
 	 *
 	 * @param {module:engine/view/element~Element|module:engine/view/text~Text|module:engine/view/documentfragment~DocumentFragment} element
 	 * @param {Object} [consumables] Used only if first parameter is {@link module:engine/view/element~Element view element} instance.
 	 * @param {Boolean} consumables.name If set to true element's name will be included.
-	 * @param {String|Array.<String>} consumables.attribute Attribute name or array of attribute names.
-	 * @param {String|Array.<String>} consumables.class Class name or array of class names.
-	 * @param {String|Array.<String>} consumables.style Style name or array of style names.
+	 * @param {String|Array.<String>} consumables.attributes Attribute name or array of attribute names.
+	 * @param {String|Array.<String>} consumables.classes Class name or array of class names.
+	 * @param {String|Array.<String>} consumables.styles Style name or array of style names.
 	 * @returns {Boolean|null} Returns `true` when all items included in method's call can be consumed. Returns `false`
 	 * when first already consumed item is found and `null` when first non-consumable item is found.
 	 */
@@ -148,25 +148,25 @@ export default class ViewConsumable {
 	 * It returns `true` when all items included in method's call can be consumed, otherwise returns `false`.
 	 *
 	 *		viewConsumable.consume( p, { name: true } ); // Consumes element's name.
-	 *		viewConsumable.consume( p, { attribute: 'name' } ); // Consumes element's attribute.
-	 *		viewConsumable.consume( p, { class: 'foobar' } ); // Consumes element's class.
-	 *		viewConsumable.consume( p, { style: 'color' } ); // Consumes element's style.
-	 *		viewConsumable.consume( p, { attribute: 'name', style: 'color' } ); // Consumes attribute and style.
-	 *		viewConsumable.consume( p, { class: [ 'baz', 'bar' ] } ); // Multiple consumables can be consumed.
+	 *		viewConsumable.consume( p, { attributes: 'name' } ); // Consumes element's attribute.
+	 *		viewConsumable.consume( p, { classes: 'foobar' } ); // Consumes element's class.
+	 *		viewConsumable.consume( p, { styles: 'color' } ); // Consumes element's style.
+	 *		viewConsumable.consume( p, { attributes: 'name', styles: 'color' } ); // Consumes attribute and style.
+	 *		viewConsumable.consume( p, { classes: [ 'baz', 'bar' ] } ); // Multiple consumables can be consumed.
 	 *		viewConsumable.consume( textNode ); // Consumes text node.
 	 *		viewConsumable.consume( docFragment ); // Consumes document fragment.
 	 *
 	 * Consuming classes and styles as attribute will test if all added classes/styles can be consumed.
 	 *
-	 *		viewConsumable.consume( p, { attribute: 'class' } ); // Consume only if all added classes can be consumed.
-	 *		viewConsumable.consume( p, { attribute: 'style' } ); // Consume only if all added styles can be consumed.
+	 *		viewConsumable.consume( p, { attributes: 'class' } ); // Consume only if all added classes can be consumed.
+	 *		viewConsumable.consume( p, { attributes: 'style' } ); // Consume only if all added styles can be consumed.
 	 *
 	 * @param {module:engine/view/element~Element|module:engine/view/text~Text|module:engine/view/documentfragment~DocumentFragment} element
 	 * @param {Object} [consumables] Used only if first parameter is {@link module:engine/view/element~Element view element} instance.
 	 * @param {Boolean} consumables.name If set to true element's name will be included.
-	 * @param {String|Array.<String>} consumables.attribute Attribute name or array of attribute names.
-	 * @param {String|Array.<String>} consumables.class Class name or array of class names.
-	 * @param {String|Array.<String>} consumables.style Style name or array of style names.
+	 * @param {String|Array.<String>} consumables.attributes Attribute name or array of attribute names.
+	 * @param {String|Array.<String>} consumables.classes Class name or array of class names.
+	 * @param {String|Array.<String>} consumables.styles Style name or array of style names.
 	 * @returns {Boolean} Returns `true` when all items included in method's call can be consumed,
 	 * otherwise returns `false`.
 	 */
@@ -193,26 +193,26 @@ export default class ViewConsumable {
 	 * method's call.
 	 *
 	 *		viewConsumable.revert( p, { name: true } ); // Reverts element's name.
-	 *		viewConsumable.revert( p, { attribute: 'name' } ); // Reverts element's attribute.
-	 *		viewConsumable.revert( p, { class: 'foobar' } ); // Reverts element's class.
-	 *		viewConsumable.revert( p, { style: 'color' } ); // Reverts element's style.
-	 *		viewConsumable.revert( p, { attribute: 'name', style: 'color' } ); // Reverts attribute and style.
-	 *		viewConsumable.revert( p, { class: [ 'baz', 'bar' ] } ); // Multiple names can be reverted.
+	 *		viewConsumable.revert( p, { attributes: 'name' } ); // Reverts element's attribute.
+	 *		viewConsumable.revert( p, { classes: 'foobar' } ); // Reverts element's class.
+	 *		viewConsumable.revert( p, { styles: 'color' } ); // Reverts element's style.
+	 *		viewConsumable.revert( p, { attributes: 'name', styles: 'color' } ); // Reverts attribute and style.
+	 *		viewConsumable.revert( p, { classes: [ 'baz', 'bar' ] } ); // Multiple names can be reverted.
 	 *		viewConsumable.revert( textNode ); // Reverts text node.
 	 *		viewConsumable.revert( docFragment ); // Reverts document fragment.
 	 *
 	 * Reverting classes and styles as attribute will revert all classes/styles that were previously added for
 	 * consumption.
 	 *
-	 *		viewConsumable.revert( p, { attribute: 'class' } ); // Reverts all classes added for consumption.
-	 *		viewConsumable.revert( p, { attribute: 'style' } ); // Reverts all styles added for consumption.
+	 *		viewConsumable.revert( p, { attributes: 'class' } ); // Reverts all classes added for consumption.
+	 *		viewConsumable.revert( p, { attributes: 'style' } ); // Reverts all styles added for consumption.
 	 *
 	 * @param {module:engine/view/element~Element|module:engine/view/text~Text|module:engine/view/documentfragment~DocumentFragment} element
 	 * @param {Object} [consumables] Used only if first parameter is {@link module:engine/view/element~Element view element} instance.
 	 * @param {Boolean} consumables.name If set to true element's name will be included.
-	 * @param {String|Array.<String>} consumables.attribute Attribute name or array of attribute names.
-	 * @param {String|Array.<String>} consumables.class Class name or array of class names.
-	 * @param {String|Array.<String>} consumables.style Style name or array of style names.
+	 * @param {String|Array.<String>} consumables.attributes Attribute name or array of attribute names.
+	 * @param {String|Array.<String>} consumables.classes Class name or array of class names.
+	 * @param {String|Array.<String>} consumables.styles Style name or array of style names.
 	 */
 	revert( element, consumables ) {
 		const elementConsumables = this._consumables.get( element );
@@ -239,9 +239,9 @@ export default class ViewConsumable {
 	static consumablesFromElement( element ) {
 		const consumables = {
 			name: true,
-			attribute: [],
-			class: [],
-			style: []
+			attributes: [],
+			classes: [],
+			styles: []
 		};
 
 		const attributes = element.getAttributeKeys();
@@ -252,19 +252,19 @@ export default class ViewConsumable {
 				continue;
 			}
 
-			consumables.attribute.push( attribute );
+			consumables.attributes.push( attribute );
 		}
 
 		const classes = element.getClassNames();
 
 		for ( const className of classes ) {
-			consumables.class.push( className );
+			consumables.classes.push( className );
 		}
 
 		const styles = element.getStyleNames();
 
 		for ( const style of styles ) {
-			consumables.style.push( style );
+			consumables.styles.push( style );
 		}
 
 		return consumables;
@@ -335,9 +335,9 @@ class ViewElementConsumables {
 		 * @member {Object}
 		 */
 		this._consumables = {
-			attribute: new Map(),
-			style: new Map(),
-			class: new Map()
+			attributes: new Map(),
+			styles: new Map(),
+			classes: new Map()
 		};
 	}
 
@@ -350,17 +350,17 @@ class ViewElementConsumables {
 	 *
 	 * Attributes classes and styles:
 	 *
-	 *		consumables.add( { attribute: 'title', class: 'foo', style: 'color' } );
-	 *		consumables.add( { attribute: [ 'title', 'name' ], class: [ 'foo', 'bar' ] );
+	 *		consumables.add( { attributes: 'title', classes: 'foo', styles: 'color' } );
+	 *		consumables.add( { attributes: [ 'title', 'name' ], classes: [ 'foo', 'bar' ] );
 	 *
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `viewconsumable-invalid-attribute` when `class` or `style`
 	 * attribute is provided - it should be handled separately by providing `style` and `class` in consumables object.
 	 *
 	 * @param {Object} consumables Object describing which parts of the element can be consumed.
 	 * @param {Boolean} consumables.name If set to `true` element's name will be added as consumable.
-	 * @param {String|Array.<String>} consumables.attribute Attribute name or array of attribute names to add as consumable.
-	 * @param {String|Array.<String>} consumables.class Class name or array of class names to add as consumable.
-	 * @param {String|Array.<String>} consumables.style Style name or array of style names to add as consumable.
+	 * @param {String|Array.<String>} consumables.attributes Attribute name or array of attribute names to add as consumable.
+	 * @param {String|Array.<String>} consumables.classes Class name or array of class names to add as consumable.
+	 * @param {String|Array.<String>} consumables.styles Style name or array of style names to add as consumable.
 	 */
 	add( consumables ) {
 		if ( consumables.name ) {
@@ -383,14 +383,14 @@ class ViewElementConsumables {
 	 *
 	 * Attributes classes and styles:
 	 *
-	 *		consumables.test( { attribute: 'title', class: 'foo', style: 'color' } );
-	 *		consumables.test( { attribute: [ 'title', 'name' ], class: [ 'foo', 'bar' ] );
+	 *		consumables.test( { attributes: 'title', classes: 'foo', styles: 'color' } );
+	 *		consumables.test( { attributes: [ 'title', 'name' ], classes: [ 'foo', 'bar' ] );
 	 *
 	 * @param {Object} consumables Object describing which parts of the element should be tested.
 	 * @param {Boolean} consumables.name If set to `true` element's name will be tested.
-	 * @param {String|Array.<String>} consumables.attribute Attribute name or array of attribute names to test.
-	 * @param {String|Array.<String>} consumables.class Class name or array of class names to test.
-	 * @param {String|Array.<String>} consumables.style Style name or array of style names to test.
+	 * @param {String|Array.<String>} consumables.attributes Attribute name or array of attribute names to test.
+	 * @param {String|Array.<String>} consumables.classes Class name or array of class names to test.
+	 * @param {String|Array.<String>} consumables.styles Style name or array of style names to test.
 	 * @returns {Boolean|null} `true` when all tested items can be consumed, `null` when even one of the items
 	 * was never marked for consumption and `false` when even one of the items was already consumed.
 	 */
@@ -423,14 +423,14 @@ class ViewElementConsumables {
 	 *
 	 * Attributes classes and styles:
 	 *
-	 *		consumables.consume( { attribute: 'title', class: 'foo', style: 'color' } );
-	 *		consumables.consume( { attribute: [ 'title', 'name' ], class: [ 'foo', 'bar' ] );
+	 *		consumables.consume( { attributes: 'title', classes: 'foo', styles: 'color' } );
+	 *		consumables.consume( { attributes: [ 'title', 'name' ], classes: [ 'foo', 'bar' ] );
 	 *
 	 * @param {Object} consumables Object describing which parts of the element should be consumed.
 	 * @param {Boolean} consumables.name If set to `true` element's name will be consumed.
-	 * @param {String|Array.<String>} consumables.attribute Attribute name or array of attribute names to consume.
-	 * @param {String|Array.<String>} consumables.class Class name or array of class names to consume.
-	 * @param {String|Array.<String>} consumables.style Style name or array of style names to consume.
+	 * @param {String|Array.<String>} consumables.attributes Attribute name or array of attribute names to consume.
+	 * @param {String|Array.<String>} consumables.classes Class name or array of class names to consume.
+	 * @param {String|Array.<String>} consumables.styles Style name or array of style names to consume.
 	 */
 	consume( consumables ) {
 		if ( consumables.name ) {
@@ -452,14 +452,14 @@ class ViewElementConsumables {
 	 *
 	 * Attributes classes and styles:
 	 *
-	 *		consumables.revert( { attribute: 'title', class: 'foo', style: 'color' } );
-	 *		consumables.revert( { attribute: [ 'title', 'name' ], class: [ 'foo', 'bar' ] );
+	 *		consumables.revert( { attributes: 'title', classes: 'foo', styles: 'color' } );
+	 *		consumables.revert( { attributes: [ 'title', 'name' ], classes: [ 'foo', 'bar' ] );
 	 *
 	 * @param {Object} consumables Object describing which parts of the element should be reverted.
 	 * @param {Boolean} consumables.name If set to `true` element's name will be reverted.
-	 * @param {String|Array.<String>} consumables.attribute Attribute name or array of attribute names to revert.
-	 * @param {String|Array.<String>} consumables.class Class name or array of class names to revert.
-	 * @param {String|Array.<String>} consumables.style Style name or array of style names to revert.
+	 * @param {String|Array.<String>} consumables.attributes Attribute name or array of attribute names to revert.
+	 * @param {String|Array.<String>} consumables.classes Class name or array of class names to revert.
+	 * @param {String|Array.<String>} consumables.styles Style name or array of style names to revert.
 	 */
 	revert( consumables ) {
 		if ( consumables.name ) {
@@ -480,7 +480,7 @@ class ViewElementConsumables {
 	 * type is provided - it should be handled separately by providing actual style/class type.
 	 *
 	 * @private
-	 * @param {String} type Type of the consumable item: `attribute`, `class` or `style`.
+	 * @param {String} type Type of the consumable item: `attributes`, `classes` or `styles`.
 	 * @param {String|Array.<String>} item Consumable item or array of items.
 	 */
 	_add( type, item ) {
@@ -488,22 +488,22 @@ class ViewElementConsumables {
 		const consumables = this._consumables[ type ];
 
 		for ( const name of items ) {
-			if ( type === 'attribute' && ( name === 'class' || name === 'style' ) ) {
+			if ( type === 'attributes' && ( name === 'class' || name === 'style' ) ) {
 				/**
 				 * Class and style attributes should be handled separately in
 				 * {@link module:engine/conversion/viewconsumable~ViewConsumable#add `ViewConsumable#add()`}.
 				 *
 				 * What you have done is trying to use:
 				 *
-				 *		consumables.add( { attribute: [ 'class', 'style' ] } );
+				 *		consumables.add( { attributes: [ 'class', 'style' ] } );
 				 *
 				 * While each class and style should be registered separately:
 				 *
-				 *		consumables.add( { class: 'some-class', style: 'font-weight' } );
+				 *		consumables.add( { classes: 'some-class', styles: 'font-weight' } );
 				 *
 				 * @error viewconsumable-invalid-attribute
 				 */
-				throw new CKEditorError( 'viewconsumable-invalid-attribute: Classes and styles should be handled separately.' );
+				throw new CKEditorError( 'viewconsumable-invalid-attributes: Classes and styles should be handled separately.' );
 			}
 
 			consumables.set( name, true );
@@ -514,7 +514,7 @@ class ViewElementConsumables {
 	 * Helper method that tests consumables of a given type: attribute, class or style.
 	 *
 	 * @private
-	 * @param {String} type Type of the consumable item: `attribute`, `class` or `style`.
+	 * @param {String} type Type of the consumable item: `attributes`, `classes` or `styles`.
 	 * @param {String|Array.<String>} item Consumable item or array of items.
 	 * @returns {Boolean|null} Returns `true` if all items can be consumed, `null` when one of the items cannot be
 	 * consumed and `false` when one of the items is already consumed.
@@ -524,9 +524,11 @@ class ViewElementConsumables {
 		const consumables = this._consumables[ type ];
 
 		for ( const name of items ) {
-			if ( type === 'attribute' && ( name === 'class' || name === 'style' ) ) {
+			if ( type === 'attributes' && ( name === 'class' || name === 'style' ) ) {
+				const consumableName = name == 'class' ? 'classes' : 'styles';
+
 				// Check all classes/styles if class/style attribute is tested.
-				const value = this._test( name, [ ...this._consumables[ name ].keys() ] );
+				const value = this._test( consumableName, [ ...this._consumables[ consumableName ].keys() ] );
 
 				if ( value !== true ) {
 					return value;
@@ -551,7 +553,7 @@ class ViewElementConsumables {
 	 * Helper method that consumes items of a given type: attribute, class or style.
 	 *
 	 * @private
-	 * @param {String} type Type of the consumable item: `attribute`, `class` or `style`.
+	 * @param {String} type Type of the consumable item: `attributes`, `classes` or `styles`.
 	 * @param {String|Array.<String>} item Consumable item or array of items.
 	 */
 	_consume( type, item ) {
@@ -559,9 +561,11 @@ class ViewElementConsumables {
 		const consumables = this._consumables[ type ];
 
 		for ( const name of items ) {
-			if ( type === 'attribute' && ( name === 'class' || name === 'style' ) ) {
+			if ( type === 'attributes' && ( name === 'class' || name === 'style' ) ) {
+				const consumableName = name == 'class' ? 'classes' : 'styles';
+
 				// If class or style is provided for consumption - consume them all.
-				this._consume( name, [ ...this._consumables[ name ].keys() ] );
+				this._consume( consumableName, [ ...this._consumables[ consumableName ].keys() ] );
 			} else {
 				consumables.set( name, false );
 			}
@@ -572,7 +576,7 @@ class ViewElementConsumables {
 	 * Helper method that reverts items of a given type: attribute, class or style.
 	 *
 	 * @private
-	 * @param {String} type Type of the consumable item: `attribute`, `class` or , `style`.
+	 * @param {String} type Type of the consumable item: `attributes`, `classes` or , `styles`.
 	 * @param {String|Array.<String>} item Consumable item or array of items.
 	 */
 	_revert( type, item ) {
@@ -580,9 +584,11 @@ class ViewElementConsumables {
 		const consumables = this._consumables[ type ];
 
 		for ( const name of items ) {
-			if ( type === 'attribute' && ( name === 'class' || name === 'style' ) ) {
+			if ( type === 'attributes' && ( name === 'class' || name === 'style' ) ) {
+				const consumableName = name == 'class' ? 'classes' : 'styles';
+
 				// If class or style is provided for reverting - revert them all.
-				this._revert( name, [ ...this._consumables[ name ].keys() ] );
+				this._revert( consumableName, [ ...this._consumables[ consumableName ].keys() ] );
 			} else {
 				const value = consumables.get( name );
 

--- a/src/conversion/viewconsumable.js
+++ b/src/conversion/viewconsumable.js
@@ -503,7 +503,7 @@ class ViewElementConsumables {
 				 *
 				 * @error viewconsumable-invalid-attribute
 				 */
-				throw new CKEditorError( 'viewconsumable-invalid-attributes: Classes and styles should be handled separately.' );
+				throw new CKEditorError( 'viewconsumable-invalid-attribute: Classes and styles should be handled separately.' );
 			}
 
 			consumables.set( name, true );

--- a/src/dev-utils/view.js
+++ b/src/dev-utils/view.js
@@ -337,7 +337,7 @@ export function parse( data, options = {} ) {
 		const nodes = view._removeChildren( 0, view.childCount );
 
 		root._removeChildren( 0, root.childCount );
-		root._appendChildren( nodes );
+		root._appendChild( nodes );
 
 		view = root;
 	}
@@ -924,7 +924,7 @@ function _convertViewElements( rootNode ) {
 				throw new Error( 'Parse error - cannot parse inside UIElement.' );
 			}
 
-			convertedElement._appendChildren( _convertViewElements( child ) );
+			convertedElement._appendChild( _convertViewElements( child ) );
 		}
 
 		return convertedElement;

--- a/src/model/documentfragment.js
+++ b/src/model/documentfragment.js
@@ -52,7 +52,7 @@ export default class DocumentFragment {
 		this._children = new NodeList();
 
 		if ( children ) {
-			this._insertChildren( 0, children );
+			this._insertChild( 0, children );
 		}
 	}
 
@@ -261,13 +261,13 @@ export default class DocumentFragment {
 	}
 
 	/**
-	 * {@link #_insertChildren Inserts} one or more nodes at the end of this document fragment.
+	 * {@link #_insertChild Inserts} one or more nodes at the end of this document fragment.
 	 *
 	 * @protected
 	 * @param {module:engine/model/item~Item|Iterable.<module:engine/model/item~Item>} items Items to be inserted.
 	 */
-	_appendChildren( items ) {
-		this._insertChildren( this.childCount, items );
+	_appendChild( items ) {
+		this._insertChild( this.childCount, items );
 	}
 
 	/**
@@ -278,7 +278,7 @@ export default class DocumentFragment {
 	 * @param {Number} index Index at which nodes should be inserted.
 	 * @param {module:engine/model/item~Item|Iterable.<module:engine/model/item~Item>} items Items to be inserted.
 	 */
-	_insertChildren( index, items ) {
+	_insertChild( index, items ) {
 		const nodes = normalize( items );
 
 		for ( const node of nodes ) {

--- a/src/model/element.js
+++ b/src/model/element.js
@@ -54,7 +54,7 @@ export default class Element extends Node {
 		this._children = new NodeList();
 
 		if ( children ) {
-			this._insertChildren( 0, children );
+			this._insertChild( 0, children );
 		}
 	}
 
@@ -234,14 +234,14 @@ export default class Element extends Node {
 	}
 
 	/**
-	 * {@link module:engine/model/element~Element#_insertChildren Inserts} one or more nodes at the end of this element.
+	 * {@link module:engine/model/element~Element#_insertChild Inserts} one or more nodes at the end of this element.
 	 *
 	 * @see module:engine/model/writer~Writer#append
 	 * @protected
 	 * @param {module:engine/model/item~Item|Iterable.<module:engine/model/item~Item>} nodes Nodes to be inserted.
 	 */
-	_appendChildren( nodes ) {
-		this._insertChildren( this.childCount, nodes );
+	_appendChild( nodes ) {
+		this._insertChild( this.childCount, nodes );
 	}
 
 	/**
@@ -253,7 +253,7 @@ export default class Element extends Node {
 	 * @param {Number} index Index at which nodes should be inserted.
 	 * @param {module:engine/model/item~Item|Iterable.<module:engine/model/item~Item>} items Items to be inserted.
 	 */
-	_insertChildren( index, items ) {
+	_insertChild( index, items ) {
 		const nodes = normalize( items );
 
 		for ( const node of nodes ) {

--- a/src/model/node.js
+++ b/src/model/node.js
@@ -20,7 +20,7 @@ import compareArrays from '@ckeditor/ckeditor5-utils/src/comparearrays';
  * However, it is **very important** that nodes already attached to model tree should be only changed through
  * {@link module:engine/model/writer~Writer Writer API}.
  *
- * Changes done by `Node` methods, like {@link module:engine/model/element~Element#_insertChildren _insertChildren} or
+ * Changes done by `Node` methods, like {@link module:engine/model/element~Element#_insertChild _insertChild} or
  * {@link module:engine/model/node~Node#_setAttribute _setAttribute}
  * do not generate {@link module:engine/model/operation/operation~Operation operations}
  * which are essential for correct editor work if you modify nodes in {@link module:engine/model/document~Document document} root.

--- a/src/model/operation/utils.js
+++ b/src/model/operation/utils.js
@@ -45,7 +45,7 @@ export function _insert( position, nodes ) {
 
 	// Insert nodes at given index. After splitting we have a proper index and insertion is between nodes,
 	// using basic `Element` API.
-	parent._insertChildren( index, nodes );
+	parent._insertChild( index, nodes );
 
 	// Merge text nodes, if possible. Merging is needed only at points where inserted nodes "touch" "old" nodes.
 	_mergeNodesAtIndex( parent, index + nodes.length );
@@ -224,7 +224,7 @@ function _mergeNodesAtIndex( element, index ) {
 		element._removeChildren( index - 1, 2 );
 
 		// Insert merged text node.
-		element._insertChildren( index - 1, mergedNode );
+		element._insertChild( index - 1, mergedNode );
 	}
 }
 
@@ -249,7 +249,7 @@ function _splitNodeAtPosition( position ) {
 		const firstPart = new Text( textNode.data.substr( 0, offsetDiff ), textNode.getAttributes() );
 		const secondPart = new Text( textNode.data.substr( offsetDiff ), textNode.getAttributes() );
 
-		element._insertChildren( index, [ firstPart, secondPart ] );
+		element._insertChild( index, [ firstPart, secondPart ] );
 	}
 }
 

--- a/src/model/utils/insertcontent.js
+++ b/src/model/utils/insertcontent.js
@@ -382,7 +382,7 @@ class Insertion {
 		// cause that would lead to an infinite loop. The paragraph would be rejected in
 		// the next _handleNode() call and we'd be here again.
 		if ( this._getAllowedIn( paragraph, this.position.parent ) && this.schema.checkChild( paragraph, node ) ) {
-			paragraph._appendChildren( node );
+			paragraph._appendChild( node );
 			this._handleNode( paragraph, context );
 		}
 	}

--- a/src/view/documentfragment.js
+++ b/src/view/documentfragment.js
@@ -34,7 +34,7 @@ export default class DocumentFragment {
 		this._children = [];
 
 		if ( children ) {
-			this._insertChildren( 0, children );
+			this._insertChild( 0, children );
 		}
 	}
 
@@ -102,14 +102,14 @@ export default class DocumentFragment {
 	}
 
 	/**
-	 * {@link module:engine/view/documentfragment~DocumentFragment#_insertChildren Insert} a child node or a list of child nodes at the end
+	 * {@link module:engine/view/documentfragment~DocumentFragment#_insertChild Insert} a child node or a list of child nodes at the end
 	 * and sets the parent of these nodes to this fragment.
 	 *
 	 * @param {module:engine/view/item~Item|Iterable.<module:engine/view/item~Item>} items Items to be inserted.
 	 * @returns {Number} Number of appended nodes.
 	 */
-	_appendChildren( items ) {
-		return this._insertChildren( this.childCount, items );
+	_appendChild( items ) {
+		return this._insertChild( this.childCount, items );
 	}
 
 	/**
@@ -149,7 +149,7 @@ export default class DocumentFragment {
 	 * @param {module:engine/view/item~Item|Iterable.<module:engine/view/item~Item>} items Items to be inserted.
 	 * @returns {Number} Number of inserted nodes.
 	 */
-	_insertChildren( index, items ) {
+	_insertChild( index, items ) {
 		this._fireChange( 'children', this );
 		let count = 0;
 

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -421,7 +421,7 @@ export default class DomConverter {
 
 			if ( options.withChildren || options.withChildren === undefined ) {
 				for ( const child of this.domChildrenToView( domNode, options ) ) {
-					viewElement._appendChildren( child );
+					viewElement._appendChild( child );
 				}
 			}
 

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -79,7 +79,7 @@ export default class Element extends Node {
 		this._children = [];
 
 		if ( children ) {
-			this._insertChildren( 0, children );
+			this._insertChild( 0, children );
 		}
 
 		/**
@@ -513,7 +513,7 @@ export default class Element extends Node {
 	}
 
 	/**
-	 * {@link module:engine/view/element~Element#_insertChildren Insert} a child node or a list of child nodes at the end of this node
+	 * {@link module:engine/view/element~Element#_insertChild Insert} a child node or a list of child nodes at the end of this node
 	 * and sets the parent of these nodes to this element.
 	 *
 	 * @see module:engine/view/writer~Writer#insert
@@ -522,8 +522,8 @@ export default class Element extends Node {
 	 * @fires module:engine/view/node~Node#change
 	 * @returns {Number} Number of appended nodes.
 	 */
-	_appendChildren( items ) {
-		return this._insertChildren( this.childCount, items );
+	_appendChild( items ) {
+		return this._insertChild( this.childCount, items );
 	}
 
 	/**
@@ -537,7 +537,7 @@ export default class Element extends Node {
 	 * @fires module:engine/view/node~Node#change
 	 * @returns {Number} Number of inserted nodes.
 	 */
-	_insertChildren( index, items ) {
+	_insertChild( index, items ) {
 		this._fireChange( 'children', this );
 		let count = 0;
 

--- a/src/view/elementdefinition.jsdoc
+++ b/src/view/elementdefinition.jsdoc
@@ -12,7 +12,7 @@
  *
  *		const viewDefinition = {
  *			name: 'h1',
- *			class: [ 'foo', 'bar' ]
+ *			classes: [ 'foo', 'bar' ]
  *		};
  *
  * Above describes a view element:
@@ -23,11 +23,11 @@
  *
  *      const viewDefinition = {
  *          name: 'span',
- *          style: {
+ *          styles: {
  *              'font-size': '12px',
  *              'font-weight': 'bold'
  *          },
- *          attribute: {
+ *          attributes: {
  *              'data-id': '123'
  *          }
  *      };
@@ -49,10 +49,10 @@
  * @typedef {String|Object} module:engine/view/elementdefinition~ElementDefinition
  *
  * @property {String} name View element name.
- * @property {String|Array.<String>} [class] Class name or array of class names to match. Each name can be
+ * @property {String|Array.<String>} [classes] Class name or array of class names to match. Each name can be
  * provided in a form of string.
- * @property {Object} [style] Object with key-value pairs representing styles. Each object key represents style name.
+ * @property {Object} [styles] Object with key-value pairs representing styles. Each object key represents style name.
  * Value under that key must be a string.
- * @property {Object} [attribute] Object with key-value pairs representing attributes. Each object key represents
+ * @property {Object} [attributes] Object with key-value pairs representing attributes. Each object key represents
  * attribute name. Value under that key must be a string.
  */

--- a/src/view/emptyelement.js
+++ b/src/view/emptyelement.js
@@ -50,13 +50,13 @@ export default class EmptyElement extends Element {
 	}
 
 	/**
-	 * Overrides {@link module:engine/view/element~Element#_insertChildren} method.
+	 * Overrides {@link module:engine/view/element~Element#_insertChild} method.
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `view-emptyelement-cannot-add` to prevent
 	 * adding any child nodes to EmptyElement.
 	 *
 	 * @protected
 	 */
-	_insertChildren( index, nodes ) {
+	_insertChild( index, nodes ) {
 		if ( nodes && ( nodes instanceof Node || Array.from( nodes ).length > 0 ) ) {
 			/**
 			 * Cannot add children to {@link module:engine/view/emptyelement~EmptyElement}.

--- a/src/view/matcher.js
+++ b/src/view/matcher.js
@@ -39,14 +39,14 @@ export default class Matcher {
 	 *
 	 *		// Single class.
 	 *		matcher.add( {
-	 *			class: 'foobar'
+	 *			classes: 'foobar'
 	 *		} );
 	 *
 	 * See {@link module:engine/view/matcher~MatcherPattern} for more examples.
 	 *
 	 * Multiple patterns can be added in one call:
 	 *
-	 * 		matcher.add( 'div', { class: 'foobar' } );
+	 * 		matcher.add( 'div', { classes: 'foobar' } );
 	 *
 	 * @param {Object|String|RegExp|Function} pattern Object describing pattern details. If string or regular expression
 	 * is provided it will be used to match element's name. Pattern can be also provided in a form
@@ -54,14 +54,14 @@ export default class Matcher {
 	 * Function's return value will be stored under `match` key of the object returned from
 	 * {@link module:engine/view/matcher~Matcher#match match} or {@link module:engine/view/matcher~Matcher#matchAll matchAll} methods.
 	 * @param {String|RegExp} [pattern.name] Name or regular expression to match element's name.
-	 * @param {Object} [pattern.attribute] Object with key-value pairs representing attributes to match. Each object key
+	 * @param {Object} [pattern.attributes] Object with key-value pairs representing attributes to match. Each object key
 	 * represents attribute name. Value under that key can be either:
 	 * * `true` - then attribute is just required (can be empty),
 	 * * a string - then attribute has to be equal, or
 	 * * a regular expression - then attribute has to match the expression.
-	 * @param {String|RegExp|Array} [pattern.class] Class name or array of class names to match. Each name can be
+	 * @param {String|RegExp|Array} [pattern.classes] Class name or array of class names to match. Each name can be
 	 * provided in a form of string or regular expression.
-	 * @param {Object} [pattern.style] Object with key-value pairs representing styles to match. Each object key
+	 * @param {Object} [pattern.styles] Object with key-value pairs representing styles to match. Each object key
 	 * represents style name. Value under that key can be either a string or a regular expression and it will be used
 	 * to match style value.
 	 */
@@ -73,8 +73,8 @@ export default class Matcher {
 			}
 
 			// Single class name/RegExp can be provided.
-			if ( item.class && ( typeof item.class == 'string' || item.class instanceof RegExp ) ) {
-				item.class = [ item.class ];
+			if ( item.classes && ( typeof item.classes == 'string' || item.classes instanceof RegExp ) ) {
+				item.classes = [ item.classes ];
 			}
 
 			this._patterns.push( item );
@@ -92,9 +92,9 @@ export default class Matcher {
 	 *			pattern: <pattern used to match found element>,
 	 *			match: {
 	 *				name: true,
-	 *				attribute: [ 'title', 'href' ],
-	 *				class: [ 'foo' ],
-	 *				style: [ 'color', 'position' ]
+	 *				attributes: [ 'title', 'href' ],
+	 *				classes: [ 'foo' ],
+	 *				styles: [ 'color', 'position' ]
 	 *			}
 	 *		}
 	 *
@@ -106,9 +106,9 @@ export default class Matcher {
 	 * @returns {Object|String|RegExp|Function} result.pattern Pattern that was used to find matched element.
 	 * @returns {Object} result.match Object representing matched element parts.
 	 * @returns {Boolean} [result.match.name] True if name of the element was matched.
-	 * @returns {Array} [result.match.attribute] Array with matched attribute names.
-	 * @returns {Array} [result.match.class] Array with matched class names.
-	 * @returns {Array} [result.match.style] Array with matched style names.
+	 * @returns {Array} [result.match.attributes] Array with matched attribute names.
+	 * @returns {Array} [result.match.classes] Array with matched class names.
+	 * @returns {Array} [result.match.styles] Array with matched style names.
 	 */
 	match( ...element ) {
 		for ( const singleElement of element ) {
@@ -199,28 +199,28 @@ function isElementMatching( element, pattern ) {
 	}
 
 	// Check element's attributes.
-	if ( pattern.attribute ) {
-		match.attribute = matchAttributes( pattern.attribute, element );
+	if ( pattern.attributes ) {
+		match.attributes = matchAttributes( pattern.attributes, element );
 
-		if ( !match.attribute ) {
+		if ( !match.attributes ) {
 			return null;
 		}
 	}
 
 	// Check element's classes.
-	if ( pattern.class ) {
-		match.class = matchClasses( pattern.class, element );
+	if ( pattern.classes ) {
+		match.classes = matchClasses( pattern.classes, element );
 
-		if ( !match.class ) {
+		if ( !match.classes ) {
 			return false;
 		}
 	}
 
 	// Check element's styles.
-	if ( pattern.style ) {
-		match.style = matchStyles( pattern.style, element );
+	if ( pattern.styles ) {
+		match.styles = matchStyles( pattern.styles, element );
 
-		if ( !match.style ) {
+		if ( !match.styles ) {
 			return false;
 		}
 	}
@@ -373,22 +373,22 @@ function matchStyles( patterns, element ) {
  *
  *		// Match view element which has given class.
  *		const pattern = {
- *			class: 'foobar'
+ *			classes: 'foobar'
  *		};
  *
  *		// Match view element class using regular expression.
  *		const pattern = {
- *			class: /foo.../
+ *			classes: /foo.../
  *		};
  *
  *		// Multiple classes to match.
  *		const pattern = {
- *			class: [ 'baz', 'bar', /foo.../ ]
+ *			classes: [ 'baz', 'bar', /foo.../ ]
  *		}:
  *
  *		// Match view element which has given styles.
  *		const pattern = {
- *			style: {
+ *			styles: {
  *				position: 'absolute',
  *				color: /^\w*blue$/
  *			}
@@ -397,10 +397,10 @@ function matchStyles( patterns, element ) {
  *		// Pattern with multiple properties.
  *		const pattern = {
  *			name: 'span',
- *			style: {
+ *			styles: {
  *				'font-weight': 'bold'
  *			},
- *			class: 'highlighted'
+ *			classes: 'highlighted'
  *		};
  *
  * If `MatcherPattern` is given as a `Function`, the function takes a view element as a first and only parameter and
@@ -438,9 +438,9 @@ function matchStyles( patterns, element ) {
  * @typedef {String|RegExp|Object|Function} module:engine/view/matcher~MatcherPattern
  *
  * @property {String|RegExp} [name] View element name to match.
- * @property {String|RegExp|Array.<String|RegExp>} [class] View element's class name(s) to match.
- * @property {Object} [style] Object with key-value pairs representing styles to match.
+ * @property {String|RegExp|Array.<String|RegExp>} [classes] View element's class name(s) to match.
+ * @property {Object} [styles] Object with key-value pairs representing styles to match.
  * Each object key represents style name. Value can be given as `String` or `RegExp`.
- * @property {Object} [attribute] Object with key-value pairs representing attributes to match.
+ * @property {Object} [attributes] Object with key-value pairs representing attributes to match.
  * Each object key represents attribute name. Value can be given as `String` or `RegExp`.
  */

--- a/src/view/node.js
+++ b/src/view/node.js
@@ -26,7 +26,7 @@ export default class Node {
 	 */
 	constructor() {
 		/**
-		 * Parent element. Null by default. Set by {@link module:engine/view/element~Element#_insertChildren}.
+		 * Parent element. Null by default. Set by {@link module:engine/view/element~Element#_insertChild}.
 		 *
 		 * @readonly
 		 * @member {module:engine/view/element~Element|module:engine/view/documentfragment~DocumentFragment|null}

--- a/src/view/uielement.js
+++ b/src/view/uielement.js
@@ -52,11 +52,11 @@ export default class UIElement extends Element {
 	}
 
 	/**
-	 * Overrides {@link module:engine/view/element~Element#_insertChildren} method.
+	 * Overrides {@link module:engine/view/element~Element#_insertChild} method.
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `view-uielement-cannot-add` to prevent adding any child nodes
 	 * to UIElement.
 	 */
-	_insertChildren( index, nodes ) {
+	_insertChild( index, nodes ) {
 		if ( nodes && ( nodes instanceof Node || Array.from( nodes ).length > 0 ) ) {
 			/**
 			 * Cannot add children to {@link module:engine/view/uielement~UIElement}.

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -537,7 +537,7 @@ export default class Writer {
 		else if ( nodeBefore.is( 'attributeElement' ) && nodeAfter.is( 'attributeElement' ) && nodeBefore.isSimilar( nodeAfter ) ) {
 			// Move all children nodes from node placed after selection and remove that node.
 			const count = nodeBefore.childCount;
-			nodeBefore._appendChildren( nodeAfter.getChildren() );
+			nodeBefore._appendChild( nodeAfter.getChildren() );
 
 			nodeAfter._remove();
 			this._removeFromClonedElementsGroup( nodeAfter );
@@ -628,7 +628,7 @@ export default class Writer {
 		}
 
 		const insertionPosition = this._breakAttributes( position, true );
-		const length = container._insertChildren( insertionPosition.offset, nodes );
+		const length = container._insertChild( insertionPosition.offset, nodes );
 
 		for ( const node of nodes ) {
 			this._addToClonedElementsGroup( node );
@@ -955,8 +955,8 @@ export default class Writer {
 
 				// Wrap current node with new attribute.
 				child._remove();
-				newAttribute._appendChildren( child );
-				parent._insertChildren( i, newAttribute );
+				newAttribute._appendChild( child );
+				parent._insertChild( i, newAttribute );
 
 				wrapPositions.push(	new Position( parent, i ) );
 			}
@@ -1018,7 +1018,7 @@ export default class Writer {
 				child._remove();
 				this._removeFromClonedElementsGroup( child );
 
-				parent._insertChildren( i, unwrapped );
+				parent._insertChild( i, unwrapped );
 
 				// Save start and end position of moved items.
 				unwrapPositions.push(
@@ -1155,7 +1155,7 @@ export default class Writer {
 		fakePosition.isSimilar = () => false;
 
 		// Insert fake element in position location.
-		position.parent._insertChildren( position.offset, fakePosition );
+		position.parent._insertChild( position.offset, fakePosition );
 
 		// Range around inserted fake attribute element.
 		const wrapRange = new Range( position, position.getShiftedBy( 1 ) );
@@ -1428,14 +1428,14 @@ export default class Writer {
 			this._addToClonedElementsGroup( clonedNode );
 
 			// Insert cloned node to position's parent node.
-			positionParent.parent._insertChildren( offsetAfter, clonedNode );
+			positionParent.parent._insertChild( offsetAfter, clonedNode );
 
 			// Get nodes to move.
 			const count = positionParent.childCount - positionOffset;
 			const nodesToMove = positionParent._removeChildren( positionOffset, count );
 
 			// Move nodes to cloned node.
-			clonedNode._appendChildren( nodesToMove );
+			clonedNode._appendChild( nodesToMove );
 
 			// Create new position to work on.
 			const newPosition = new Position( positionParent.parent, offsetAfter );
@@ -1605,7 +1605,7 @@ function breakTextNode( position ) {
 	position.parent._data = position.parent.data.slice( 0, position.offset );
 
 	// Insert new text node after position's parent text node.
-	position.parent.parent._insertChildren( position.parent.index + 1, new Text( textToMove ) );
+	position.parent.parent._insertChild( position.parent.index + 1, new Text( textToMove ) );
 
 	// Return new position between two newly created text nodes.
 	return new Position( position.parent.parent, position.parent.index + 1 );

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -402,7 +402,7 @@ describe( 'DataController', () => {
 			const modelElement = parseModel( '<div><paragraph>foobar</paragraph></div>', schema );
 			const modelRoot = model.document.getRoot();
 
-			downcastMarkerToHighlight( { model: 'marker:a', view: { class: 'a' } } )( data.downcastDispatcher );
+			downcastMarkerToHighlight( { model: 'marker:a', view: { classes: 'a' } } )( data.downcastDispatcher );
 
 			model.change( writer => {
 				writer.insert( modelElement, modelRoot, 0 );
@@ -419,8 +419,8 @@ describe( 'DataController', () => {
 			const modelElement = parseModel( '<div><paragraph>foo</paragraph><paragraph>bar</paragraph></div>', schema );
 			const modelRoot = model.document.getRoot();
 
-			downcastMarkerToHighlight( { model: 'marker:a', view: { class: 'a' } } )( data.downcastDispatcher );
-			downcastMarkerToHighlight( { model: 'marker:b', view: { class: 'b' } } )( data.downcastDispatcher );
+			downcastMarkerToHighlight( { model: 'marker:a', view: { classes: 'a' } } )( data.downcastDispatcher );
+			downcastMarkerToHighlight( { model: 'marker:b', view: { classes: 'b' } } )( data.downcastDispatcher );
 
 			const modelP1 = modelElement.getChild( 0 );
 			const modelP2 = modelElement.getChild( 1 );

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -142,7 +142,7 @@ describe( 'Conversion', () => {
 					model: 'fancyParagraph',
 					view: {
 						name: 'p',
-						class: 'fancy'
+						classes: 'fancy'
 					}
 				} );
 
@@ -157,7 +157,7 @@ describe( 'Conversion', () => {
 						'div',
 						{
 							// Any element with `display: block` style.
-							style: {
+							styles: {
 								display: 'block'
 							}
 						}
@@ -237,7 +237,7 @@ describe( 'Conversion', () => {
 					model: 'bold',
 					view: {
 						name: 'span',
-						class: 'bold'
+						classes: 'bold'
 					}
 				} );
 
@@ -252,11 +252,11 @@ describe( 'Conversion', () => {
 						'b',
 						{
 							name: 'span',
-							class: 'bold'
+							classes: 'bold'
 						},
 						{
 							name: 'span',
-							style: {
+							styles: {
 								'font-weight': 'bold'
 							}
 						},
@@ -266,7 +266,7 @@ describe( 'Conversion', () => {
 							if ( viewElement.is( 'span' ) && fontWeight && /\d+/.test( fontWeight ) && Number( fontWeight ) > 500 ) {
 								return {
 									name: true,
-									style: [ 'font-weight' ]
+									styles: [ 'font-weight' ]
 								};
 							}
 						}
@@ -322,13 +322,13 @@ describe( 'Conversion', () => {
 					view: {
 						big: {
 							name: 'span',
-							style: {
+							styles: {
 								'font-size': '1.2em'
 							}
 						},
 						small: {
 							name: 'span',
-							style: {
+							styles: {
 								'font-size': '0.8em'
 							}
 						}
@@ -422,13 +422,13 @@ describe( 'Conversion', () => {
 					view: {
 						underline: {
 							name: 'span',
-							style: {
+							styles: {
 								'text-decoration': 'underline'
 							}
 						},
 						lineThrough: {
 							name: 'span',
-							style: {
+							styles: {
 								'text-decoration': 'line-through'
 							}
 						}
@@ -551,12 +551,12 @@ describe( 'Conversion', () => {
 					},
 					upcastAlso: {
 						right: {
-							style: {
+							styles: {
 								'text-align': 'right'
 							}
 						},
 						center: {
-							style: {
+							styles: {
 								'text-align': 'center'
 							}
 						}

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -742,7 +742,7 @@ describe( 'downcast-converters', () => {
 			const modelElement = new ModelElement( 'paragraph', { classes: 'foo' }, new ModelText( 'foobar' ) );
 
 			dispatcher.on( 'attribute:class', ( evt, data, conversionApi ) => {
-				conversionApi.consumable.consume( data.item, 'attributes:class' );
+				conversionApi.consumable.consume( data.item, 'attribute:class' );
 			}, { priority: 'high' } );
 
 			model.change( writer => {

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -77,7 +77,7 @@ describe( 'downcast-helpers', () => {
 				model: 'fancyParagraph',
 				view: {
 					name: 'p',
-					class: 'fancy'
+					classes: 'fancy'
 				}
 			} );
 
@@ -137,7 +137,7 @@ describe( 'downcast-helpers', () => {
 				model: 'invert',
 				view: {
 					name: 'span',
-					class: [ 'font-light', 'bg-dark' ]
+					classes: [ 'font-light', 'bg-dark' ]
 				}
 			} );
 
@@ -159,13 +159,13 @@ describe( 'downcast-helpers', () => {
 				view: {
 					big: {
 						name: 'span',
-						style: {
+						styles: {
 							'font-size': '1.2em'
 						}
 					},
 					small: {
 						name: 'span',
-						style: {
+						styles: {
 							'font-size': '0.8em'
 						}
 					}
@@ -474,7 +474,7 @@ describe( 'downcast-helpers', () => {
 				model: 'search',
 				view: {
 					name: 'span',
-					attribute: {
+					attributes: {
 						'data-marker': 'search'
 					}
 				}
@@ -511,7 +511,7 @@ describe( 'downcast-helpers', () => {
 
 	describe( 'downcastMarkerToHighlight', () => {
 		it( 'config.view is a highlight descriptor', () => {
-			const helper = downcastMarkerToHighlight( { model: 'comment', view: { class: 'comment' } } );
+			const helper = downcastMarkerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
 
 			conversion.for( 'downcast' ).add( helper );
 
@@ -524,8 +524,8 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'can be overwritten using priority', () => {
-			const helperA = downcastMarkerToHighlight( { model: 'comment', view: { class: 'comment' } } );
-			const helperB = downcastMarkerToHighlight( { model: 'comment', view: { class: 'new-comment' }, priority: 'high' } );
+			const helperA = downcastMarkerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
+			const helperB = downcastMarkerToHighlight( { model: 'comment', view: { classes: 'new-comment' }, priority: 'high' } );
 
 			conversion.for( 'downcast' ).add( helperA ).add( helperB );
 
@@ -544,7 +544,7 @@ describe( 'downcast-helpers', () => {
 					const commentType = data.markerName.split( ':' )[ 1 ];
 
 					return {
-						class: [ 'comment', 'comment-' + commentType ]
+						classes: [ 'comment', 'comment-' + commentType ]
 					};
 				}
 			} );
@@ -739,10 +739,10 @@ describe( 'downcast-converters', () => {
 		} );
 
 		it( 'should be possible to override setAttribute', () => {
-			const modelElement = new ModelElement( 'paragraph', { class: 'foo' }, new ModelText( 'foobar' ) );
+			const modelElement = new ModelElement( 'paragraph', { classes: 'foo' }, new ModelText( 'foobar' ) );
 
 			dispatcher.on( 'attribute:class', ( evt, data, conversionApi ) => {
-				conversionApi.consumable.consume( data.item, 'attribute:class' );
+				conversionApi.consumable.consume( data.item, 'attributes:class' );
 			}, { priority: 'high' } );
 
 			model.change( writer => {
@@ -1244,7 +1244,7 @@ describe( 'downcast-converters', () => {
 	describe( 'highlight', () => {
 		describe( 'on text', () => {
 			const highlightDescriptor = {
-				class: 'highlight-class',
+				classes: 'highlight-class',
 				priority: 7,
 				attributes: { title: 'title' }
 			};
@@ -1294,7 +1294,7 @@ describe( 'downcast-converters', () => {
 				dispatcher.on( 'addMarker:marker', highlightElement( highlightDescriptor ) );
 				dispatcher.on( 'removeMarker:marker', removeHighlight( highlightDescriptor ) );
 
-				const newDescriptor = { class: 'override-class' };
+				const newDescriptor = { classes: 'override-class' };
 
 				dispatcher.on( 'addMarker:marker', highlightText( newDescriptor ), { priority: 'high' } );
 				dispatcher.on( 'addMarker:marker', highlightElement( newDescriptor ), { priority: 'high' } );
@@ -1341,7 +1341,7 @@ describe( 'downcast-converters', () => {
 			} );
 
 			it( 'should do nothing if collapsed marker is converted', () => {
-				const descriptor = { class: 'foo' };
+				const descriptor = { classes: 'foo' };
 
 				dispatcher.on( 'addMarker:marker', highlightText( descriptor ), { priority: 'high' } );
 				dispatcher.on( 'addMarker:marker', highlightElement( descriptor ), { priority: 'high' } );
@@ -1363,9 +1363,9 @@ describe( 'downcast-converters', () => {
 			} );
 
 			it( 'should correctly wrap and unwrap multiple, intersecting markers', () => {
-				const descriptorFoo = { class: 'foo' };
-				const descriptorBar = { class: 'bar' };
-				const descriptorXyz = { class: 'xyz' };
+				const descriptorFoo = { classes: 'foo' };
+				const descriptorBar = { classes: 'bar' };
+				const descriptorXyz = { classes: 'xyz' };
 
 				dispatcher.on( 'addMarker:markerFoo', highlightText( descriptorFoo ) );
 				dispatcher.on( 'addMarker:markerBar', highlightText( descriptorBar ) );
@@ -1500,7 +1500,7 @@ describe( 'downcast-converters', () => {
 
 		describe( 'on element', () => {
 			const highlightDescriptor = {
-				class: 'highlight-class',
+				classes: 'highlight-class',
 				priority: 7,
 				attributes: { title: 'title' },
 				id: 'customId'
@@ -1514,7 +1514,7 @@ describe( 'downcast-converters', () => {
 					const viewContainer = new ViewContainerElement( 'div' );
 
 					viewContainer._setCustomProperty( 'addHighlight', ( element, descriptor, writer ) => {
-						writer.addClass( descriptor.class, element );
+						writer.addClass( descriptor.classes, element );
 					} );
 
 					viewContainer._setCustomProperty( 'removeHighlight', ( element, id, writer ) => {
@@ -1558,7 +1558,7 @@ describe( 'downcast-converters', () => {
 			} );
 
 			it( 'should be possible to override', () => {
-				const newDescriptor = { class: 'override-class' };
+				const newDescriptor = { classes: 'override-class' };
 
 				dispatcher.on( 'addMarker:marker', highlightText( newDescriptor ), { priority: 'high' } );
 				dispatcher.on( 'addMarker:marker', highlightElement( newDescriptor ), { priority: 'high' } );
@@ -1627,7 +1627,7 @@ describe( 'downcast-converters', () => {
 	describe( 'createViewElementFromHighlightDescriptor()', () => {
 		it( 'should return attribute element from descriptor object', () => {
 			const descriptor = {
-				class: 'foo-class',
+				classes: 'foo-class',
 				attributes: { one: '1', two: '2' },
 				priority: 7,
 			};
@@ -1645,7 +1645,7 @@ describe( 'downcast-converters', () => {
 
 		it( 'should return attribute element from descriptor object - array with classes', () => {
 			const descriptor = {
-				class: [ 'foo-class', 'bar-class' ],
+				classes: [ 'foo-class', 'bar-class' ],
 				attributes: { one: '1', two: '2' },
 				priority: 7,
 			};
@@ -1680,7 +1680,7 @@ describe( 'downcast-converters', () => {
 
 		it( 'should create element without priority', () => {
 			const descriptor = {
-				class: 'foo-class',
+				classes: 'foo-class',
 				attributes: { one: '1', two: '2' },
 			};
 			const element = createViewElementFromHighlightDescriptor( descriptor );
@@ -1697,7 +1697,7 @@ describe( 'downcast-converters', () => {
 
 		it( 'should create element without attributes', () => {
 			const descriptor = {
-				class: 'foo-class',
+				classes: 'foo-class',
 				priority: 7
 			};
 			const element = createViewElementFromHighlightDescriptor( descriptor );

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -1112,8 +1112,8 @@ describe( 'downcast-converters', () => {
 		} );
 
 		it( 'should not remove view ui elements that are placed next to removed content', () => {
-			modelRoot._appendChildren( new ModelText( 'fozbar' ) );
-			viewRoot._appendChildren( [
+			modelRoot._appendChild( new ModelText( 'fozbar' ) );
+			viewRoot._appendChild( [
 				new ViewText( 'foz' ),
 				new ViewUIElement( 'span' ),
 				new ViewText( 'bar' )
@@ -1135,8 +1135,8 @@ describe( 'downcast-converters', () => {
 		} );
 
 		it( 'should remove correct amount of text when it is split by view ui element', () => {
-			modelRoot._appendChildren( new ModelText( 'fozbar' ) );
-			viewRoot._appendChildren( [
+			modelRoot._appendChild( new ModelText( 'fozbar' ) );
+			viewRoot._appendChild( [
 				new ViewText( 'foz' ),
 				new ViewUIElement( 'span' ),
 				new ViewText( 'bar' )
@@ -1211,8 +1211,8 @@ describe( 'downcast-converters', () => {
 			const viewUi2 = new ViewUIElement( 'span' );
 			const viewP2 = new ViewContainerElement( 'p' );
 
-			modelRoot._appendChildren( [ modelP1, modelP2 ] );
-			viewRoot._appendChildren( [ viewP1, viewUi1, viewUi2, viewP2 ] );
+			modelRoot._appendChild( [ modelP1, modelP2 ] );
+			viewRoot._appendChild( [ viewP1, viewUi1, viewUi2, viewP2 ] );
 
 			controller.mapper.bindElements( modelP1, viewP1 );
 			controller.mapper.bindElements( modelP2, viewP2 );

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -51,7 +51,7 @@ describe( 'downcast-selection-converters', () => {
 		mapper = new Mapper();
 		mapper.bindElements( modelRoot, viewRoot );
 
-		highlightDescriptor = { class: 'marker', priority: 1 };
+		highlightDescriptor = { classes: 'marker', priority: 1 };
 
 		dispatcher = new DowncastDispatcher( { mapper, viewSelection } );
 
@@ -243,7 +243,7 @@ describe( 'downcast-selection-converters', () => {
 
 			it( 'in marker - using highlight descriptor creator', () => {
 				dispatcher.on( 'addMarker:marker2', highlightText(
-					data => ( { 'class': data.markerName } )
+					data => ( { classes: data.markerName } )
 				) );
 
 				setModelData( model, 'foobar' );

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -298,7 +298,7 @@ describe( 'downcast-selection-converters', () => {
 				setModelData( model, '' );
 
 				// Add two ui elements to view.
-				viewRoot._appendChildren( [
+				viewRoot._appendChild( [
 					new ViewUIElement( 'span' ),
 					new ViewUIElement( 'span' )
 				] );
@@ -333,7 +333,7 @@ describe( 'downcast-selection-converters', () => {
 
 					// Add ui element to view.
 					const uiElement = new ViewUIElement( 'span' );
-					viewRoot._insertChildren( 1, uiElement );
+					viewRoot._insertChild( 1, uiElement );
 
 					dispatcher.convertSelection( docSelection, model.markers, writer );
 				} );
@@ -358,7 +358,7 @@ describe( 'downcast-selection-converters', () => {
 
 					// Add ui element to view.
 					const uiElement = new ViewUIElement( 'span' );
-					viewRoot._insertChildren( 1, uiElement, writer );
+					viewRoot._insertChild( 1, uiElement, writer );
 					dispatcher.convertSelection( docSelection, model.markers, writer );
 				} );
 

--- a/tests/conversion/downcastdispatcher.js
+++ b/tests/conversion/downcastdispatcher.js
@@ -152,7 +152,7 @@ describe( 'DowncastDispatcher', () => {
 
 	describe( 'convertInsert', () => {
 		it( 'should fire event with correct parameters for every item in passed range', () => {
-			root._appendChildren( [
+			root._appendChild( [
 				new ModelText( 'foo', { bold: true } ),
 				new ModelElement( 'image' ),
 				new ModelText( 'bar' ),
@@ -206,7 +206,7 @@ describe( 'DowncastDispatcher', () => {
 		} );
 
 		it( 'should not fire events for already consumed parts of model', () => {
-			root._appendChildren( [
+			root._appendChild( [
 				new ModelElement( 'image', { src: 'foo.jpg', title: 'bar', bold: true }, [
 					new ModelElement( 'caption', {}, new ModelText( 'title' ) )
 				] )
@@ -252,7 +252,7 @@ describe( 'DowncastDispatcher', () => {
 		beforeEach( () => {
 			dispatcher.off( 'selection' );
 
-			root._appendChildren( new ModelText( 'foobar' ) );
+			root._appendChild( new ModelText( 'foobar' ) );
 			model.change( writer => {
 				writer.setSelection( [
 					new ModelRange( new ModelPosition( root, [ 1 ] ), new ModelPosition( root, [ 3 ] ) ),
@@ -378,7 +378,7 @@ describe( 'DowncastDispatcher', () => {
 			const text = new ModelText( 'abc' );
 			const caption = new ModelElement( 'caption', null, text );
 			const image = new ModelElement( 'image', null, caption );
-			root._appendChildren( [ image ] );
+			root._appendChild( [ image ] );
 
 			// Create view elements that will be "mapped" to model elements.
 			const viewCaption = new ViewContainerElement( 'caption' );
@@ -441,7 +441,7 @@ describe( 'DowncastDispatcher', () => {
 		beforeEach( () => {
 			text = new ModelText( 'foo bar baz' );
 			element = new ModelElement( 'paragraph', null, [ text ] );
-			root._appendChildren( [ element ] );
+			root._appendChild( [ element ] );
 
 			range = ModelRange.createFromParentsAndOffsets( element, 0, element, 4 );
 		} );
@@ -521,7 +521,7 @@ describe( 'DowncastDispatcher', () => {
 		beforeEach( () => {
 			text = new ModelText( 'foo bar baz' );
 			element = new ModelElement( 'paragraph', null, [ text ] );
-			root._appendChildren( [ element ] );
+			root._appendChild( [ element ] );
 
 			range = ModelRange.createFromParentsAndOffsets( element, 0, element, 4 );
 		} );

--- a/tests/conversion/mapper.js
+++ b/tests/conversion/mapper.js
@@ -181,7 +181,7 @@ describe( 'Mapper', () => {
 			] );
 
 			modelDiv = new ModelRootElement();
-			modelDiv._appendChildren( [
+			modelDiv._appendChild( [
 				new ModelText( 'x' ),
 				modelP,
 				new ModelText( 'zz' )
@@ -451,7 +451,7 @@ describe( 'Mapper', () => {
 			modelCaption = new ModelElement( 'caption', {}, new ModelText( 'foo' ) );
 			modelWidget = new ModelElement( 'widget', {}, [ modelImg, modelCaption ] );
 			modelDiv = new ModelRootElement();
-			modelDiv._appendChildren( [ new ModelText( 'x' ), modelWidget, new ModelText( 'zz' ) ] );
+			modelDiv._appendChild( [ new ModelText( 'x' ), modelWidget, new ModelText( 'zz' ) ] );
 
 			viewTextX = new ViewText( 'y' );
 			viewTextZZ = new ViewText( 'zz' );

--- a/tests/conversion/upcast-converters.js
+++ b/tests/conversion/upcast-converters.js
@@ -232,7 +232,7 @@ describe( 'upcast-helpers', () => {
 			const helper = upcastElementToAttribute( {
 				view: {
 					name: 'span',
-					style: {
+					styles: {
 						'font-size': /[\s\S]+/
 					}
 				},
@@ -304,12 +304,12 @@ describe( 'upcast-helpers', () => {
 		it( 'should allow two converters to convert attributes on the same element', () => {
 			const helperA = upcastElementToAttribute( {
 				model: 'attribA',
-				view: { name: 'span', class: 'attrib-a' }
+				view: { name: 'span', classes: 'attrib-a' }
 			} );
 
 			const helperB = upcastElementToAttribute( {
 				model: 'attribB',
-				view: { name: 'span', style: { color: 'attrib-b' } }
+				view: { name: 'span', styles: { color: 'attrib-b' } }
 			} );
 
 			conversion.for( 'upcast' ).add( helperA ).add( helperB );
@@ -333,7 +333,7 @@ describe( 'upcast-helpers', () => {
 
 			const helperB = upcastElementToAttribute( {
 				model: 'attribB',
-				view: { name: 'strong', class: 'foo' }
+				view: { name: 'strong', classes: 'foo' }
 			} );
 
 			conversion.for( 'upcast' ).add( helperBold ).add( helperA ).add( helperB );

--- a/tests/conversion/viewconsumable.js
+++ b/tests/conversion/viewconsumable.js
@@ -537,7 +537,7 @@ describe( 'ViewConsumable', () => {
 			const child1 = new ViewElement( 'p', { 'title': 'baz' }, [ text1 ] );
 			const child2 = new ViewElement( 'p' );
 			const child3 = new ViewElement( 'p', { 'style': 'top:10px;', 'class': 'qux bar' }, [ text2, child2 ] );
-			el._appendChildren( [ child1, child3 ] );
+			el._appendChild( [ child1, child3 ] );
 
 			const newConsumable = ViewConsumable.createFrom( el );
 

--- a/tests/conversion/viewconsumable.js
+++ b/tests/conversion/viewconsumable.js
@@ -36,62 +36,62 @@ describe( 'ViewConsumable', () => {
 			expect( viewConsumable.test( fragment ) ).to.be.true;
 		} );
 
-		it( 'should allow to add attributes classes and styles', () => {
-			viewConsumable.add( el, { attribute: 'href' } );
-			viewConsumable.add( el, { class: 'foobar' } );
-			viewConsumable.add( el, { style: 'color' } );
+		it( 'should allow to add attribute classes and styles', () => {
+			viewConsumable.add( el, { attributes: 'href' } );
+			viewConsumable.add( el, { classes: 'foobar' } );
+			viewConsumable.add( el, { styles: 'color' } );
 
-			expect( viewConsumable.test( el, { attribute: 'href' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { class: 'foobar' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { style: 'color' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'href' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'foobar' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'color' } ) ).to.be.true;
 			expect( viewConsumable.test( el, { name: true } ) ).to.be.null;
 		} );
 
-		it( 'should allow to add attributes classes and styles in one call', () => {
-			viewConsumable.add( el, { attribute: 'href', class: 'foobar', style: 'color' } );
+		it( 'should allow to add attribute classes and styles in one call', () => {
+			viewConsumable.add( el, { attributes: 'href', classes: 'foobar', styles: 'color' } );
 
-			expect( viewConsumable.test( el, { attribute: 'href' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { class: 'foobar' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { style: 'color' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'href' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'foobar' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'color' } ) ).to.be.true;
 			expect( viewConsumable.test( el, { name: true } ) ).to.be.null;
 		} );
 
-		it( 'should allow to add multiple attributes in one call', () => {
-			viewConsumable.add( el, { attribute: [ 'href', 'target', 'title' ] } );
+		it( 'should allow to add multiple attribute in one call', () => {
+			viewConsumable.add( el, { attributes: [ 'href', 'target', 'title' ] } );
 
-			expect( viewConsumable.test( el, { attribute: 'href' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'target' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'title' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'href' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'target' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'title' } ) ).to.be.true;
 			expect( viewConsumable.test( el, { name: true } ) ).to.be.null;
 		} );
 
 		it( 'should allow to add multiple classes in one call', () => {
-			viewConsumable.add( el, { class: [ 'foo', 'bar', 'baz' ] } );
+			viewConsumable.add( el, { classes: [ 'foo', 'bar', 'baz' ] } );
 
-			expect( viewConsumable.test( el, { class: 'foo' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { class: 'bar' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { class: 'baz' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'foo' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'bar' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'baz' } ) ).to.be.true;
 			expect( viewConsumable.test( el, { name: true } ) ).to.be.null;
 		} );
 
 		it( 'should allow to add multiple styles in one call', () => {
-			viewConsumable.add( el, { style: [ 'color', 'position', 'top' ] } );
+			viewConsumable.add( el, { styles: [ 'color', 'position', 'top' ] } );
 
-			expect( viewConsumable.test( el, { style: 'color' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { style: 'position' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { style: 'top' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'color' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'position' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'top' } ) ).to.be.true;
 			expect( viewConsumable.test( el, { name: true } ) ).to.be.null;
 		} );
 
 		it( 'should throw if class attribute is added', () => {
 			expect( () => {
-				viewConsumable.add( el, { attribute: 'class' } );
+				viewConsumable.add( el, { attributes: 'class' } );
 			} ).to.throw( 'viewconsumable-invalid-attribute' );
 		} );
 
 		it( 'should throw if style attribute is added', () => {
 			expect( () => {
-				viewConsumable.add( el, { attribute: 'style' } );
+				viewConsumable.add( el, { attributes: 'style' } );
 			} ).to.throw( 'viewconsumable-invalid-attribute' );
 		} );
 	} );
@@ -126,50 +126,50 @@ describe( 'ViewConsumable', () => {
 			expect( viewConsumable.test( fragment2 ) ).to.be.null;
 		} );
 
-		it( 'should test attributes, classes and styles', () => {
+		it( 'should test attribute, classes and styles', () => {
 			const el = new ViewElement( 'p' );
 
-			viewConsumable.add( el, { attribute: 'href', class: 'foobar', style: 'color' } );
+			viewConsumable.add( el, { attributes: 'href', classes: 'foobar', styles: 'color' } );
 
-			expect( viewConsumable.test( el, { attribute: 'href' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { class: 'foobar' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { style: 'color' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'href', class: 'foobar', style: 'color' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'href', class: 'baz' } ) ).to.be.null;
+			expect( viewConsumable.test( el, { attributes: 'href' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'foobar' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'color' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'href', classes: 'foobar', styles: 'color' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'href', classes: 'baz' } ) ).to.be.null;
 			expect( viewConsumable.test( el, { name: true } ) ).to.be.null;
 
-			viewConsumable.consume( el, { style: 'color' } );
-			expect( viewConsumable.test( el, { attribute: 'href', style: 'color' } ) ).to.be.false;
+			viewConsumable.consume( el, { styles: 'color' } );
+			expect( viewConsumable.test( el, { attributes: 'href', styles: 'color' } ) ).to.be.false;
 		} );
 
-		it( 'should allow to test multiple attributes in one call', () => {
-			viewConsumable.add( el, { attribute: [ 'href', 'title', 'target' ] } );
+		it( 'should allow to test multiple attribute in one call', () => {
+			viewConsumable.add( el, { attributes: [ 'href', 'title', 'target' ] } );
 
-			expect( viewConsumable.test( el, { attribute: [ 'href', 'title', 'target' ] } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: [ 'href', 'title', 'alt' ] } ) ).to.be.null;
+			expect( viewConsumable.test( el, { attributes: [ 'href', 'title', 'target' ] } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: [ 'href', 'title', 'alt' ] } ) ).to.be.null;
 
-			viewConsumable.consume( el, { attribute: 'target' } );
-			expect( viewConsumable.test( el, { attribute: [ 'href', 'title', 'target' ] } ) ).to.be.false;
+			viewConsumable.consume( el, { attributes: 'target' } );
+			expect( viewConsumable.test( el, { attributes: [ 'href', 'title', 'target' ] } ) ).to.be.false;
 		} );
 
 		it( 'should allow to test multiple classes in one call', () => {
-			viewConsumable.add( el, { class: [ 'foo', 'bar', 'baz' ] } );
+			viewConsumable.add( el, { classes: [ 'foo', 'bar', 'baz' ] } );
 
-			expect( viewConsumable.test( el, { class: [ 'foo', 'bar', 'baz' ] } ) ).to.be.true;
-			expect( viewConsumable.test( el, { class: [ 'foo', 'bar', 'qux' ] } ) ).to.be.null;
+			expect( viewConsumable.test( el, { classes: [ 'foo', 'bar', 'baz' ] } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: [ 'foo', 'bar', 'qux' ] } ) ).to.be.null;
 
-			viewConsumable.consume( el, { class: 'bar' } );
-			expect( viewConsumable.test( el, { class: [ 'foo', 'bar', 'baz' ] } ) ).to.be.false;
+			viewConsumable.consume( el, { classes: 'bar' } );
+			expect( viewConsumable.test( el, { classes: [ 'foo', 'bar', 'baz' ] } ) ).to.be.false;
 		} );
 
 		it( 'should allow to test multiple styles in one call', () => {
-			viewConsumable.add( el, { style: [ 'color', 'position', 'top' ] } );
+			viewConsumable.add( el, { styles: [ 'color', 'position', 'top' ] } );
 
-			expect( viewConsumable.test( el, { style: [ 'color', 'position', 'top' ] } ) ).to.be.true;
-			expect( viewConsumable.test( el, { style: [ 'color', 'position', 'left' ] } ) ).to.be.null;
+			expect( viewConsumable.test( el, { styles: [ 'color', 'position', 'top' ] } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: [ 'color', 'position', 'left' ] } ) ).to.be.null;
 
-			viewConsumable.consume( el, { style: 'top' } );
-			expect( viewConsumable.test( el, { style: [ 'color', 'position', 'top' ] } ) ).to.be.false;
+			viewConsumable.consume( el, { styles: 'top' } );
+			expect( viewConsumable.test( el, { styles: [ 'color', 'position', 'top' ] } ) ).to.be.false;
 		} );
 
 		it( 'should return null if not consumable', () => {
@@ -184,46 +184,46 @@ describe( 'ViewConsumable', () => {
 		} );
 
 		it( 'should return null if first non-consumable item is found', () => {
-			viewConsumable.add( el, { attribute: 'foo' } );
+			viewConsumable.add( el, { attributes: 'foo' } );
 
-			expect( viewConsumable.test( el, { attribute: [ 'foo', 'bar' ] } ) ).to.be.null;
+			expect( viewConsumable.test( el, { attributes: [ 'foo', 'bar' ] } ) ).to.be.null;
 		} );
 
 		it( 'should return false if first already consumed item is found', () => {
-			viewConsumable.add( el, { name: true, attribute: [ 'foo', 'bar' ] } );
-			viewConsumable.consume( el, { attribute: 'bar' } );
+			viewConsumable.add( el, { name: true, attributes: [ 'foo', 'bar' ] } );
+			viewConsumable.consume( el, { attributes: 'bar' } );
 			viewConsumable.consume( el, { name: true } );
 
-			expect( viewConsumable.test( el, { attribute: [ 'foo', 'bar' ] } ) ).to.be.false;
+			expect( viewConsumable.test( el, { attributes: [ 'foo', 'bar' ] } ) ).to.be.false;
 			expect( viewConsumable.test( el, { name: true } ) ).to.be.false;
 		} );
 
 		it( 'should test all classes if class attribute is tested', () => {
-			viewConsumable.add( el, { class: [ 'foo', 'bar', 'baz' ] } );
-			expect( viewConsumable.test( el, { attribute: 'class' } ) ).to.be.true;
-			expect( viewConsumable.consume( el, { class: 'baz' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'class' } ) ).to.be.false;
+			viewConsumable.add( el, { classes: [ 'foo', 'bar', 'baz' ] } );
+			expect( viewConsumable.test( el, { attributes: 'class' } ) ).to.be.true;
+			expect( viewConsumable.consume( el, { classes: 'baz' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'class' } ) ).to.be.false;
 		} );
 
 		it( 'should test all styles if style attribute is tested', () => {
-			viewConsumable.add( el, { style: [ 'color', 'top', 'position' ] } );
-			expect( viewConsumable.test( el, { attribute: 'style' } ) ).to.be.true;
-			expect( viewConsumable.consume( el, { style: 'top' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'style' } ) ).to.be.false;
+			viewConsumable.add( el, { styles: [ 'color', 'top', 'position' ] } );
+			expect( viewConsumable.test( el, { attributes: 'style' } ) ).to.be.true;
+			expect( viewConsumable.consume( el, { styles: 'top' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'style' } ) ).to.be.false;
 		} );
 
 		it( 'should return false when testing class attribute when consumed classes exists', () => {
-			viewConsumable.add( el, { class: [ 'foo', 'baz' ] } );
-			expect( viewConsumable.consume( el, { class: 'baz' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'class' } ) ).to.be.false;
-			expect( viewConsumable.consume( el, { attribute: 'class' } ) ).to.be.false;
+			viewConsumable.add( el, { classes: [ 'foo', 'baz' ] } );
+			expect( viewConsumable.consume( el, { classes: 'baz' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'class' } ) ).to.be.false;
+			expect( viewConsumable.consume( el, { attributes: 'class' } ) ).to.be.false;
 		} );
 
 		it( 'should return false when testing style attribute when consumed styles exists', () => {
-			viewConsumable.add( el, { style: [ 'top', 'left' ] } );
-			expect( viewConsumable.consume( el, { style: 'top' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'style' } ) ).to.be.false;
-			expect( viewConsumable.consume( el, { attribute: 'style' } ) ).to.be.false;
+			viewConsumable.add( el, { styles: [ 'top', 'left' ] } );
+			expect( viewConsumable.consume( el, { styles: 'top' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'style' } ) ).to.be.false;
+			expect( viewConsumable.consume( el, { attributes: 'style' } ) ).to.be.false;
 		} );
 	} );
 
@@ -265,81 +265,81 @@ describe( 'ViewConsumable', () => {
 			expect( viewConsumable.consume( el, { name: true } ) ).to.be.false;
 		} );
 
-		it( 'should consume attributes, classes and styles', () => {
-			viewConsumable.add( el, { class: 'foobar', attribute: 'href', style: 'color' } );
+		it( 'should consume attribute, classes and styles', () => {
+			viewConsumable.add( el, { classes: 'foobar', attributes: 'href', styles: 'color' } );
 
-			const consumed1 = viewConsumable.consume( el, { class: 'foobar' } );
-			const consumed2 = viewConsumable.consume( el, { attribute: 'href' } );
-			const consumed3 = viewConsumable.consume( el, { style: 'color' } );
+			const consumed1 = viewConsumable.consume( el, { classes: 'foobar' } );
+			const consumed2 = viewConsumable.consume( el, { attributes: 'href' } );
+			const consumed3 = viewConsumable.consume( el, { styles: 'color' } );
 
 			expect( consumed1 ).to.be.true;
 			expect( consumed2 ).to.be.true;
 			expect( consumed3 ).to.be.true;
 
-			expect( viewConsumable.test( el, { class: 'foobar' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { attribute: 'href' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { style: 'color' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { classes: 'foobar' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { attributes: 'href' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { styles: 'color' } ) ).to.be.false;
 		} );
 
-		it( 'should consume multiple attributes', () => {
-			viewConsumable.add( el, { attribute: [ 'href', 'title', 'name' ] } );
+		it( 'should consume multiple attribute', () => {
+			viewConsumable.add( el, { attributes: [ 'href', 'title', 'name' ] } );
 
-			const consumed = viewConsumable.consume( el, { attribute: [ 'href', 'title' ] } );
+			const consumed = viewConsumable.consume( el, { attributes: [ 'href', 'title' ] } );
 
 			expect( consumed ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'href' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { attribute: 'title' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { attribute: 'name' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'href' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { attributes: 'title' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { attributes: 'name' } ) ).to.be.true;
 		} );
 
 		it( 'should consume multiple styles', () => {
-			viewConsumable.add( el, { style: [ 'color', 'top', 'position' ] } );
+			viewConsumable.add( el, { styles: [ 'color', 'top', 'position' ] } );
 
-			const consumed = viewConsumable.consume( el, { style: [ 'color', 'position' ] } );
+			const consumed = viewConsumable.consume( el, { styles: [ 'color', 'position' ] } );
 
 			expect( consumed ).to.be.true;
-			expect( viewConsumable.test( el, { style: 'color' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { style: 'position' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { style: 'top' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'color' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { styles: 'position' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { styles: 'top' } ) ).to.be.true;
 		} );
 
 		it( 'should consume multiple classes', () => {
-			viewConsumable.add( el, { class: [ 'foo', 'bar', 'baz' ] } );
+			viewConsumable.add( el, { classes: [ 'foo', 'bar', 'baz' ] } );
 
-			const consumed = viewConsumable.consume( el, { class: [ 'bar', 'baz' ] } );
+			const consumed = viewConsumable.consume( el, { classes: [ 'bar', 'baz' ] } );
 
 			expect( consumed ).to.be.true;
-			expect( viewConsumable.test( el, { class: 'bar' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { class: 'baz' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { class: 'foo' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'bar' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { classes: 'baz' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { classes: 'foo' } ) ).to.be.true;
 		} );
 
 		it( 'should consume only if all items can be consumed', () => {
-			viewConsumable.add( el, { style: [ 'position', 'color' ], attribute: [ 'href', 'title' ] } );
+			viewConsumable.add( el, { styles: [ 'position', 'color' ], attributes: [ 'href', 'title' ] } );
 
-			const consumed = viewConsumable.consume( el, { style: [ 'color', 'top' ] } );
+			const consumed = viewConsumable.consume( el, { styles: [ 'color', 'top' ] } );
 			expect( consumed ).to.be.false;
-			expect( viewConsumable.test( el, { style: 'color' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'color' } ) ).to.be.true;
 		} );
 
 		it( 'should consume all classes when class attribute is provided', () => {
-			expect( viewConsumable.consume( el, { attribute: 'class' } ) ).to.be.false;
-			viewConsumable.add( el, { class: [ 'foo', 'bar', 'baz' ] } );
-			expect( viewConsumable.consume( el, { attribute: 'class' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'class' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { class: 'foo' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { class: 'bar' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { class: 'baz' } ) ).to.be.false;
+			expect( viewConsumable.consume( el, { attributes: 'class' } ) ).to.be.false;
+			viewConsumable.add( el, { classes: [ 'foo', 'bar', 'baz' ] } );
+			expect( viewConsumable.consume( el, { attributes: 'class' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'class' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { classes: 'foo' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { classes: 'bar' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { classes: 'baz' } ) ).to.be.false;
 		} );
 
 		it( 'should consume all styles when style attribute is provided', () => {
-			expect( viewConsumable.consume( el, { attribute: 'style' } ) ).to.be.false;
-			viewConsumable.add( el, { style: [ 'color', 'top', 'position' ] } );
-			expect( viewConsumable.consume( el, { attribute: 'style' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'style' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { style: 'color' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { style: 'top' } ) ).to.be.false;
-			expect( viewConsumable.test( el, { style: 'position' } ) ).to.be.false;
+			expect( viewConsumable.consume( el, { attributes: 'style' } ) ).to.be.false;
+			viewConsumable.add( el, { styles: [ 'color', 'top', 'position' ] } );
+			expect( viewConsumable.consume( el, { attributes: 'style' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'style' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { styles: 'color' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { styles: 'top' } ) ).to.be.false;
+			expect( viewConsumable.test( el, { styles: 'position' } ) ).to.be.false;
 		} );
 	} );
 
@@ -391,34 +391,34 @@ describe( 'ViewConsumable', () => {
 			expect( viewConsumable.test( el, { name: true } ) ).to.be.true;
 		} );
 
-		it( 'should revert classes, attributes and styles', () => {
-			viewConsumable.add( el, { class: 'foobar', style: 'color', attribute: 'name' } );
-			viewConsumable.consume( el, { class: 'foobar', style: 'color', attribute: 'name' } );
+		it( 'should revert classes, attribute and styles', () => {
+			viewConsumable.add( el, { classes: 'foobar', styles: 'color', attributes: 'name' } );
+			viewConsumable.consume( el, { classes: 'foobar', styles: 'color', attributes: 'name' } );
 
-			viewConsumable.revert( el, { class: 'foobar' } );
-			viewConsumable.revert( el, { style: 'color' } );
-			viewConsumable.revert( el, { attribute: 'name' } );
+			viewConsumable.revert( el, { classes: 'foobar' } );
+			viewConsumable.revert( el, { styles: 'color' } );
+			viewConsumable.revert( el, { attributes: 'name' } );
 
-			expect( viewConsumable.test( el, { class: 'foobar', style: 'color', attribute: 'name' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'foobar', styles: 'color', attributes: 'name' } ) ).to.be.true;
 		} );
 
-		it( 'should revert multiple classes, attributes and styles in one call #1', () => {
+		it( 'should revert multiple classes, attribute and styles in one call #1', () => {
 			viewConsumable.add( el, {
-				class: 'foobar',
-				style: 'color',
-				attribute: 'name'
+				classes: 'foobar',
+				styles: 'color',
+				attributes: 'name'
 			} );
-			viewConsumable.consume( el, { class: 'foobar', style: 'color', attribute: 'name' } );
-			viewConsumable.revert( el, { class: 'foobar', style: 'color', attribute: 'name' } );
+			viewConsumable.consume( el, { classes: 'foobar', styles: 'color', attributes: 'name' } );
+			viewConsumable.revert( el, { classes: 'foobar', styles: 'color', attributes: 'name' } );
 
-			expect( viewConsumable.test( el, { class: 'foobar', style: 'color', attribute: 'name' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'foobar', styles: 'color', attributes: 'name' } ) ).to.be.true;
 		} );
 
-		it( 'should revert multiple classes, attributes and styles in one call #2', () => {
+		it( 'should revert multiple classes, attribute and styles in one call #2', () => {
 			const consumables = {
-				class: [ 'foobar', 'baz' ],
-				style: [ 'color', 'position' ],
-				attribute: [ 'name', 'href' ]
+				classes: [ 'foobar', 'baz' ],
+				styles: [ 'color', 'position' ],
+				attributes: [ 'name', 'href' ]
 			};
 
 			viewConsumable.add( el, consumables );
@@ -429,33 +429,33 @@ describe( 'ViewConsumable', () => {
 		} );
 
 		it( 'should revert only items that were previously added', () => {
-			viewConsumable.add( el, { class: 'foobar' } );
-			viewConsumable.consume( el, { class: 'foobar' } );
-			viewConsumable.revert( el, { class: 'foobar', attribute: 'name' } );
+			viewConsumable.add( el, { classes: 'foobar' } );
+			viewConsumable.consume( el, { classes: 'foobar' } );
+			viewConsumable.revert( el, { classes: 'foobar', attributes: 'name' } );
 
-			expect( viewConsumable.test( el, { class: 'foobar' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { attribute: 'name' } ) ).to.be.null;
+			expect( viewConsumable.test( el, { classes: 'foobar' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { attributes: 'name' } ) ).to.be.null;
 		} );
 
 		it( 'should revert all classes when class attribute is provided', () => {
-			viewConsumable.add( el, { class: [ 'foo', 'bar', 'baz' ] } );
-			expect( viewConsumable.consume( el, { class: [ 'foo', 'bar', 'baz' ] } ) ).to.be.true;
-			viewConsumable.revert( el, { attribute: 'class' } );
+			viewConsumable.add( el, { classes: [ 'foo', 'bar', 'baz' ] } );
+			expect( viewConsumable.consume( el, { classes: [ 'foo', 'bar', 'baz' ] } ) ).to.be.true;
+			viewConsumable.revert( el, { attributes: 'class' } );
 
-			expect( viewConsumable.test( el, { class: 'foo' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { class: 'bar' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { class: 'baz' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { class: 'qux' } ) ).to.be.null;
+			expect( viewConsumable.test( el, { classes: 'foo' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'bar' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'baz' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { classes: 'qux' } ) ).to.be.null;
 		} );
 
 		it( 'should revert all styles when style attribute is provided', () => {
-			viewConsumable.add( el, { style: [ 'color', 'top' ] } );
-			expect( viewConsumable.consume( el, { style: [ 'color', 'top' ] } ) ).to.be.true;
-			viewConsumable.revert( el, { attribute: 'style' } );
+			viewConsumable.add( el, { styles: [ 'color', 'top' ] } );
+			expect( viewConsumable.consume( el, { styles: [ 'color', 'top' ] } ) ).to.be.true;
+			viewConsumable.revert( el, { attributes: 'style' } );
 
-			expect( viewConsumable.test( el, { style: 'color' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { style: 'top' } ) ).to.be.true;
-			expect( viewConsumable.test( el, { style: 'qux' } ) ).to.be.null;
+			expect( viewConsumable.test( el, { styles: 'color' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'top' } ) ).to.be.true;
+			expect( viewConsumable.test( el, { styles: 'qux' } ) ).to.be.null;
 		} );
 	} );
 
@@ -465,24 +465,24 @@ describe( 'ViewConsumable', () => {
 
 			expect( consumables ).to.be.an( 'object' );
 			expect( consumables.name ).to.be.true;
-			expect( consumables.attribute ).to.be.an( 'array' );
-			expect( consumables.attribute.length ).to.equal( 0 );
-			expect( consumables.class ).to.be.an( 'array' );
-			expect( consumables.class.length ).to.equal( 0 );
-			expect( consumables.style ).to.be.an( 'array' );
-			expect( consumables.style.length ).to.equal( 0 );
+			expect( consumables.attributes ).to.be.an( 'array' );
+			expect( consumables.attributes.length ).to.equal( 0 );
+			expect( consumables.classes ).to.be.an( 'array' );
+			expect( consumables.classes.length ).to.equal( 0 );
+			expect( consumables.styles ).to.be.an( 'array' );
+			expect( consumables.styles.length ).to.equal( 0 );
 		} );
 
-		it( 'should add all attributes', () => {
+		it( 'should add all attribute', () => {
 			el._setAttribute( 'title', 'foobar' );
 			el._setAttribute( 'href', 'https://ckeditor.com' );
 
 			const consumables = ViewConsumable.consumablesFromElement( el );
-			expect( consumables.attribute.length ).to.equal( 2 );
-			expect( consumables.attribute.indexOf( 'title' ) > -1 ).to.be.true;
-			expect( consumables.attribute.indexOf( 'href' ) > -1 ).to.be.true;
-			expect( consumables.class.length ).to.equal( 0 );
-			expect( consumables.style.length ).to.equal( 0 );
+			expect( consumables.attributes.length ).to.equal( 2 );
+			expect( consumables.attributes.indexOf( 'title' ) > -1 ).to.be.true;
+			expect( consumables.attributes.indexOf( 'href' ) > -1 ).to.be.true;
+			expect( consumables.classes.length ).to.equal( 0 );
+			expect( consumables.styles.length ).to.equal( 0 );
 			expect( consumables.name ).to.be.true;
 		} );
 
@@ -490,12 +490,12 @@ describe( 'ViewConsumable', () => {
 			el._addClass( [ 'foo', 'bar', 'baz' ] );
 
 			const consumables = ViewConsumable.consumablesFromElement( el );
-			expect( consumables.class.length ).to.equal( 3 );
-			expect( consumables.class.indexOf( 'foo' ) > -1 ).to.be.true;
-			expect( consumables.class.indexOf( 'bar' ) > -1 ).to.be.true;
-			expect( consumables.class.indexOf( 'baz' ) > -1 ).to.be.true;
-			expect( consumables.attribute.length ).to.equal( 0 );
-			expect( consumables.style.length ).to.equal( 0 );
+			expect( consumables.classes.length ).to.equal( 3 );
+			expect( consumables.classes.indexOf( 'foo' ) > -1 ).to.be.true;
+			expect( consumables.classes.indexOf( 'bar' ) > -1 ).to.be.true;
+			expect( consumables.classes.indexOf( 'baz' ) > -1 ).to.be.true;
+			expect( consumables.attributes.length ).to.equal( 0 );
+			expect( consumables.styles.length ).to.equal( 0 );
 			expect( consumables.name ).to.be.true;
 		} );
 
@@ -506,11 +506,11 @@ describe( 'ViewConsumable', () => {
 			} );
 
 			const consumables = ViewConsumable.consumablesFromElement( el );
-			expect( consumables.style.length ).to.equal( 2 );
-			expect( consumables.style.indexOf( 'color' ) > -1 ).to.be.true;
-			expect( consumables.style.indexOf( 'position' ) > -1 ).to.be.true;
-			expect( consumables.attribute.length ).to.equal( 0 );
-			expect( consumables.class.length ).to.equal( 0 );
+			expect( consumables.styles.length ).to.equal( 2 );
+			expect( consumables.styles.indexOf( 'color' ) > -1 ).to.be.true;
+			expect( consumables.styles.indexOf( 'position' ) > -1 ).to.be.true;
+			expect( consumables.attributes.length ).to.equal( 0 );
+			expect( consumables.classes.length ).to.equal( 0 );
 			expect( consumables.name ).to.be.true;
 		} );
 	} );
@@ -544,9 +544,9 @@ describe( 'ViewConsumable', () => {
 			expect( newConsumable.test( el, { name: true } ) ).to.be.true;
 			expect( newConsumable.test( text1 ) ).to.be.true;
 			expect( newConsumable.test( text2 ) ).to.be.true;
-			expect( newConsumable.test( child1, { name: true, attribute: 'title' } ) ).to.be.true;
+			expect( newConsumable.test( child1, { name: true, attributes: 'title' } ) ).to.be.true;
 			expect( newConsumable.test( child2, { name: true } ) ).to.be.true;
-			expect( newConsumable.test( child3, { name: true, style: 'top', class: [ 'qux', 'bar' ] } ) ).to.be.true;
+			expect( newConsumable.test( child3, { name: true, styles: 'top', classes: [ 'qux', 'bar' ] } ) ).to.be.true;
 		} );
 	} );
 } );

--- a/tests/dataprocessor/htmldataprocessor.js
+++ b/tests/dataprocessor/htmldataprocessor.js
@@ -97,7 +97,7 @@ describe( 'HtmlDataProcessor', () => {
 
 		it( 'should return text if document fragment with single text node is passed', () => {
 			const fragment = new ViewDocumentFragment();
-			fragment._appendChildren( parse( 'foo bar' ) );
+			fragment._appendChild( parse( 'foo bar' ) );
 
 			expect( dataProcessor.toData( fragment ) ).to.equal( 'foo bar' );
 		} );

--- a/tests/dataprocessor/xmldataprocessor.js
+++ b/tests/dataprocessor/xmldataprocessor.js
@@ -89,7 +89,7 @@ describe( 'XmlDataProcessor', () => {
 
 		it( 'should return text if document fragment with single text node is passed', () => {
 			const fragment = new ViewDocumentFragment();
-			fragment._appendChildren( parse( 'foo bar' ) );
+			fragment._appendChild( parse( 'foo bar' ) );
 
 			expect( dataProcessor.toData( fragment ) ).to.equal( 'foo bar' );
 		} );

--- a/tests/dev-utils/enableenginedebug.js
+++ b/tests/dev-utils/enableenginedebug.js
@@ -233,7 +233,7 @@ describe( 'debug tools', () => {
 
 		describe( 'for operations', () => {
 			beforeEach( () => {
-				modelRoot._appendChildren( [ new ModelText( 'foobar' ) ] );
+				modelRoot._appendChild( [ new ModelText( 'foobar' ) ] );
 			} );
 
 			it( 'AttributeOperation', () => {
@@ -256,7 +256,7 @@ describe( 'debug tools', () => {
 
 			it( 'DetachOperation (element)', () => {
 				const element = new ModelElement( 'element' );
-				modelRoot._insertChildren( 0, element );
+				modelRoot._insertChild( 0, element );
 
 				const op = new DetachOperation( ModelPosition.createBefore( element ), 1 );
 
@@ -268,7 +268,7 @@ describe( 'debug tools', () => {
 
 			it( 'DetachOperation (multiple nodes)', () => {
 				const element = new ModelElement( 'element' );
-				modelRoot._insertChildren( 0, element );
+				modelRoot._insertChild( 0, element );
 
 				const op = new DetachOperation( ModelPosition.createBefore( element ), 2 );
 
@@ -376,7 +376,7 @@ describe( 'debug tools', () => {
 			} );
 
 			it( 'AttributeDelta', () => {
-				modelRoot._appendChildren( new ModelText( 'foobar' ) );
+				modelRoot._appendChild( new ModelText( 'foobar' ) );
 
 				const delta = new AttributeDelta();
 				const op = new AttributeOperation( ModelRange.createIn( modelRoot ), 'key', null, { foo: 'bar' }, 0 );
@@ -427,7 +427,7 @@ describe( 'debug tools', () => {
 			} );
 
 			it( 'MarkerDelta', () => {
-				modelRoot._appendChildren( new ModelText( 'foobar' ) );
+				modelRoot._appendChild( new ModelText( 'foobar' ) );
 
 				const delta = new MarkerDelta();
 				const op = new MarkerOperation( 'marker', null, ModelRange.createIn( modelRoot ), modelDoc.markers, 0 );
@@ -445,7 +445,7 @@ describe( 'debug tools', () => {
 				const firstEle = new ModelElement( 'paragraph' );
 				const removedEle = new ModelElement( 'paragraph', null, [ new ModelText( 'foo' ) ] );
 
-				otherRoot._appendChildren( [ firstEle, removedEle ] );
+				otherRoot._appendChild( [ firstEle, removedEle ] );
 
 				const graveyard = modelDoc.graveyard;
 				const delta = new MergeDelta();
@@ -471,7 +471,7 @@ describe( 'debug tools', () => {
 				const firstEle = new ModelElement( 'paragraph' );
 				const removedEle = new ModelElement( 'paragraph', null, [ new ModelText( 'foo' ) ] );
 
-				otherRoot._appendChildren( [ firstEle, removedEle ] );
+				otherRoot._appendChild( [ firstEle, removedEle ] );
 
 				const delta = new MergeDelta();
 				const move = new MoveOperation( ModelPosition.createAt( removedEle, 0 ), 3, ModelPosition.createAt( firstEle, 0 ), 0 );
@@ -527,7 +527,7 @@ describe( 'debug tools', () => {
 				const otherRoot = modelDoc.createRoot( 'main', 'otherRoot' );
 				const splitEle = new ModelElement( 'paragraph', null, [ new ModelText( 'foo' ) ] );
 
-				otherRoot._appendChildren( [ splitEle ] );
+				otherRoot._appendChild( [ splitEle ] );
 
 				const delta = new SplitDelta();
 				const insert = new InsertOperation( ModelPosition.createAt( otherRoot, 1 ), [ new ModelElement( 'paragraph' ) ], 0 );
@@ -546,7 +546,7 @@ describe( 'debug tools', () => {
 				const otherRoot = modelDoc.createRoot( 'main', 'otherRoot' );
 				const splitEle = new ModelElement( 'paragraph', null, [ new ModelText( 'foo' ) ] );
 
-				otherRoot._appendChildren( [ splitEle ] );
+				otherRoot._appendChild( [ splitEle ] );
 
 				const delta = new SplitDelta();
 				const insert = new InsertOperation( ModelPosition.createAt( otherRoot, 1 ), [ new ModelElement( 'paragraph' ) ], 0 );
@@ -581,7 +581,7 @@ describe( 'debug tools', () => {
 				const otherRoot = modelDoc.createRoot( 'main', 'otherRoot' );
 				const unwrapEle = new ModelElement( 'paragraph', null, [ new ModelText( 'foo' ) ] );
 
-				otherRoot._appendChildren( [ unwrapEle ] );
+				otherRoot._appendChild( [ unwrapEle ] );
 
 				const graveyard = modelDoc.graveyard;
 				const delta = new UnwrapDelta();
@@ -630,7 +630,7 @@ describe( 'debug tools', () => {
 			const modelDoc = model.document;
 			const modelRoot = modelDoc.createRoot();
 
-			modelRoot._appendChildren( [
+			modelRoot._appendChild( [
 				new ModelElement( 'paragraph', { foo: 'bar' }, [
 					new ModelText( 'This is ' ), new ModelText( 'bold', { bold: true } ), new ModelText( '.' )
 				] ),
@@ -699,7 +699,7 @@ describe( 'debug tools', () => {
 			const viewDoc = new ViewDocument();
 			const viewRoot = createViewRoot( viewDoc );
 
-			viewRoot._appendChildren( [
+			viewRoot._appendChild( [
 				new ViewContainerElement( 'p', { foo: 'bar' }, [
 					new ViewText( 'This is ' ), new ViewAttributeElement( 'b', null, new ViewText( 'bold' ) ), new ViewText( '.' )
 				] ),
@@ -904,7 +904,7 @@ describe( 'debug tools', () => {
 			const firstEle = new ModelElement( 'paragraph' );
 			const removedEle = new ModelElement( 'paragraph', null, [ new ModelText( 'foo' ) ] );
 
-			otherRoot._appendChildren( [ firstEle, removedEle ] );
+			otherRoot._appendChild( [ firstEle, removedEle ] );
 
 			const delta = new MergeDelta();
 			const graveyard = modelDoc.graveyard;
@@ -930,7 +930,7 @@ describe( 'debug tools', () => {
 			const firstEle = new ModelElement( 'paragraph' );
 			const removedEle = new ModelElement( 'paragraph', null, [ new ModelText( 'foo' ) ] );
 
-			otherRoot._appendChildren( [ firstEle, removedEle ] );
+			otherRoot._appendChild( [ firstEle, removedEle ] );
 
 			const delta = new MergeDelta();
 			const graveyard = modelDoc.graveyard;

--- a/tests/dev-utils/model.js
+++ b/tests/dev-utils/model.js
@@ -57,7 +57,7 @@ describe( 'model test utils', () => {
 	describe( 'getData', () => {
 		it( 'should use stringify method', () => {
 			const stringifySpy = sandbox.spy( getData, '_stringify' );
-			root._appendChildren( new Element( 'b', null, new Text( 'btext' ) ) );
+			root._appendChild( new Element( 'b', null, new Text( 'btext' ) ) );
 
 			expect( getData( model, { withoutSelection: true } ) ).to.equal( '<b>btext</b>' );
 			sinon.assert.calledOnce( stringifySpy );
@@ -66,7 +66,7 @@ describe( 'model test utils', () => {
 
 		it( 'should use stringify method with selection', () => {
 			const stringifySpy = sandbox.spy( getData, '_stringify' );
-			root._appendChildren( new Element( 'b', null, new Text( 'btext' ) ) );
+			root._appendChild( new Element( 'b', null, new Text( 'btext' ) ) );
 			model.change( writer => {
 				writer.setSelection( Range.createFromParentsAndOffsets( root, 0, root, 1 ) );
 			} );
@@ -214,7 +214,7 @@ describe( 'model test utils', () => {
 		} );
 
 		it( 'writes elements and texts', () => {
-			root._appendChildren( [
+			root._appendChild( [
 				new Element( 'a', null, new Text( 'atext' ) ),
 				new Element( 'b', null, [
 					new Element( 'c1' ),
@@ -230,7 +230,7 @@ describe( 'model test utils', () => {
 		} );
 
 		it( 'writes element attributes', () => {
-			root._appendChildren(
+			root._appendChild(
 				new Element( 'a', { foo: true, bar: 1, car: false }, [
 					new Element( 'b', { fooBar: 'x y', barFoo: { x: 1, y: 2 } } )
 				] )
@@ -244,7 +244,7 @@ describe( 'model test utils', () => {
 		} );
 
 		it( 'writes text attributes', () => {
-			root._appendChildren( [
+			root._appendChild( [
 				new Text( 'foo', { bold: true } ),
 				new Text( 'bar' ),
 				new Text( 'bom', { bold: true, italic: true } ),
@@ -260,7 +260,7 @@ describe( 'model test utils', () => {
 		} );
 
 		it( 'writes unicode text', () => {
-			root._appendChildren( new Text( 'நிலைக்கு' ) );
+			root._appendChild( new Text( 'நிலைக்கு' ) );
 
 			expect( stringify( root ) ).to.equal( 'நிலைக்கு' );
 		} );
@@ -272,7 +272,7 @@ describe( 'model test utils', () => {
 				elA = new Element( 'a' );
 				elB = new Element( 'b' );
 
-				root._appendChildren( [
+				root._appendChild( [
 					elA,
 					new Text( 'foo' ),
 					new Text( 'bar', { bold: true } ),
@@ -397,7 +397,7 @@ describe( 'model test utils', () => {
 			it( 'writes selection in unicode text', () => {
 				const root = document.createRoot( '$root', 'empty' );
 
-				root._appendChildren( new Text( 'நிலைக்கு' ) );
+				root._appendChild( new Text( 'நிலைக்கு' ) );
 				model.change( writer => {
 					writer.setSelection( Range.createFromParentsAndOffsets( root, 2, root, 6 ) );
 				} );

--- a/tests/dev-utils/view.js
+++ b/tests/dev-utils/view.js
@@ -40,7 +40,7 @@ describe( 'view test utils', () => {
 				const viewDocument = view.document;
 				const options = { showType: false, showPriority: false, withoutSelection: true };
 				const root = createAttachedRoot( viewDocument, element );
-				root._appendChildren( new Element( 'p' ) );
+				root._appendChild( new Element( 'p' ) );
 
 				expect( getData( view, options ) ).to.equal( '<p></p>' );
 				sinon.assert.calledOnce( stringifySpy );
@@ -61,7 +61,7 @@ describe( 'view test utils', () => {
 				const viewDocument = view.document;
 				const options = { showType: false, showPriority: false };
 				const root = createAttachedRoot( viewDocument, element );
-				root._appendChildren( new Element( 'p' ) );
+				root._appendChild( new Element( 'p' ) );
 
 				view.change( writer => {
 					writer.setSelection( Range.createFromParentsAndOffsets( root, 0, root, 1 ) );

--- a/tests/model/delta/renamedelta.js
+++ b/tests/model/delta/renamedelta.js
@@ -39,7 +39,7 @@ describe( 'RenameDelta', () => {
 		} );
 
 		it( 'should return correct RenameDelta', () => {
-			root._appendChildren( new Element( 'p', null, new Text( 'abc' ) ) );
+			root._appendChild( new Element( 'p', null, new Text( 'abc' ) ) );
 
 			model.change( writer => {
 				writer.rename( root.getChild( 0 ), 'h' );

--- a/tests/model/delta/transform/_utils/utils.js
+++ b/tests/model/delta/transform/_utils/utils.js
@@ -225,7 +225,7 @@ export function getFilledDocument() {
 	const doc = model.document;
 	const root = doc.createRoot();
 
-	root._insertChildren( 0, [
+	root._insertChild( 0, [
 		new Element( 'x' ),
 		new Element( 'x' ),
 		new Element( 'x', [], new Text( 'a' ) ),

--- a/tests/model/delta/transform/transform.js
+++ b/tests/model/delta/transform/transform.js
@@ -44,7 +44,7 @@ describe( 'transform', () => {
 		doc = model.document;
 		root = doc.createRoot();
 
-		root._appendChildren( new Element( 'p', null, new Text( 'foobar' ) ) );
+		root._appendChild( new Element( 'p', null, new Text( 'foobar' ) ) );
 
 		baseVersion = doc.version;
 	} );

--- a/tests/model/differ.js
+++ b/tests/model/differ.js
@@ -27,7 +27,7 @@ describe( 'Differ', () => {
 
 		root = doc.createRoot();
 
-		root._appendChildren( [
+		root._appendChild( [
 			new Element( 'paragraph', null, [
 				new Text( 'foo' )
 			] ),
@@ -615,7 +615,7 @@ describe( 'Differ', () => {
 		} );
 
 		it( 'reinsert removed element', () => {
-			doc.graveyard._appendChildren( new Element( 'listItem' ) );
+			doc.graveyard._appendChild( new Element( 'listItem' ) );
 
 			const sourcePosition = new Position( doc.graveyard, [ 0 ] );
 			const targetPosition = new Position( root, [ 2 ] );
@@ -1252,7 +1252,7 @@ describe( 'Differ', () => {
 			// In a result, removing `paragraph` was discarded.
 			// The mistake was that the checking for removing was done at incorrect moment.
 			root._removeChildren( 0, root.childCount );
-			root._appendChildren( [
+			root._appendChild( [
 				new Element( 'paragraph', null, new Text( 'foo' ) ),
 				new Element( 'image' ),
 				new Element( 'blockQuote', null, [
@@ -1283,7 +1283,7 @@ describe( 'Differ', () => {
 		// inserted children should not be shown on changes list.
 		it( 'proper filtering of changes in inserted elements', () => {
 			root._removeChildren( 0, root.childCount );
-			root._appendChildren( new Element( 'image' ) );
+			root._appendChild( new Element( 'image' ) );
 
 			const blockQuote = new Element( 'blockQuote', null, new Element( 'paragraph' ) );
 
@@ -1307,7 +1307,7 @@ describe( 'Differ', () => {
 		// Since we are inserting into a new element, the insertion of moved element should not be shown on changes list.
 		it( 'proper filtering of changes in inserted elements #2', () => {
 			root._removeChildren( 0, root.childCount );
-			root._appendChildren( new Element( 'image' ) );
+			root._appendChild( new Element( 'image' ) );
 
 			model.change( () => {
 				// Insert `div` after `image`.

--- a/tests/model/document.js
+++ b/tests/model/document.js
@@ -343,7 +343,7 @@ describe( 'Document', () => {
 			const spy = sinon.spy();
 
 			const root = doc.getRoot();
-			root._appendChildren( new Text( 'foo' ) );
+			root._appendChild( new Text( 'foo' ) );
 
 			doc.on( 'change', spy );
 

--- a/tests/model/documentfragment.js
+++ b/tests/model/documentfragment.js
@@ -126,10 +126,10 @@ describe( 'DocumentFragment', () => {
 		} );
 	} );
 
-	describe( '_insertChildren', () => {
+	describe( '_insertChild', () => {
 		it( 'should add children to the document fragment', () => {
 			const frag = new DocumentFragment( new Text( 'xy' ) );
-			frag._insertChildren( 1, new Text( 'foo' ) );
+			frag._insertChild( 1, new Text( 'foo' ) );
 
 			expect( frag.childCount ).to.equal( 2 );
 			expect( frag.maxOffset ).to.equal( 5 );
@@ -140,13 +140,13 @@ describe( 'DocumentFragment', () => {
 		it( 'should accept strings and arrays', () => {
 			const frag = new DocumentFragment();
 
-			frag._insertChildren( 0, 'abc' );
+			frag._insertChild( 0, 'abc' );
 			expect( frag.childCount ).to.equal( 1 );
 			expect( frag.maxOffset ).to.equal( 3 );
 			expect( frag.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'abc' );
 
 			frag._removeChildren( 0, 1 );
-			frag._insertChildren( 0, [ new Element( 'p' ), 'abc' ] );
+			frag._insertChild( 0, [ new Element( 'p' ), 'abc' ] );
 
 			expect( frag.childCount ).to.equal( 2 );
 			expect( frag.maxOffset ).to.equal( 4 );
@@ -159,7 +159,7 @@ describe( 'DocumentFragment', () => {
 			const text = new Text( 'abcxyz', { bold: true } );
 			const textProxy = new TextProxy( text, 2, 3 );
 
-			frag._insertChildren( 0, textProxy );
+			frag._insertChild( 0, textProxy );
 
 			expect( frag.childCount ).to.equal( 1 );
 			expect( frag.maxOffset ).to.equal( 3 );
@@ -169,10 +169,10 @@ describe( 'DocumentFragment', () => {
 		} );
 	} );
 
-	describe( '_appendChildren', () => {
+	describe( '_appendChild', () => {
 		it( 'should add children to the end of the element', () => {
 			const frag = new DocumentFragment( new Text( 'xy' ) );
-			frag._appendChildren( new Text( 'foo' ) );
+			frag._appendChild( new Text( 'foo' ) );
 
 			expect( frag.childCount ).to.equal( 2 );
 			expect( frag.maxOffset ).to.equal( 5 );

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -34,7 +34,7 @@ describe( 'DocumentSelection', () => {
 		model = new Model();
 		doc = model.document;
 		root = doc.createRoot();
-		root._appendChildren( [
+		root._appendChild( [
 			new Element( 'p' ),
 			new Element( 'p' ),
 			new Element( 'p', [], new Text( 'foobar' ) ),
@@ -73,7 +73,7 @@ describe( 'DocumentSelection', () => {
 			model = new Model();
 			doc = model.document;
 			root = doc.createRoot();
-			root._insertChildren( 0, new Text( 'foobar' ) );
+			root._insertChild( 0, new Text( 'foobar' ) );
 			selection = doc.selection;
 
 			const ranges = Array.from( selection.getRanges() );
@@ -89,7 +89,7 @@ describe( 'DocumentSelection', () => {
 			model = new Model();
 			doc = model.document;
 			root = doc.createRoot();
-			root._insertChildren( 0, [
+			root._insertChild( 0, [
 				new Element( 'img' ),
 				new Element( 'p', [], new Text( 'foobar' ) )
 			] );
@@ -113,7 +113,7 @@ describe( 'DocumentSelection', () => {
 		} );
 
 		it( 'should be false for the default range (object selection) ', () => {
-			root._insertChildren( 0, new Element( 'widget' ) );
+			root._insertChild( 0, new Element( 'widget' ) );
 
 			expect( selection.isCollapsed ).to.be.false;
 		} );
@@ -133,7 +133,7 @@ describe( 'DocumentSelection', () => {
 		} );
 
 		it( 'should equal the default range\'s start (object selection)', () => {
-			root._insertChildren( 0, new Element( 'widget' ) );
+			root._insertChild( 0, new Element( 'widget' ) );
 
 			const expectedPos = new Position( root, [ 0 ] );
 
@@ -155,7 +155,7 @@ describe( 'DocumentSelection', () => {
 		} );
 
 		it( 'should equal the default range\'s end (object selection)', () => {
-			root._insertChildren( 0, new Element( 'widget' ) );
+			root._insertChild( 0, new Element( 'widget' ) );
 
 			const expectedPos = new Position( root, [ 1 ] );
 
@@ -406,7 +406,7 @@ describe( 'DocumentSelection', () => {
 
 		beforeEach( () => {
 			root._removeChildren( 0, root.childCount );
-			root._appendChildren( [
+			root._appendChild( [
 				new Element( 'p', [], new Text( 'foobar' ) ),
 				new Element( 'p', [], [] )
 			] );
@@ -466,7 +466,7 @@ describe( 'DocumentSelection', () => {
 
 		describe( 'are updated on a direct range change', () => {
 			beforeEach( () => {
-				root._insertChildren( 0, [
+				root._insertChild( 0, [
 					new Element( 'p', { p: true } ),
 					new Text( 'a', { a: true } ),
 					new Element( 'p', { p: true } ),
@@ -666,7 +666,7 @@ describe( 'DocumentSelection', () => {
 
 			it( 'are removed when containing element is merged with a non-empty element', () => {
 				const emptyP2 = new Element( 'p', null, 'x' );
-				root._appendChildren( emptyP2 );
+				root._appendChild( emptyP2 );
 
 				emptyP._setAttribute( fooStoreAttrKey, 'bar' );
 				emptyP2._setAttribute( fooStoreAttrKey, 'bar' );
@@ -695,7 +695,7 @@ describe( 'DocumentSelection', () => {
 			it( 'are removed only once in case of multi-op deltas', () => {
 				let batch;
 				const emptyP2 = new Element( 'p', null, 'x' );
-				root._appendChildren( emptyP2 );
+				root._appendChild( emptyP2 );
 
 				emptyP._setAttribute( fooStoreAttrKey, 'bar' );
 				emptyP2._setAttribute( fooStoreAttrKey, 'bar' );
@@ -728,7 +728,7 @@ describe( 'DocumentSelection', () => {
 
 			it( 'are not removed or merged when containing element is merged with another empty element', () => {
 				const emptyP2 = new Element( 'p', null );
-				root._appendChildren( emptyP2 );
+				root._appendChild( emptyP2 );
 
 				emptyP._setAttribute( fooStoreAttrKey, 'bar' );
 				emptyP2._setAttribute( abcStoreAttrKey, 'bar' );
@@ -885,7 +885,7 @@ describe( 'DocumentSelection', () => {
 
 		beforeEach( () => {
 			root._removeChildren( 0, root.childCount );
-			root._insertChildren( 0, [
+			root._insertChild( 0, [
 				new Element( 'p', [], new Text( 'abcdef' ) ),
 				new Element( 'p', [], new Text( 'foobar' ) ),
 				new Text( 'xyz' )
@@ -1223,7 +1223,7 @@ describe( 'DocumentSelection', () => {
 
 		it( '`DocumentSelection#change:range` event should be fire once even if selection contains multi-ranges', () => {
 			root._removeChildren( 0, root.childCount );
-			root._insertChildren( 0, [
+			root._insertChild( 0, [
 				new Element( 'p', [], new Text( 'abcdef' ) ),
 				new Element( 'p', [], new Text( 'foobar' ) ),
 				new Text( 'xyz #2' )
@@ -1251,7 +1251,7 @@ describe( 'DocumentSelection', () => {
 
 	it( 'should throw if one of ranges starts or ends inside surrogate pair', () => {
 		root._removeChildren( 0, root.childCount );
-		root._appendChildren( '\uD83D\uDCA9' );
+		root._appendChild( '\uD83D\uDCA9' );
 
 		expect( () => {
 			doc.selection._setTo( Range.createFromParentsAndOffsets( root, 0, root, 1 ) );
@@ -1264,7 +1264,7 @@ describe( 'DocumentSelection', () => {
 
 	it( 'should throw if one of ranges starts or ends between base character and combining mark', () => {
 		root._removeChildren( 0, root.childCount );
-		root._appendChildren( 'foo̻̐ͩbar' );
+		root._appendChild( 'foo̻̐ͩbar' );
 
 		expect( () => {
 			doc.selection._setTo( Range.createFromParentsAndOffsets( root, 3, root, 9 ) );

--- a/tests/model/element.js
+++ b/tests/model/element.js
@@ -98,10 +98,10 @@ describe( 'Element', () => {
 		} );
 	} );
 
-	describe( '_insertChildren', () => {
+	describe( '_insertChild', () => {
 		it( 'should add a child to the element', () => {
 			const element = new Element( 'elem', [], new Text( 'xy' ) );
-			element._insertChildren( 1, new Text( 'foo' ) );
+			element._insertChild( 1, new Text( 'foo' ) );
 
 			expect( element.childCount ).to.equal( 2 );
 			expect( element.maxOffset ).to.equal( 5 );
@@ -111,7 +111,7 @@ describe( 'Element', () => {
 
 		it( 'should accept arrays and strings', () => {
 			const element = new Element( 'elem' );
-			element._insertChildren( 0, [ new Element( 'image' ), 'xy', new Element( 'list' ) ] );
+			element._insertChild( 0, [ new Element( 'image' ), 'xy', new Element( 'list' ) ] );
 
 			expect( element.childCount ).to.equal( 3 );
 			expect( element.maxOffset ).to.equal( 4 );
@@ -122,7 +122,7 @@ describe( 'Element', () => {
 
 		it( 'should accept strings', () => {
 			const element = new Element( 'div' );
-			element._insertChildren( 0, 'abc' );
+			element._insertChild( 0, 'abc' );
 
 			expect( element.childCount ).to.equal( 1 );
 			expect( element.maxOffset ).to.equal( 3 );
@@ -134,7 +134,7 @@ describe( 'Element', () => {
 			const text = new Text( 'abcxyz', { bold: true } );
 			const textProxy = new TextProxy( text, 2, 3 );
 
-			element._insertChildren( 0, textProxy );
+			element._insertChild( 0, textProxy );
 
 			expect( element.childCount ).to.equal( 1 );
 			expect( element.maxOffset ).to.equal( 3 );
@@ -144,16 +144,16 @@ describe( 'Element', () => {
 		} );
 	} );
 
-	describe( '_appendChildren', () => {
-		it( 'should use _insertChildren to add children at the end of the element', () => {
+	describe( '_appendChild', () => {
+		it( 'should use _insertChild to add children at the end of the element', () => {
 			const element = new Element( 'elem', [], new Text( 'xy' ) );
 
-			sinon.spy( element, '_insertChildren' );
+			sinon.spy( element, '_insertChild' );
 
 			const text = new Text( 'foo' );
-			element._appendChildren( text );
+			element._appendChild( text );
 
-			expect( element._insertChildren.calledWithExactly( 0, text ) );
+			expect( element._insertChild.calledWithExactly( 0, text ) );
 		} );
 	} );
 

--- a/tests/model/liveposition.js
+++ b/tests/model/liveposition.js
@@ -26,7 +26,7 @@ describe( 'LivePosition', () => {
 		ul = new Element( 'ul', [], [ li1, li2 ] );
 		p = new Element( 'p', [], new Text( 'qwerty' ) );
 
-		root._insertChildren( 0, [ p, ul ] );
+		root._insertChild( 0, [ p, ul ] );
 	} );
 
 	afterEach( () => {

--- a/tests/model/liverange.js
+++ b/tests/model/liverange.js
@@ -34,7 +34,7 @@ describe( 'LiveRange', () => {
 		ul = new Element( 'ul', [], lis );
 		p = new Element( 'p', [], new Text( 'qwertyuiop' ) );
 
-		root._insertChildren( 0, [ ul, p, new Text( 'xyzxyz' ) ] );
+		root._insertChild( 0, [ ul, p, new Text( 'xyzxyz' ) ] );
 	} );
 
 	it( 'should be an instance of Range', () => {

--- a/tests/model/markercollection.js
+++ b/tests/model/markercollection.js
@@ -241,7 +241,7 @@ describe( 'Marker', () => {
 	} );
 
 	it( 'should provide API that returns up-to-date marker range parameters', () => {
-		root._appendChildren( new Text( 'foo' ) );
+		root._appendChild( new Text( 'foo' ) );
 
 		const range = Range.createFromParentsAndOffsets( root, 1, root, 2 );
 		const marker = model.markers._set( 'name', range );

--- a/tests/model/node.js
+++ b/tests/model/node.js
@@ -30,7 +30,7 @@ describe( 'Node', () => {
 
 		doc = model.document;
 		root = doc.createRoot();
-		root._appendChildren( [ one, two, three ] );
+		root._appendChild( [ one, two, three ] );
 	} );
 
 	describe( 'should have a correct property', () => {
@@ -91,7 +91,7 @@ describe( 'Node', () => {
 
 			// DocumentFragment does not have document property, so node's document property should be null.
 			const docFrag = new DocumentFragment();
-			docFrag._appendChildren( node );
+			docFrag._appendChild( node );
 			expect( node ).to.have.property( 'document' ).that.is.null;
 		} );
 	} );
@@ -149,7 +149,7 @@ describe( 'Node', () => {
 	describe( '_remove()', () => {
 		it( 'should remove node from it\'s parent', () => {
 			const element = new Element( 'p' );
-			element._appendChildren( node );
+			element._appendChild( node );
 
 			node._remove();
 
@@ -357,7 +357,7 @@ describe( 'Node', () => {
 			const otherRoot = new Element( 'root' );
 			const otherElement = new Element( 'element' );
 
-			otherRoot._appendChildren( otherElement );
+			otherRoot._appendChild( otherElement );
 
 			expect( otherElement.isBefore( three ) ).to.be.false;
 		} );
@@ -395,7 +395,7 @@ describe( 'Node', () => {
 			const otherRoot = new Element( 'root' );
 			const otherElement = new Element( 'element' );
 
-			otherRoot._appendChildren( otherElement );
+			otherRoot._appendChild( otherElement );
 
 			expect( three.isAfter( otherElement ) ).to.be.false;
 		} );

--- a/tests/model/operation/attributeoperation.js
+++ b/tests/model/operation/attributeoperation.js
@@ -61,7 +61,7 @@ describe( 'AttributeOperation', () => {
 	} );
 
 	it( 'should insert attribute to the set of nodes', () => {
-		root._insertChildren( 0, new Text( 'bar' ) );
+		root._insertChild( 0, new Text( 'bar' ) );
 
 		model.applyOperation( wrapInDelta(
 			new AttributeOperation(
@@ -82,7 +82,7 @@ describe( 'AttributeOperation', () => {
 	} );
 
 	it( 'should add attribute to the existing attributes', () => {
-		root._insertChildren( 0, new Text( 'x', { foo: true, bar: true } ) );
+		root._insertChild( 0, new Text( 'x', { foo: true, bar: true } ) );
 
 		model.applyOperation( wrapInDelta(
 			new AttributeOperation(
@@ -103,7 +103,7 @@ describe( 'AttributeOperation', () => {
 	} );
 
 	it( 'should change attribute to the set of nodes', () => {
-		root._insertChildren( 0, new Text( 'bar', { isNew: false } ) );
+		root._insertChild( 0, new Text( 'bar', { isNew: false } ) );
 
 		model.applyOperation( wrapInDelta(
 			new AttributeOperation(
@@ -124,7 +124,7 @@ describe( 'AttributeOperation', () => {
 	} );
 
 	it( 'should change attribute in the middle of existing attributes', () => {
-		root._insertChildren( 0, new Text( 'x', { foo: true, x: 1, bar: true } ) );
+		root._insertChild( 0, new Text( 'x', { foo: true, x: 1, bar: true } ) );
 
 		model.applyOperation( wrapInDelta(
 			new AttributeOperation(
@@ -145,7 +145,7 @@ describe( 'AttributeOperation', () => {
 	} );
 
 	it( 'should work correctly if old and new value are same', () => {
-		root._insertChildren( 0, new Text( 'bar', { foo: 'bar' } ) );
+		root._insertChild( 0, new Text( 'bar', { foo: 'bar' } ) );
 
 		model.applyOperation( wrapInDelta(
 			new AttributeOperation(
@@ -164,7 +164,7 @@ describe( 'AttributeOperation', () => {
 	} );
 
 	it( 'should remove attribute', () => {
-		root._insertChildren( 0, new Text( 'x', { foo: true, x: true, bar: true } ) );
+		root._insertChild( 0, new Text( 'x', { foo: true, x: true, bar: true } ) );
 
 		model.applyOperation( wrapInDelta(
 			new AttributeOperation(
@@ -185,7 +185,7 @@ describe( 'AttributeOperation', () => {
 
 	describe( '_validate()', () => {
 		it( 'should not throw for non-primitive attribute values', () => {
-			root._insertChildren( 0, new Text( 'x', { foo: [ 'bar', 'xyz' ] } ) );
+			root._insertChild( 0, new Text( 'x', { foo: [ 'bar', 'xyz' ] } ) );
 
 			expect( () => {
 				const operation = new AttributeOperation(
@@ -201,7 +201,7 @@ describe( 'AttributeOperation', () => {
 		} );
 
 		it( 'should throw an error when one try to remove and the attribute does not exists', () => {
-			root._insertChildren( 0, new Text( 'x' ) );
+			root._insertChild( 0, new Text( 'x' ) );
 
 			expect( () => {
 				const operation = new AttributeOperation(
@@ -217,7 +217,7 @@ describe( 'AttributeOperation', () => {
 		} );
 
 		it( 'should throw an error when one try to insert and the attribute already exists', () => {
-			root._insertChildren( 0, new Text( 'x', { x: 1 } ) );
+			root._insertChild( 0, new Text( 'x', { x: 1 } ) );
 
 			expect( () => {
 				const operation = new AttributeOperation(
@@ -233,7 +233,7 @@ describe( 'AttributeOperation', () => {
 		} );
 
 		it( 'should not throw when attribute value is the same', () => {
-			root._insertChildren( 0, new Text( 'x', { foo: true } ) );
+			root._insertChild( 0, new Text( 'x', { foo: true } ) );
 
 			expect( () => {
 				const operation = new AttributeOperation(
@@ -263,7 +263,7 @@ describe( 'AttributeOperation', () => {
 	} );
 
 	it( 'should undo adding attribute by applying reverse operation', () => {
-		root._insertChildren( 0, new Text( 'bar' ) );
+		root._insertChild( 0, new Text( 'bar' ) );
 
 		const operation = new AttributeOperation(
 			new Range( new Position( root, [ 0 ] ), new Position( root, [ 3 ] ) ),
@@ -287,7 +287,7 @@ describe( 'AttributeOperation', () => {
 		const eleA = new Element( 'a', [], new Text( 'abc' ) );
 		const eleB = new Element( 'b', [], new Text( 'xyz' ) );
 
-		root._insertChildren( 0, [ eleA, eleB ] );
+		root._insertChild( 0, [ eleA, eleB ] );
 
 		model.applyOperation( wrapInDelta(
 			new AttributeOperation(
@@ -308,7 +308,7 @@ describe( 'AttributeOperation', () => {
 		const eleA = new Element( 'a', fooAttr, new Text( 'abc' ) );
 		const eleB = new Element( 'b', fooAttr, new Text( 'xyz' ) );
 
-		root._insertChildren( 0, [ eleA, eleB ] );
+		root._insertChild( 0, [ eleA, eleB ] );
 
 		model.applyOperation( wrapInDelta(
 			new AttributeOperation(
@@ -324,7 +324,7 @@ describe( 'AttributeOperation', () => {
 	} );
 
 	it( 'should undo changing attribute by applying reverse operation', () => {
-		root._insertChildren( 0, new Text( 'bar', { isNew: false } ) );
+		root._insertChild( 0, new Text( 'bar', { isNew: false } ) );
 
 		const operation = new AttributeOperation(
 			new Range( new Position( root, [ 0 ] ), new Position( root, [ 3 ] ) ),
@@ -346,7 +346,7 @@ describe( 'AttributeOperation', () => {
 	} );
 
 	it( 'should undo remove attribute by applying reverse operation', () => {
-		root._insertChildren( 0, new Text( 'bar', { foo: true } ) );
+		root._insertChild( 0, new Text( 'bar', { foo: true } ) );
 
 		const operation = new AttributeOperation(
 			new Range( new Position( root, [ 0 ] ), new Position( root, [ 3 ] ) ),
@@ -390,8 +390,8 @@ describe( 'AttributeOperation', () => {
 		const attrA = { foo: 'a' };
 		const attrB = { foo: 'b' };
 
-		root._insertChildren( 0, new Text( 'abc', attrA ) );
-		root._insertChildren( 1, new Text( 'xyz', attrB ) );
+		root._insertChild( 0, new Text( 'abc', attrA ) );
+		root._insertChild( 1, new Text( 'xyz', attrB ) );
 
 		model.applyOperation( wrapInDelta(
 			new AttributeOperation(

--- a/tests/model/operation/detachoperation.js
+++ b/tests/model/operation/detachoperation.js
@@ -40,7 +40,7 @@ describe( 'DetachOperation', () => {
 			const root = doc.createRoot();
 			const element = new Element( 'element' );
 
-			root._appendChildren( [ element ] );
+			root._appendChild( [ element ] );
 
 			const op = new DetachOperation( Position.createBefore( element ), 1 );
 

--- a/tests/model/operation/insertoperation.js
+++ b/tests/model/operation/insertoperation.js
@@ -78,7 +78,7 @@ describe( 'InsertOperation', () => {
 	} );
 
 	it( 'should insert between existing nodes', () => {
-		root._insertChildren( 0, new Text( 'xy' ) );
+		root._insertChild( 0, new Text( 'xy' ) );
 
 		model.applyOperation( wrapInDelta(
 			new InsertOperation(

--- a/tests/model/operation/markeroperation.js
+++ b/tests/model/operation/markeroperation.js
@@ -20,7 +20,7 @@ describe( 'MarkerOperation', () => {
 		model = new Model();
 		doc = model.document;
 		root = doc.createRoot();
-		root._appendChildren( new Text( 'foo' ) );
+		root._appendChild( new Text( 'foo' ) );
 		range = Range.createFromParentsAndOffsets( root, 0, root, 0 );
 	} );
 

--- a/tests/model/operation/moveoperation.js
+++ b/tests/model/operation/moveoperation.js
@@ -46,7 +46,7 @@ describe( 'MoveOperation', () => {
 		const p1 = new Element( 'p1', [], new Element( 'x' ) );
 		const p2 = new Element( 'p2' );
 
-		root._insertChildren( 0, [ p1, p2 ] );
+		root._insertChild( 0, [ p1, p2 ] );
 
 		model.applyOperation( wrapInDelta(
 			new MoveOperation(
@@ -67,7 +67,7 @@ describe( 'MoveOperation', () => {
 	} );
 
 	it( 'should move position of children in one node backward', () => {
-		root._insertChildren( 0, new Text( 'xbarx' ) );
+		root._insertChild( 0, new Text( 'xbarx' ) );
 
 		model.applyOperation( wrapInDelta(
 			new MoveOperation(
@@ -84,7 +84,7 @@ describe( 'MoveOperation', () => {
 	} );
 
 	it( 'should move position of children in one node forward', () => {
-		root._insertChildren( 0, new Text( 'xbarx' ) );
+		root._insertChild( 0, new Text( 'xbarx' ) );
 
 		model.applyOperation( wrapInDelta(
 			new MoveOperation(
@@ -124,7 +124,7 @@ describe( 'MoveOperation', () => {
 		const p1 = new Element( 'p1', [], new Element( 'x' ) );
 		const p2 = new Element( 'p2' );
 
-		root._insertChildren( 0, [ p1, p2 ] );
+		root._insertChild( 0, [ p1, p2 ] );
 
 		const operation = new MoveOperation(
 			new Position( root, [ 0, 0 ] ),
@@ -152,7 +152,7 @@ describe( 'MoveOperation', () => {
 
 	describe( '_validate()', () => {
 		it( 'should throw an error if number of nodes to move exceeds the number of existing nodes in given element', () => {
-			root._insertChildren( 0, new Text( 'xbarx' ) );
+			root._insertChild( 0, new Text( 'xbarx' ) );
 
 			const operation = new MoveOperation(
 				new Position( root, [ 3 ] ),
@@ -166,8 +166,8 @@ describe( 'MoveOperation', () => {
 
 		it( 'should throw an error if target or source parent-element specified by position does not exist', () => {
 			const p = new Element( 'p' );
-			p._insertChildren( 0, new Text( 'foo' ) );
-			root._insertChildren( 0, [ new Text( 'ab' ), p ] );
+			p._insertChild( 0, new Text( 'foo' ) );
+			root._insertChild( 0, [ new Text( 'ab' ), p ] );
 
 			const operation = new MoveOperation(
 				new Position( root, [ 2, 0 ] ),
@@ -182,7 +182,7 @@ describe( 'MoveOperation', () => {
 		} );
 
 		it( 'should throw an error if operation tries to move a range between the beginning and the end of that range', () => {
-			root._insertChildren( 0, new Text( 'xbarx' ) );
+			root._insertChild( 0, new Text( 'xbarx' ) );
 
 			const operation = new MoveOperation(
 				new Position( root, [ 1 ] ),
@@ -196,7 +196,7 @@ describe( 'MoveOperation', () => {
 
 		it( 'should throw an error if operation tries to move a range into a sub-tree of a node that is in that range', () => {
 			const p = new Element( 'p', [], [ new Element( 'p' ) ] );
-			root._insertChildren( 0, [ new Text( 'ab' ), p, new Text( 'xy' ) ] );
+			root._insertChild( 0, [ new Text( 'ab' ), p, new Text( 'xy' ) ] );
 
 			const operation = new MoveOperation(
 				new Position( root, [ 1 ] ),
@@ -210,7 +210,7 @@ describe( 'MoveOperation', () => {
 
 		it( 'should not throw an error if operation move a range into a sibling', () => {
 			const p = new Element( 'p' );
-			root._insertChildren( 0, [ new Text( 'ab' ), p, new Text( 'xy' ) ] );
+			root._insertChild( 0, [ new Text( 'ab' ), p, new Text( 'xy' ) ] );
 
 			const operation = new MoveOperation(
 				new Position( root, [ 1 ] ),
@@ -224,8 +224,8 @@ describe( 'MoveOperation', () => {
 
 		it( 'should not throw when operation paths looks like incorrect but move is between different roots', () => {
 			const p = new Element( 'p' );
-			root._insertChildren( 0, [ new Text( 'a' ), p, new Text( 'b' ) ] );
-			doc.graveyard._insertChildren( 0, new Text( 'abc' ) );
+			root._insertChild( 0, [ new Text( 'a' ), p, new Text( 'b' ) ] );
+			doc.graveyard._insertChild( 0, new Text( 'abc' ) );
 
 			const operation = new MoveOperation(
 				new Position( doc.graveyard, [ 0 ] ),

--- a/tests/model/operation/reinsertoperation.js
+++ b/tests/model/operation/reinsertoperation.js
@@ -65,7 +65,7 @@ describe( 'ReinsertOperation', () => {
 	} );
 
 	it( 'should create RemoveOperation as a reverse', () => {
-		graveyard._appendChildren( new Element( 'x' ) );
+		graveyard._appendChild( new Element( 'x' ) );
 
 		const reverse = operation.getReversed();
 
@@ -87,7 +87,7 @@ describe( 'ReinsertOperation', () => {
 	it( 'should undo reinsert set of nodes by applying reverse operation', () => {
 		const reverse = operation.getReversed();
 
-		graveyard._insertChildren( 0, new Text( 'xx' ) );
+		graveyard._insertChild( 0, new Text( 'xx' ) );
 
 		model.applyOperation( wrapInDelta( operation ) );
 
@@ -106,7 +106,7 @@ describe( 'ReinsertOperation', () => {
 		it( 'should throw when target position is not in the document', () => {
 			const docFrag = new DocumentFragment();
 
-			graveyard._insertChildren( 0, new Text( 'xx' ) );
+			graveyard._insertChild( 0, new Text( 'xx' ) );
 
 			operation = new ReinsertOperation(
 				graveyardPosition,

--- a/tests/model/operation/removeoperation.js
+++ b/tests/model/operation/removeoperation.js
@@ -58,7 +58,7 @@ describe( 'RemoveOperation', () => {
 	} );
 
 	it( 'should be able to remove set of nodes and append them to graveyard root', () => {
-		root._insertChildren( 0, new Text( 'fozbar' ) );
+		root._insertChild( 0, new Text( 'fozbar' ) );
 
 		model.applyOperation( wrapInDelta(
 			new RemoveOperation(
@@ -115,7 +115,7 @@ describe( 'RemoveOperation', () => {
 		const operation = new RemoveOperation( position, 3, new Position( doc.graveyard, [ 0 ] ), 0 );
 		const reverse = operation.getReversed();
 
-		root._insertChildren( 0, new Text( 'bar' ) );
+		root._insertChild( 0, new Text( 'bar' ) );
 
 		model.applyOperation( wrapInDelta( operation ) );
 
@@ -130,7 +130,7 @@ describe( 'RemoveOperation', () => {
 	} );
 
 	it( 'should properly remove a node that is already in a graveyard', () => {
-		doc.graveyard._appendChildren( [ new Element( 'x' ), new Element( 'y' ), new Element( 'z' ) ] );
+		doc.graveyard._appendChild( [ new Element( 'x' ), new Element( 'y' ), new Element( 'z' ) ] );
 
 		const position = new Position( doc.graveyard, [ 2 ] );
 		const operation = new RemoveOperation( position, 1, new Position( doc.graveyard, [ 0 ] ), 0 );
@@ -148,7 +148,7 @@ describe( 'RemoveOperation', () => {
 			const docFrag = new DocumentFragment();
 			const item = new Element( 'foo' );
 
-			docFrag._appendChildren( [ item ] );
+			docFrag._appendChild( [ item ] );
 
 			const op = new RemoveOperation(
 				new Position( docFrag, [ 0 ] ),

--- a/tests/model/operation/renameoperation.js
+++ b/tests/model/operation/renameoperation.js
@@ -22,7 +22,7 @@ describe( 'RenameOperation', () => {
 		root = doc.createRoot();
 
 		element = new Element( oldName );
-		root._appendChildren( element );
+		root._appendChild( element );
 
 		position = Position.createBefore( element );
 	} );

--- a/tests/model/operation/rootattributeoperation.js
+++ b/tests/model/operation/rootattributeoperation.js
@@ -180,7 +180,7 @@ describe( 'RootAttributeOperation', () => {
 		it( 'should throw an error when trying to change non-root element', () => {
 			const child = new Element( 'p' );
 			const parent = new Element( 'p' );
-			parent._appendChildren( child );
+			parent._appendChild( child );
 
 			expect( () => {
 				const op = new RootAttributeOperation(

--- a/tests/model/operation/utils.js
+++ b/tests/model/operation/utils.js
@@ -29,7 +29,7 @@ describe( 'Operation utils', () => {
 		// offset:	0123456789
 		// data:	foobarIxyz
 		// bold:	___BBBB___
-		root._appendChildren( [
+		root._appendChild( [
 			new Text( 'foo' ),
 			new Text( 'bar', { bold: true } ),
 			new Element( 'image', { src: 'img.jpg' } ),

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -56,7 +56,7 @@ describe( 'Position', () => {
 
 		p = new Element( 'p' );
 
-		root._insertChildren( 0, [ p, ul ] );
+		root._insertChild( 0, [ p, ul ] );
 	} );
 
 	describe( 'constructor()', () => {
@@ -868,7 +868,7 @@ describe( 'Position', () => {
 
 			const p = new Element( 'p', null, 'foobar' );
 
-			root._appendChildren( p );
+			root._appendChild( p );
 
 			const postion = new Position( root, [ 0, 3 ] ); // <p>foo^bar</p>
 
@@ -897,7 +897,7 @@ describe( 'Position', () => {
 
 			const p = new Element( 'p', null, new Element( 'a' ) );
 
-			root._appendChildren( p );
+			root._appendChild( p );
 
 			const postion = new Position( root, [ 0, 0 ] ); // <p>^<a></a></p>
 

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -160,7 +160,7 @@ describe( 'Range', () => {
 		beforeEach( () => {
 			p = new Element( 'p', [], new Text( 'foz' ) );
 
-			root._insertChildren( 0, [ p ] );
+			root._insertChild( 0, [ p ] );
 		} );
 
 		describe( 'createIn()', () => {
@@ -245,7 +245,7 @@ describe( 'Range', () => {
 			}
 
 			beforeEach( () => {
-				root._appendChildren( new Text( 'abcdefghijklmnopqrtuvwxyz' ) );
+				root._appendChild( new Text( 'abcdefghijklmnopqrtuvwxyz' ) );
 			} );
 
 			it( 'should throw if empty array is passed', () => {
@@ -337,9 +337,9 @@ describe( 'Range', () => {
 			const e1 = new Element( 'e1' );
 			const e2 = new Element( 'e2' );
 
-			e1._insertChildren( 0, [ a, b ] );
-			e2._insertChildren( 0, [ x, y ] );
-			root._insertChildren( 0, [ e1, e2 ] );
+			e1._insertChild( 0, [ a, b ] );
+			e2._insertChild( 0, [ x, y ] );
+			root._insertChild( 0, [ e1, e2 ] );
 
 			const range = new Range(
 				new Position( root, [ 0, 1 ] ),
@@ -462,9 +462,9 @@ describe( 'Range', () => {
 			d = new Element( 'd' );
 
 			xxx = new Text( 'xxx' );
-			b._appendChildren( xxx );
+			b._appendChild( xxx );
 
-			root._appendChildren( [ a, b, c, d ] );
+			root._appendChild( [ a, b, c, d ] );
 		} );
 
 		it( 'should return true if element is inside range and false when it is not inside range', () => {
@@ -1233,7 +1233,7 @@ describe( 'Range', () => {
 
 	describe( 'getTransformedByDeltas()', () => {
 		beforeEach( () => {
-			root._appendChildren( new Text( 'foobar' ) );
+			root._appendChild( new Text( 'foobar' ) );
 			range = Range.createFromParentsAndOffsets( root, 2, root, 5 );
 		} );
 
@@ -1357,7 +1357,7 @@ describe( 'Range', () => {
 	}
 
 	function prepareRichRoot() {
-		root._insertChildren( 0, [
+		root._insertChild( 0, [
 			new Element( 'div', [], [
 				new Element( 'h', [], new Text( 'first' ) ),
 				new Element( 'p', [], new Text( 'lorem ipsum' ) )

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -1501,7 +1501,7 @@ describe( 'Schema', () => {
 			const text = new Text( 'foo', { a: 1, b: 1 } );
 			const image = new Element( 'image', { a: 1, b: 1 } );
 
-			root._appendChildren( [ text, image ] );
+			root._appendChild( [ text, image ] );
 
 			model.change( writer => {
 				schema.removeDisallowedAttributes( root.getChildren(), writer );
@@ -1548,7 +1548,7 @@ describe( 'Schema', () => {
 			const paragraph = new Element( 'paragraph', [], [ foo, imageInParagraph ] );
 			const div = new Element( 'div', [], [ paragraph, bar, imageInDiv ] );
 
-			root._appendChildren( [ div ] );
+			root._appendChild( [ div ] );
 
 			model.change( writer => {
 				schema.removeDisallowedAttributes( root.getChildren(), writer );
@@ -1612,7 +1612,7 @@ describe( 'Schema', () => {
 				} );
 
 				const div = new Element( 'div' );
-				root1._appendChildren( div );
+				root1._appendChild( div );
 
 				const div2 = new Element( 'div' );
 
@@ -1626,7 +1626,7 @@ describe( 'Schema', () => {
 				} );
 
 				const div = new Element( 'div' );
-				root1._appendChildren( div );
+				root1._appendChild( div );
 
 				expect( schema.checkChild( div, div ) ).to.be.true;
 			} );
@@ -2063,7 +2063,7 @@ describe( 'Schema', () => {
 			it( 'does not break when trying to check registered child in a context which contains non-registered elements', () => {
 				const foo404 = new Element( 'foo404' );
 
-				root1._appendChildren( foo404 );
+				root1._appendChild( foo404 );
 
 				schema.register( '$root' );
 				schema.register( '$text', {
@@ -2452,7 +2452,7 @@ describe( 'Schema', () => {
 			// Edge case because p>p should not exist in the first place.
 			// But it's good to know that it blocks also this.
 			const p = new Element( 'p' );
-			r1p1._appendChildren( p );
+			r1p1._appendChild( p );
 
 			expect( schema.checkChild( p, '$text' ) ).to.be.false;
 		} );
@@ -2746,7 +2746,7 @@ describe( 'SchemaContext', () => {
 		it( 'filters out DocumentFragment when it is a first item of context - element', () => {
 			const p = new Element( 'paragraph' );
 			const docFrag = new DocumentFragment();
-			docFrag._appendChildren( p );
+			docFrag._appendChild( p );
 
 			const ctx = new SchemaContext( p );
 
@@ -2757,7 +2757,7 @@ describe( 'SchemaContext', () => {
 		it( 'filters out DocumentFragment when it is a first item of context - position', () => {
 			const p = new Element( 'paragraph' );
 			const docFrag = new DocumentFragment();
-			docFrag._appendChildren( p );
+			docFrag._appendChild( p );
 
 			const ctx = new SchemaContext( new Position( docFrag, [ 0, 0 ] ) );
 

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -25,7 +25,7 @@ describe( 'Selection', () => {
 		model = new Model();
 		doc = model.document;
 		root = doc.createRoot();
-		root._appendChildren( [
+		root._appendChild( [
 			new Element( 'p' ),
 			new Element( 'p' ),
 			new Element( 'p', [], new Text( 'foobar' ) ),
@@ -1128,7 +1128,7 @@ describe( 'Selection', () => {
 		let rangeInFullP;
 
 		beforeEach( () => {
-			root._insertChildren( 0, [
+			root._insertChild( 0, [
 				new Element( 'p', [], new Text( 'foobar' ) ),
 				new Element( 'p', [], [] )
 			] );

--- a/tests/model/textproxy.js
+++ b/tests/model/textproxy.js
@@ -17,10 +17,10 @@ describe( 'TextProxy', () => {
 		doc = model.document;
 		root = doc.createRoot();
 		element = new Element( 'div' );
-		root._insertChildren( 0, element );
+		root._insertChild( 0, element );
 
 		text = new Text( 'foobar', { foo: 'bar' } );
-		element._insertChildren( 0, [ new Text( 'abc' ), text ] );
+		element._insertChild( 0, [ new Text( 'abc' ), text ] );
 		textProxy = new TextProxy( text, 2, 3 );
 
 		textNoParent = new Text( 'abcxyz' );

--- a/tests/model/treewalker.js
+++ b/tests/model/treewalker.js
@@ -40,7 +40,7 @@ describe( 'TreeWalker', () => {
 		paragraph = new Element( 'p', [], [ ba, r, img2, x ] );
 		img1 = new Element( 'img1' );
 
-		root._insertChildren( 0, [ img1, paragraph ] );
+		root._insertChild( 0, [ img1, paragraph ] );
 
 		rootBeginning = new Position( root, [ 0 ] );
 		rootEnding = new Position( root, [ 2 ] );

--- a/tests/model/utils-tests/utils.js
+++ b/tests/model/utils-tests/utils.js
@@ -32,7 +32,7 @@ describe( 'getNodesAndText', () => {
 		div = new Element( 'div', [], new Text( 'foobar' ) );
 		p = new Element( 'p', [], new Text( 'abcxyz' ) );
 
-		root._insertChildren( 0, [ div, p ] );
+		root._insertChild( 0, [ div, p ] );
 	} );
 
 	it( 'reads two elements with text', () => {
@@ -120,7 +120,7 @@ describe( 'createRangeOnElementOnly', () => {
 	it( 'should create a range that contains only the given element', () => {
 		const parent = new Element( 'parent' );
 		const element = new Element( 'elem' );
-		parent._appendChildren( element );
+		parent._appendChild( element );
 
 		const range = createRangeOnElementOnly( element );
 

--- a/tests/model/utils/deletecontent.js
+++ b/tests/model/utils/deletecontent.js
@@ -327,7 +327,7 @@ describe( 'DataController utils', () => {
 					// <pparent>x<paragraph>x<pchild>fo[o</pchild></paragraph></pparent>
 					// <pparent><paragraph><pchild>b]ar</pchild>y</paragraph>y</pparent>
 
-					root._appendChildren(
+					root._appendChild(
 						new Element( 'pparent', null, [
 							'x',
 							new Element( 'paragraph', null, [
@@ -337,7 +337,7 @@ describe( 'DataController utils', () => {
 						] )
 					);
 
-					root._appendChildren(
+					root._appendChild(
 						new Element( 'pparent', null, [
 							new Element( 'paragraph', null, [
 								new Element( 'pchild', null, 'bar' ),
@@ -380,7 +380,7 @@ describe( 'DataController utils', () => {
 					// We need to use the raw API due to https://github.com/ckeditor/ckeditor5-engine/issues/905.
 					// <pparent>x<paragraph>foo<pchild>ba[r</pchild></paragraph></pparent><paragraph>b]om</paragraph>
 
-					root._appendChildren(
+					root._appendChild(
 						new Element( 'pparent', null, [
 							'x',
 							new Element( 'paragraph', null, [
@@ -390,7 +390,7 @@ describe( 'DataController utils', () => {
 						] )
 					);
 
-					root._appendChildren(
+					root._appendChild(
 						new Element( 'paragraph', null, 'bom' )
 					);
 
@@ -427,11 +427,11 @@ describe( 'DataController utils', () => {
 					// We need to use the raw API due to https://github.com/ckeditor/ckeditor5-engine/issues/905.
 					// <paragraph>fo[o</paragraph><pparent><paragraph><pchild>bar]</pchild></paragraph></pparent>
 
-					root._appendChildren(
+					root._appendChild(
 						new Element( 'paragraph', null, 'foo' )
 					);
 
-					root._appendChildren(
+					root._appendChild(
 						new Element( 'pparent', null, [
 							new Element( 'paragraph', null, [
 								new Element( 'pchild', null, 'bar' )

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -1288,7 +1288,7 @@ describe( 'Writer', () => {
 		it( 'should not add empty delta to the batch', () => {
 			const nodeA = new Element( 'p', { a: 1 } );
 			const nodeB = new Element( 'p', { b: 2 } );
-			root._insertChildren( 0, [ nodeA, nodeB ] );
+			root._insertChild( 0, [ nodeA, nodeB ] );
 
 			setAttribute( 'a', 1, nodeA );
 
@@ -1413,7 +1413,7 @@ describe( 'Writer', () => {
 			p1 = new Element( 'p', { key1: 'value1' }, new Text( 'foo' ) );
 			p2 = new Element( 'p', { key2: 'value2' }, new Text( 'bar' ) );
 
-			root._insertChildren( 0, [ p1, p2 ] );
+			root._insertChild( 0, [ p1, p2 ] );
 		} );
 
 		it( 'should merge foo and bar into foobar', () => {
@@ -1469,10 +1469,10 @@ describe( 'Writer', () => {
 			div = new Element( 'div', [], new Text( 'foobar' ) );
 			p = new Element( 'p', [], new Text( 'abcxyz' ) );
 
-			div._insertChildren( 0, [ new Element( 'p', [], new Text( 'gggg' ) ) ] );
-			div._insertChildren( 2, [ new Element( 'p', [], new Text( 'hhhh' ) ) ] );
+			div._insertChild( 0, [ new Element( 'p', [], new Text( 'gggg' ) ) ] );
+			div._insertChild( 2, [ new Element( 'p', [], new Text( 'hhhh' ) ) ] );
 
-			root._insertChildren( 0, [ div, p ] );
+			root._insertChild( 0, [ div, p ] );
 
 			range = new Range( new Position( root, [ 0, 3 ] ), new Position( root, [ 0, 7 ] ) );
 		} );
@@ -1657,7 +1657,7 @@ describe( 'Writer', () => {
 			const root = doc.createRoot();
 			const p = new Element( 'p', null, new Text( 'abc' ) );
 
-			root._appendChildren( p );
+			root._appendChild( p );
 
 			rename( p, 'h' );
 
@@ -1669,7 +1669,7 @@ describe( 'Writer', () => {
 			const docFrag = new DocumentFragment();
 			const p = new Element( 'p' );
 
-			docFrag._appendChildren( p );
+			docFrag._appendChild( p );
 
 			rename( p, 'h' );
 
@@ -1701,7 +1701,7 @@ describe( 'Writer', () => {
 
 			p = new Element( 'p', { key: 'value' }, new Text( 'foobar' ) );
 
-			root._insertChildren( 0, p );
+			root._insertChild( 0, p );
 		} );
 
 		it( 'should split foobar to foo and bar', () => {
@@ -1724,7 +1724,7 @@ describe( 'Writer', () => {
 
 		it( 'should split inside document fragment', () => {
 			const docFrag = new DocumentFragment();
-			docFrag._appendChildren( new Element( 'p', null, new Text( 'foobar' ) ) );
+			docFrag._appendChild( new Element( 'p', null, new Text( 'foobar' ) ) );
 
 			split( new Position( docFrag, [ 0, 3 ] ) );
 
@@ -1782,7 +1782,7 @@ describe( 'Writer', () => {
 			const div = new Element( 'div', null, p );
 			const section = new Element( 'section', null, div );
 
-			root._insertChildren( 0, section );
+			root._insertChild( 0, section );
 
 			split( new Position( p, [ 3 ] ), section );
 
@@ -1806,8 +1806,8 @@ describe( 'Writer', () => {
 			const div = new Element( 'div', null, p );
 			const section = new Element( 'section', null, div );
 
-			root._insertChildren( 0, div );
-			root._insertChildren( 1, section );
+			root._insertChild( 0, div );
+			root._insertChild( 1, section );
 
 			expect( () => {
 				split( new Position( p, [ 3 ] ), section );
@@ -1829,7 +1829,7 @@ describe( 'Writer', () => {
 		beforeEach( () => {
 			root = doc.createRoot();
 
-			root._insertChildren( 0, new Text( 'foobar' ) );
+			root._insertChild( 0, new Text( 'foobar' ) );
 
 			range = new Range( new Position( root, [ 2 ] ), new Position( root, [ 4 ] ) );
 		} );
@@ -1866,7 +1866,7 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should throw if range to wrap is not flat', () => {
-			root._insertChildren( 1, [ new Element( 'p', [], new Text( 'xyz' ) ) ] );
+			root._insertChild( 1, [ new Element( 'p', [], new Text( 'xyz' ) ) ] );
 			const notFlatRange = new Range( new Position( root, [ 3 ] ), new Position( root, [ 6, 2 ] ) );
 
 			expect( () => {
@@ -1884,7 +1884,7 @@ describe( 'Writer', () => {
 
 		it( 'should throw if element to wrap with has children #2', () => {
 			const p = new Element( 'p' );
-			root._insertChildren( 0, p );
+			root._insertChild( 0, p );
 
 			expect( () => {
 				wrap( range, p );
@@ -1907,7 +1907,7 @@ describe( 'Writer', () => {
 			root = doc.createRoot();
 
 			p = new Element( 'p', [], new Text( 'xyz' ) );
-			root._insertChildren( 0, [ new Text( 'a' ), p, new Text( 'b' ) ] );
+			root._insertChild( 0, [ new Text( 'a' ), p, new Text( 'b' ) ] );
 		} );
 
 		it( 'should unwrap given element', () => {
@@ -1948,7 +1948,7 @@ describe( 'Writer', () => {
 
 		beforeEach( () => {
 			root = doc.createRoot();
-			root._appendChildren( new Text( 'foo' ) );
+			root._appendChild( new Text( 'foo' ) );
 			range = Range.createIn( root );
 		} );
 
@@ -2114,7 +2114,7 @@ describe( 'Writer', () => {
 
 		beforeEach( () => {
 			root = doc.createRoot();
-			root._appendChildren( new Text( 'foo' ) );
+			root._appendChild( new Text( 'foo' ) );
 			range = Range.createIn( root );
 		} );
 
@@ -2172,7 +2172,7 @@ describe( 'Writer', () => {
 			model.schema.extend( 'p', { allowIn: '$root' } );
 
 			root = doc.createRoot();
-			root._appendChildren( [
+			root._appendChild( [
 				new Element( 'p' ),
 				new Element( 'p' ),
 				new Element( 'p', [], new Text( 'foo' ) )
@@ -2209,7 +2209,7 @@ describe( 'Writer', () => {
 			model.schema.extend( 'p', { allowIn: '$root' } );
 
 			root = doc.createRoot();
-			root._appendChildren( [
+			root._appendChild( [
 				new Element( 'p' ),
 				new Element( 'p' ),
 				new Element( 'p', [], new Text( 'foo' ) )
@@ -2245,7 +2245,7 @@ describe( 'Writer', () => {
 			model.schema.extend( 'p', { allowIn: '$root' } );
 
 			root = doc.createRoot();
-			root._appendChildren( [
+			root._appendChild( [
 				new Element( 'p', [], [] ),
 				new Element( 'p' ),
 				new Element( 'p', [], new Text( 'foo' ) )
@@ -2290,7 +2290,7 @@ describe( 'Writer', () => {
 			model.schema.extend( 'p', { allowIn: '$root' } );
 
 			root = doc.createRoot();
-			root._appendChildren( [
+			root._appendChild( [
 				new Element( 'p', [], [] ),
 				new Element( 'p' ),
 				new Element( 'p', [], new Text( 'foo' ) )
@@ -2347,7 +2347,7 @@ describe( 'Writer', () => {
 
 		it( 'should not get attributes from the node before the caret when gravity is overridden', () => {
 			const root = doc.createRoot();
-			root._appendChildren( [
+			root._appendChild( [
 				new Text( 'foo', { foo: true } ),
 				new Text( 'bar', { foo: true, bar: true } ),
 				new Text( 'biz', { foo: true } )
@@ -2371,7 +2371,7 @@ describe( 'Writer', () => {
 
 		it( 'should allow to restorer gravity in a custom way', () => {
 			const root = doc.createRoot();
-			root._appendChildren( [ new Text( 'foobar', { foo: true } ) ] );
+			root._appendChild( [ new Text( 'foobar', { foo: true } ) ] );
 
 			setSelection( new Position( root, [ 1 ] ) );
 
@@ -2400,7 +2400,7 @@ describe( 'Writer', () => {
 
 		it( 'should restore overridden gravity to default', () => {
 			const root = doc.createRoot();
-			root._appendChildren( [
+			root._appendChild( [
 				new Text( 'foo', { foo: true } ),
 				new Text( 'bar', { foo: true, bar: true } ),
 				new Text( 'biz', { foo: true } )

--- a/tests/tickets/1323.js
+++ b/tests/tickets/1323.js
@@ -20,7 +20,7 @@ describe( 'Bug ckeditor5-engine@1323', () => {
 			model = new Model();
 			editing = new EditingController( model );
 			root = model.document.createRoot();
-			root._appendChildren( new ModelText( 'foo' ) );
+			root._appendChild( new ModelText( 'foo' ) );
 			range = ModelRange.createFromParentsAndOffsets( root, 0, root, 0 );
 		} );
 

--- a/tests/view/documentfragment.js
+++ b/tests/view/documentfragment.js
@@ -108,8 +108,8 @@ describe( 'DocumentFragment', () => {
 
 		describe( 'insertion', () => {
 			it( 'should insert children', () => {
-				const count1 = fragment._insertChildren( 0, [ el1, el3 ] );
-				const count2 = fragment._insertChildren( 1, el2 );
+				const count1 = fragment._insertChild( 0, [ el1, el3 ] );
+				const count2 = fragment._insertChild( 1, el2 );
 
 				expect( fragment.childCount ).to.equal( 3 );
 				expect( fragment.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
@@ -120,22 +120,22 @@ describe( 'DocumentFragment', () => {
 			} );
 
 			it( 'should accept strings', () => {
-				fragment._insertChildren( 0, 'abc' );
+				fragment._insertChild( 0, 'abc' );
 
 				expect( fragment.childCount ).to.equal( 1 );
 				expect( fragment.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'abc' );
 
 				fragment._removeChildren( 0, 1 );
-				fragment._insertChildren( 0, [ new Element( 'p' ), 'abc' ] );
+				fragment._insertChild( 0, [ new Element( 'p' ), 'abc' ] );
 
 				expect( fragment.childCount ).to.equal( 2 );
 				expect( fragment.getChild( 1 ) ).to.have.property( 'data' ).that.equals( 'abc' );
 			} );
 
 			it( 'should append children', () => {
-				const count1 = fragment._insertChildren( 0, el1 );
-				const count2 = fragment._appendChildren( el2 );
-				const count3 = fragment._appendChildren( el3 );
+				const count1 = fragment._insertChild( 0, el1 );
+				const count2 = fragment._appendChild( el2 );
+				const count3 = fragment._appendChild( el3 );
 
 				expect( fragment.childCount ).to.equal( 3 );
 				expect( fragment.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
@@ -152,7 +152,7 @@ describe( 'DocumentFragment', () => {
 					done();
 				} );
 
-				fragment._insertChildren( 0, el1 );
+				fragment._insertChild( 0, el1 );
 			} );
 
 			it( 'should fire change event when appending', done => {
@@ -161,7 +161,7 @@ describe( 'DocumentFragment', () => {
 					done();
 				} );
 
-				fragment._appendChildren( el1 );
+				fragment._appendChild( el1 );
 			} );
 
 			it( 'should accept and correctly handle text proxies', () => {
@@ -169,7 +169,7 @@ describe( 'DocumentFragment', () => {
 				const text = new Text( 'abcxyz' );
 				const textProxy = new TextProxy( text, 2, 3 );
 
-				frag._insertChildren( 0, textProxy );
+				frag._insertChild( 0, textProxy );
 
 				expect( frag.childCount ).to.equal( 1 );
 				expect( frag.getChild( 0 ) ).to.be.instanceof( Text );
@@ -179,9 +179,9 @@ describe( 'DocumentFragment', () => {
 
 		describe( 'getChildIndex', () => {
 			it( 'should return child index', () => {
-				fragment._appendChildren( el1 );
-				fragment._appendChildren( el2 );
-				fragment._appendChildren( el3 );
+				fragment._appendChild( el1 );
+				fragment._appendChild( el2 );
+				fragment._appendChild( el3 );
 
 				expect( fragment.childCount ).to.equal( 3 );
 				expect( fragment.getChildIndex( el1 ) ).to.equal( 0 );
@@ -192,9 +192,9 @@ describe( 'DocumentFragment', () => {
 
 		describe( 'getChildren', () => {
 			it( 'should renturn children iterator', () => {
-				fragment._appendChildren( el1 );
-				fragment._appendChildren( el2 );
-				fragment._appendChildren( el3 );
+				fragment._appendChild( el1 );
+				fragment._appendChild( el2 );
+				fragment._appendChild( el3 );
 
 				const expected = [ el1, el2, el3 ];
 				let i = 0;
@@ -210,10 +210,10 @@ describe( 'DocumentFragment', () => {
 
 		describe( '_removeChildren', () => {
 			it( 'should remove children', () => {
-				fragment._appendChildren( el1 );
-				fragment._appendChildren( el2 );
-				fragment._appendChildren( el3 );
-				fragment._appendChildren( el4 );
+				fragment._appendChild( el1 );
+				fragment._appendChild( el2 );
+				fragment._appendChild( el3 );
+				fragment._appendChild( el4 );
 
 				fragment._removeChildren( 1, 2 );
 
@@ -228,9 +228,9 @@ describe( 'DocumentFragment', () => {
 			} );
 
 			it( 'should remove one child when second parameter is not specified', () => {
-				fragment._appendChildren( el1 );
-				fragment._appendChildren( el2 );
-				fragment._appendChildren( el3 );
+				fragment._appendChild( el1 );
+				fragment._appendChild( el2 );
+				fragment._appendChild( el3 );
 
 				const removed = fragment._removeChildren( 1 );
 
@@ -243,7 +243,7 @@ describe( 'DocumentFragment', () => {
 			} );
 
 			it( 'should fire change event', done => {
-				fragment._appendChildren( el1 );
+				fragment._appendChild( el1 );
 
 				fragment.once( 'change:children', ( event, node ) => {
 					expect( node ).to.equal( fragment );

--- a/tests/view/documentselection.js
+++ b/tests/view/documentselection.js
@@ -1077,7 +1077,7 @@ describe( 'DocumentSelection', () => {
 			documentSelection._setTo( viewDocument.selection );
 			const root = createViewRoot( viewDocument, 'div', 'main' );
 			const element = new Element( 'p' );
-			root._appendChildren( element );
+			root._appendChild( element );
 
 			documentSelection._setTo( Range.createFromParentsAndOffsets( element, 0, element, 0 ) );
 

--- a/tests/view/domconverter/view-to-dom.js
+++ b/tests/view/domconverter/view-to-dom.js
@@ -31,8 +31,8 @@ describe( 'DomConverter', () => {
 			const viewText = new ViewText( 'foo' );
 			const viewP = new ViewElement( 'p', { class: 'foo' } );
 
-			viewP._appendChildren( viewImg );
-			viewP._appendChildren( viewText );
+			viewP._appendChild( viewImg );
+			viewP._appendChild( viewText );
 
 			const domImg = document.createElement( 'img' );
 
@@ -59,8 +59,8 @@ describe( 'DomConverter', () => {
 			const viewText = new ViewText( 'foo' );
 			const viewP = new ViewElement( 'p', { class: 'foo' } );
 
-			viewP._appendChildren( viewImg );
-			viewP._appendChildren( viewText );
+			viewP._appendChild( viewImg );
+			viewP._appendChild( viewText );
 
 			const domP = converter.viewToDom( viewP, document, { bind: true } );
 
@@ -96,8 +96,8 @@ describe( 'DomConverter', () => {
 			const viewText = new ViewText( 'foo' );
 			const viewP = new ViewElement( 'p', { class: 'foo' } );
 
-			viewP._appendChildren( viewImg );
-			viewP._appendChildren( viewText );
+			viewP._appendChild( viewImg );
+			viewP._appendChild( viewText );
 
 			const domImg = document.createElement( 'img' );
 
@@ -120,8 +120,8 @@ describe( 'DomConverter', () => {
 			const viewText = new ViewText( 'foo' );
 			const viewFragment = new ViewDocumentFragment();
 
-			viewFragment._appendChildren( viewImg );
-			viewFragment._appendChildren( viewText );
+			viewFragment._appendChild( viewImg );
+			viewFragment._appendChild( viewText );
 
 			const domFragment = converter.viewToDom( viewFragment, document, { bind: true } );
 
@@ -139,8 +139,8 @@ describe( 'DomConverter', () => {
 			const viewText = new ViewText( 'foo' );
 			const viewFragment = new ViewDocumentFragment();
 
-			viewFragment._appendChildren( viewImg );
-			viewFragment._appendChildren( viewText );
+			viewFragment._appendChild( viewImg );
+			viewFragment._appendChild( viewText );
 
 			const domImg = document.createElement( 'img' );
 
@@ -244,7 +244,7 @@ describe( 'DomConverter', () => {
 					const viewElement = new ViewContainerElement( 'p' );
 
 					for ( const text of inputTexts ) {
-						viewElement._appendChildren( new ViewText( text.replace( /_/g, '\u00A0' ) ) );
+						viewElement._appendChild( new ViewText( text.replace( /_/g, '\u00A0' ) ) );
 					}
 
 					const domElement = converter.viewToDom( viewElement, document );

--- a/tests/view/element.js
+++ b/tests/view/element.js
@@ -306,8 +306,8 @@ describe( 'Element', () => {
 
 		describe( 'insertion', () => {
 			it( 'should insert children', () => {
-				const count1 = parent._insertChildren( 0, [ el1, el3 ] );
-				const count2 = parent._insertChildren( 1, el2 );
+				const count1 = parent._insertChild( 0, [ el1, el3 ] );
+				const count2 = parent._insertChild( 1, el2 );
 
 				expect( parent.childCount ).to.equal( 3 );
 				expect( parent.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
@@ -318,22 +318,22 @@ describe( 'Element', () => {
 			} );
 
 			it( 'should accept strings', () => {
-				parent._insertChildren( 0, 'abc' );
+				parent._insertChild( 0, 'abc' );
 
 				expect( parent.childCount ).to.equal( 1 );
 				expect( parent.getChild( 0 ) ).to.have.property( 'data' ).that.equals( 'abc' );
 
 				parent._removeChildren( 0, 1 );
-				parent._insertChildren( 0, [ new Element( 'p' ), 'abc' ] );
+				parent._insertChild( 0, [ new Element( 'p' ), 'abc' ] );
 
 				expect( parent.childCount ).to.equal( 2 );
 				expect( parent.getChild( 1 ) ).to.have.property( 'data' ).that.equals( 'abc' );
 			} );
 
 			it( 'should append children', () => {
-				const count1 = parent._insertChildren( 0, el1 );
-				const count2 = parent._appendChildren( el2 );
-				const count3 = parent._appendChildren( el3 );
+				const count1 = parent._insertChild( 0, el1 );
+				const count2 = parent._appendChild( el2 );
+				const count3 = parent._appendChild( el3 );
 
 				expect( parent.childCount ).to.equal( 3 );
 				expect( parent.getChild( 0 ) ).to.have.property( 'name' ).that.equals( 'el1' );
@@ -349,7 +349,7 @@ describe( 'Element', () => {
 				const text = new Text( 'abcxyz' );
 				const textProxy = new TextProxy( text, 2, 3 );
 
-				element._insertChildren( 0, textProxy );
+				element._insertChild( 0, textProxy );
 
 				expect( element.childCount ).to.equal( 1 );
 				expect( element.getChild( 0 ) ).to.be.instanceof( Text );
@@ -359,9 +359,9 @@ describe( 'Element', () => {
 
 		describe( 'getChildIndex', () => {
 			it( 'should return child index', () => {
-				parent._appendChildren( el1 );
-				parent._appendChildren( el2 );
-				parent._appendChildren( el3 );
+				parent._appendChild( el1 );
+				parent._appendChild( el2 );
+				parent._appendChild( el3 );
 
 				expect( parent.childCount ).to.equal( 3 );
 				expect( parent.getChildIndex( el1 ) ).to.equal( 0 );
@@ -372,9 +372,9 @@ describe( 'Element', () => {
 
 		describe( 'getChildren', () => {
 			it( 'should renturn children iterator', () => {
-				parent._appendChildren( el1 );
-				parent._appendChildren( el2 );
-				parent._appendChildren( el3 );
+				parent._appendChild( el1 );
+				parent._appendChild( el2 );
+				parent._appendChild( el3 );
 
 				const expected = [ el1, el2, el3 ];
 				let i = 0;
@@ -390,10 +390,10 @@ describe( 'Element', () => {
 
 		describe( '_removeChildren', () => {
 			it( 'should remove children', () => {
-				parent._appendChildren( el1 );
-				parent._appendChildren( el2 );
-				parent._appendChildren( el3 );
-				parent._appendChildren( el4 );
+				parent._appendChild( el1 );
+				parent._appendChild( el2 );
+				parent._appendChild( el3 );
+				parent._appendChild( el4 );
 
 				parent._removeChildren( 1, 2 );
 
@@ -408,9 +408,9 @@ describe( 'Element', () => {
 			} );
 
 			it( 'should remove one child when second parameter is not specified', () => {
-				parent._appendChildren( el1 );
-				parent._appendChildren( el2 );
-				parent._appendChildren( el3 );
+				parent._appendChild( el1 );
+				parent._appendChild( el2 );
+				parent._appendChild( el3 );
 
 				const removed = parent._removeChildren( 1 );
 

--- a/tests/view/element.js
+++ b/tests/view/element.js
@@ -948,7 +948,7 @@ describe( 'Element', () => {
 			const el2 = new Element( 'div', null, el1 );
 			const el3 = new Element( 'div', { class: 'foo bar' }, el2 );
 
-			expect( el1.findAncestor( { class: 'foo' } ) ).to.equal( el3 );
+			expect( el1.findAncestor( { classes: 'foo' } ) ).to.equal( el3 );
 		} );
 
 		it( 'should return null if no matches found', () => {
@@ -957,7 +957,7 @@ describe( 'Element', () => {
 
 			expect( el1.findAncestor( {
 				name: 'div',
-				class: 'container'
+				classes: 'container'
 			} ) ).to.be.null;
 		} );
 	} );

--- a/tests/view/emptyelement.js
+++ b/tests/view/emptyelement.js
@@ -54,18 +54,18 @@ describe( 'EmptyElement', () => {
 		} ).to.throw( CKEditorError, 'view-emptyelement-cannot-add: Cannot add child nodes to EmptyElement instance.' );
 	} );
 
-	describe( '_appendChildren', () => {
+	describe( '_appendChild', () => {
 		it( 'should throw when try to append new child element', () => {
 			expect( () => {
-				emptyElement._appendChildren( element );
+				emptyElement._appendChild( element );
 			} ).to.throw( CKEditorError, 'view-emptyelement-cannot-add: Cannot add child nodes to EmptyElement instance.' );
 		} );
 	} );
 
-	describe( '_insertChildren', () => {
+	describe( '_insertChild', () => {
 		it( 'should throw when try to insert new child element', () => {
 			expect( () => {
-				emptyElement._insertChildren( 0, element );
+				emptyElement._insertChild( 0, element );
 			} ).to.throw( CKEditorError, 'view-emptyelement-cannot-add: Cannot add child nodes to EmptyElement instance.' );
 		} );
 	} );

--- a/tests/view/manual/uielement.js
+++ b/tests/view/manual/uielement.js
@@ -47,7 +47,7 @@ class UIElementTestPlugin extends Plugin {
 		// Add some UIElement to each paragraph.
 		editing.downcastDispatcher.on( 'insert:paragraph', ( evt, data, conversionApi ) => {
 			const viewP = conversionApi.mapper.toViewElement( data.item );
-			viewP._appendChildren( createEndingUIElement( conversionApi.writer ) );
+			viewP._appendChild( createEndingUIElement( conversionApi.writer ) );
 		}, { priority: 'lowest' } );
 	}
 }

--- a/tests/view/matcher.js
+++ b/tests/view/matcher.js
@@ -13,14 +13,14 @@ describe( 'Matcher', () => {
 			const el = new Element( 'p', { title: 'foobar' } );
 
 			expect( matcher.match( el ) ).to.be.null;
-			const pattern = { name: 'p', attribute: { title: 'foobar' } };
+			const pattern = { name: 'p', attributes: { title: 'foobar' } };
 			matcher.add( pattern );
 			const result = matcher.match( el );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'element' ).that.equal( el );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'name' ).that.is.true;
-			expect( result.match ).to.have.property( 'attribute' ).that.is.an( 'array' );
-			expect( result.match.attribute[ 0 ] ).to.equal( 'title' );
+			expect( result.match ).to.have.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes[ 0 ] ).to.equal( 'title' );
 			expect( result ).to.be.an( 'object' );
 		} );
 
@@ -77,7 +77,7 @@ describe( 'Matcher', () => {
 
 		it( 'should match element attributes', () => {
 			const pattern = {
-				attribute: {
+				attributes: {
 					title: 'foobar'
 				}
 			};
@@ -92,16 +92,16 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).and.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 
-			expect( result ).to.have.property( 'match' ).that.has.property( 'attribute' ).that.is.an( 'array' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
 
-			expect( result.match.attribute[ 0 ] ).equal( 'title' );
+			expect( result.match.attributes[ 0 ] ).equal( 'title' );
 			expect( matcher.match( el2 ) ).to.be.null;
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
 		it( 'should match element attributes using RegExp', () => {
 			const pattern = {
-				attribute: {
+				attributes: {
 					title: /fooba./
 				}
 			};
@@ -114,21 +114,21 @@ describe( 'Matcher', () => {
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'attribute' ).that.is.an( 'array' );
-			expect( result.match.attribute[ 0 ] ).equal( 'title' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes[ 0 ] ).equal( 'title' );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'attribute' ).that.is.an( 'array' );
-			expect( result.match.attribute[ 0 ] ).equal( 'title' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes[ 0 ] ).equal( 'title' );
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
 		it( 'should match if element has given attribute', () => {
 			const pattern = {
-				attribute: {
+				attributes: {
 					title: true
 				}
 			};
@@ -141,21 +141,21 @@ describe( 'Matcher', () => {
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'attribute' ).that.is.an( 'array' );
-			expect( result.match.attribute[ 0 ] ).equal( 'title' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes[ 0 ] ).equal( 'title' );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'attribute' ).that.is.an( 'array' );
-			expect( result.match.attribute[ 0 ] ).equal( 'title' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes[ 0 ] ).equal( 'title' );
 
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
 		it( 'should match element class names', () => {
-			const pattern = { class: 'foobar' };
+			const pattern = { classes: 'foobar' };
 			const matcher = new Matcher( pattern );
 			const el1 = new Element( 'p', { class: 'foobar' } );
 
@@ -163,13 +163,13 @@ describe( 'Matcher', () => {
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'class' ).that.is.an( 'array' );
-			expect( result.match.class[ 0 ] ).equal( 'foobar' );
-			expect( new Matcher( { class: 'baz' } ).match( el1 ) ).to.be.null;
+			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
+			expect( result.match.classes[ 0 ] ).equal( 'foobar' );
+			expect( new Matcher( { classes: 'baz' } ).match( el1 ) ).to.be.null;
 		} );
 
 		it( 'should match element class names using RegExp', () => {
-			const pattern = { class: /fooba./ };
+			const pattern = { classes: /fooba./ };
 			const matcher = new Matcher( pattern );
 			const el1 = new Element( 'p', { class: 'foobar'	} );
 			const el2 = new Element( 'p', { class: 'foobaz'	} );
@@ -179,21 +179,21 @@ describe( 'Matcher', () => {
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'class' ).that.is.an( 'array' );
-			expect( result.match.class[ 0 ] ).equal( 'foobar' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
+			expect( result.match.classes[ 0 ] ).equal( 'foobar' );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'class' ).that.is.an( 'array' );
-			expect( result.match.class[ 0 ] ).equal( 'foobaz' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
+			expect( result.match.classes[ 0 ] ).equal( 'foobaz' );
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
 		it( 'should match element styles', () => {
 			const pattern = {
-				style: {
+				styles: {
 					color: 'red'
 				}
 			};
@@ -205,15 +205,15 @@ describe( 'Matcher', () => {
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'style' ).that.is.an( 'array' );
-			expect( result.match.style[ 0 ] ).equal( 'color' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).equal( 'color' );
 			expect( matcher.match( el2 ) ).to.be.null;
-			expect( new Matcher( { style: { color: 'blue' } } ).match( el1 ) ).to.be.null;
+			expect( new Matcher( { styles: { color: 'blue' } } ).match( el1 ) ).to.be.null;
 		} );
 
 		it( 'should match element styles using RegExp', () => {
 			const pattern = {
-				style: {
+				styles: {
 					color: /^.*blue$/
 				}
 			};
@@ -226,15 +226,15 @@ describe( 'Matcher', () => {
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'style' ).that.is.an( 'array' );
-			expect( result.match.style[ 0 ] ).to.equal( 'color' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'style' ).that.is.an( 'array' );
-			expect( result.match.style[ 0 ] ).to.equal( 'color' );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
@@ -278,7 +278,7 @@ describe( 'Matcher', () => {
 		it( 'should match multiple attributes', () => {
 			const pattern = {
 				name: 'a',
-				attribute: {
+				attributes: {
 					name: 'foo',
 					title: 'bar'
 				}
@@ -294,15 +294,15 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.is.an( 'object' );
-			expect( result.match ).to.have.property( 'attribute' ).that.is.an( 'array' );
-			expect( result.match.attribute[ 0 ] ).to.equal( 'name' );
-			expect( result.match.attribute[ 1 ] ).to.equal( 'title' );
+			expect( result.match ).to.have.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes[ 0 ] ).to.equal( 'name' );
+			expect( result.match.attributes[ 1 ] ).to.equal( 'title' );
 		} );
 
 		it( 'should match multiple classes', () => {
 			const pattern = {
 				name: 'a',
-				class: [ 'foo', 'bar' ]
+				classes: [ 'foo', 'bar' ]
 			};
 			const matcher = new Matcher( pattern );
 			const el = new Element( 'a' );
@@ -313,15 +313,15 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.is.an( 'object' );
-			expect( result.match ).to.have.property( 'class' ).that.is.an( 'array' );
-			expect( result.match.class[ 0 ] ).to.equal( 'foo' );
-			expect( result.match.class[ 1 ] ).to.equal( 'bar' );
+			expect( result.match ).to.have.property( 'classes' ).that.is.an( 'array' );
+			expect( result.match.classes[ 0 ] ).to.equal( 'foo' );
+			expect( result.match.classes[ 1 ] ).to.equal( 'bar' );
 		} );
 
 		it( 'should match multiple styles', () => {
 			const pattern = {
 				name: 'a',
-				style: {
+				styles: {
 					color: 'red',
 					position: 'relative'
 				}
@@ -338,9 +338,9 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.is.an( 'object' );
-			expect( result.match ).to.have.property( 'style' ).that.is.an( 'array' );
-			expect( result.match.style[ 0 ] ).to.equal( 'color' );
-			expect( result.match.style[ 1 ] ).to.equal( 'position' );
+			expect( result.match ).to.have.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+			expect( result.match.styles[ 1 ] ).to.equal( 'position' );
 		} );
 	} );
 
@@ -370,7 +370,7 @@ describe( 'Matcher', () => {
 		} );
 
 		it( 'should return all matched elements when using RegExp pattern', () => {
-			const pattern = { class: /^red-.*/ };
+			const pattern = { classes: /^red-.*/ };
 			const matcher = new Matcher( pattern );
 			const el1 = new Element( 'p' );
 			const el2 = new Element( 'p' );
@@ -386,14 +386,14 @@ describe( 'Matcher', () => {
 			expect( result[ 0 ] ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result[ 0 ] ).to.have.property( 'pattern' ).that.is.equal( pattern );
 			expect( result[ 0 ] ).to.have.property( 'match' ).that.is.an( 'object' );
-			expect( result[ 0 ].match ).to.have.property( 'class' ).that.is.an( 'array' );
-			expect( result[ 0 ].match.class[ 0 ] ).to.equal( 'red-foreground' );
+			expect( result[ 0 ].match ).to.have.property( 'classes' ).that.is.an( 'array' );
+			expect( result[ 0 ].match.classes[ 0 ] ).to.equal( 'red-foreground' );
 
 			expect( result[ 1 ] ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result[ 1 ] ).to.have.property( 'pattern' ).that.is.equal( pattern );
 			expect( result[ 1 ] ).to.have.property( 'match' ).that.is.an( 'object' );
-			expect( result[ 1 ].match ).to.have.property( 'class' ).that.is.an( 'array' );
-			expect( result[ 1 ].match.class[ 0 ] ).to.equal( 'red-background' );
+			expect( result[ 1 ].match ).to.have.property( 'classes' ).that.is.an( 'array' );
+			expect( result[ 1 ].match.classes[ 0 ] ).to.equal( 'red-background' );
 
 			expect( matcher.matchAll( el3 ) ).to.be.null;
 		} );
@@ -407,7 +407,7 @@ describe( 'Matcher', () => {
 		} );
 
 		it( 'should return null if pattern has no name property', () => {
-			const matcher = new Matcher( { class: 'foo' } );
+			const matcher = new Matcher( { classes: 'foo' } );
 
 			expect( matcher.getElementName() ).to.be.null;
 		} );
@@ -425,7 +425,7 @@ describe( 'Matcher', () => {
 		} );
 
 		it( 'should return null if matcher has more than one pattern', () => {
-			const matcher = new Matcher( { name: 'div' }, { class: 'foo' } );
+			const matcher = new Matcher( { name: 'div' }, { classes: 'foo' } );
 
 			expect( matcher.getElementName() ).to.be.null;
 		} );

--- a/tests/view/node.js
+++ b/tests/view/node.js
@@ -313,7 +313,7 @@ describe( 'Node', () => {
 			const otherRoot = new Element( 'root' );
 			const otherElement = new Element( 'element' );
 
-			otherRoot._appendChildren( otherElement );
+			otherRoot._appendChild( otherElement );
 
 			expect( otherElement.isBefore( three ) ).to.be.false;
 		} );
@@ -351,7 +351,7 @@ describe( 'Node', () => {
 			const otherRoot = new Element( 'root' );
 			const otherElement = new Element( 'element' );
 
-			otherRoot._appendChildren( otherElement );
+			otherRoot._appendChild( otherElement );
 
 			expect( three.isAfter( otherElement ) ).to.be.false;
 		} );
@@ -382,7 +382,7 @@ describe( 'Node', () => {
 		it( 'should prevent circular reference when stringifying a node', () => {
 			const char = new Text( 'a' );
 			const parent = new Element( 'p', null );
-			parent._appendChildren( char );
+			parent._appendChild( char );
 
 			const json = JSON.stringify( char );
 			const parsed = JSON.parse( json );
@@ -405,7 +405,7 @@ describe( 'Node', () => {
 			img = new Element( 'img', { 'src': 'img.png' } );
 
 			root = new Element( 'p', { renderer: { markToSync: rootChangeSpy } } );
-			root._appendChildren( [ text, img ] );
+			root._appendChild( [ text, img ] );
 
 			root.on( 'change:children', ( evt, node ) => rootChangeSpy( 'children', node ) );
 			root.on( 'change:attributes', ( evt, node ) => rootChangeSpy( 'attributes', node ) );
@@ -452,18 +452,18 @@ describe( 'Node', () => {
 			} );
 		} );
 
-		describe( '_insertChildren()', () => {
+		describe( '_insertChild()', () => {
 			it( 'should fire change event', () => {
-				root._insertChildren( 1, new Element( 'img' ) );
+				root._insertChild( 1, new Element( 'img' ) );
 
 				sinon.assert.calledOnce( rootChangeSpy );
 				sinon.assert.calledWith( rootChangeSpy, 'children', root );
 			} );
 		} );
 
-		describe( '_appendChildren()', () => {
+		describe( '_appendChild()', () => {
 			it( 'should fire change event', () => {
-				root._appendChildren( new Element( 'img' ) );
+				root._appendChild( new Element( 'img' ) );
 
 				sinon.assert.calledOnce( rootChangeSpy );
 				sinon.assert.calledWith( rootChangeSpy, 'children', root );

--- a/tests/view/observer/domeventobserver.js
+++ b/tests/view/observer/domeventobserver.js
@@ -182,7 +182,7 @@ describe( 'DomEventObserver', () => {
 			const viewRoot = createViewRoot( viewDocument );
 			view.attachDomRoot( domRoot );
 			uiElement = createUIElement( 'p' );
-			viewRoot._appendChildren( uiElement );
+			viewRoot._appendChild( uiElement );
 			view.render();
 
 			domEvent = new MouseEvent( 'click', { bubbles: true } );

--- a/tests/view/observer/mutationobserver.js
+++ b/tests/view/observer/mutationobserver.js
@@ -37,7 +37,7 @@ describe( 'MutationObserver', () => {
 
 		viewRoot = viewDocument.getRoot();
 
-		viewRoot._appendChildren( parse( '<container:p>foo</container:p><container:p>bar</container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p>foo</container:p><container:p>bar</container:p>' ) );
 
 		view.render();
 	} );
@@ -97,7 +97,7 @@ describe( 'MutationObserver', () => {
 
 	it( 'should handle unbold', () => {
 		viewRoot._removeChildren( 0, viewRoot.childCount );
-		viewRoot._appendChildren( parse( '<container:p><attribute:b>foo</attribute:b></container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p><attribute:b>foo</attribute:b></container:p>' ) );
 		view.render();
 
 		const domP = domEditor.childNodes[ 0 ];
@@ -203,7 +203,7 @@ describe( 'MutationObserver', () => {
 		createViewRoot( viewDocument, 'div', 'additional' );
 		view.attachDomRoot( domAdditionalEditor, 'additional' );
 
-		viewDocument.getRoot( 'additional' )._appendChildren(
+		viewDocument.getRoot( 'additional' )._appendChild(
 			parse( '<container:p>foo</container:p><container:p>bar</container:p>' ) );
 
 		// Render AdditionalEditor (first editor has been rendered in the beforeEach function)
@@ -228,7 +228,7 @@ describe( 'MutationObserver', () => {
 		const { view: viewContainer, selection } = parse( '<container:p>foo<attribute:b>[]</attribute:b>bar</container:p>' );
 
 		view.change( writer => {
-			viewRoot._appendChildren( viewContainer );
+			viewRoot._appendChild( viewContainer );
 			writer.setSelection( selection );
 		} );
 
@@ -246,7 +246,7 @@ describe( 'MutationObserver', () => {
 		const { view: viewContainer, selection } = parse( '<container:p>foo<attribute:b>[]</attribute:b>bar</container:p>' );
 
 		view.change( writer => {
-			viewRoot._appendChildren( viewContainer );
+			viewRoot._appendChild( viewContainer );
 			writer.setSelection( selection );
 		} );
 
@@ -254,7 +254,7 @@ describe( 'MutationObserver', () => {
 		inlineFiller.data += 'x';
 
 		view.change( () => {
-			viewContainer.getChild( 1 )._appendChildren( parse( 'x' ) );
+			viewContainer.getChild( 1 )._appendChild( parse( 'x' ) );
 			mutationObserver.flush();
 		} );
 
@@ -279,7 +279,7 @@ describe( 'MutationObserver', () => {
 		);
 
 		view.change( writer => {
-			viewRoot._appendChildren( viewContainer );
+			viewRoot._appendChild( viewContainer );
 			writer.setSelection( selection );
 		} );
 
@@ -311,7 +311,7 @@ describe( 'MutationObserver', () => {
 		);
 
 		view.change( writer => {
-			viewRoot._appendChildren( viewContainer );
+			viewRoot._appendChild( viewContainer );
 			writer.setSelection( selection );
 		} );
 
@@ -354,7 +354,7 @@ describe( 'MutationObserver', () => {
 		);
 
 		view.change( writer => {
-			viewRoot._appendChildren( viewContainer );
+			viewRoot._appendChild( viewContainer );
 			writer.setSelection( selection );
 		} );
 
@@ -376,7 +376,7 @@ describe( 'MutationObserver', () => {
 	} );
 
 	it( 'should have no block filler in mutation', () => {
-		viewRoot._appendChildren( parse( '<container:p></container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p></container:p>' ) );
 
 		view.render();
 
@@ -395,7 +395,7 @@ describe( 'MutationObserver', () => {
 	} );
 
 	it( 'should ignore mutation with bogus br inserted on the end of the empty paragraph', () => {
-		viewRoot._appendChildren( parse( '<container:p></container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p></container:p>' ) );
 
 		view.render();
 
@@ -408,7 +408,7 @@ describe( 'MutationObserver', () => {
 	} );
 
 	it( 'should ignore mutation with bogus br inserted on the end of the paragraph with text', () => {
-		viewRoot._appendChildren( parse( '<container:p>foo</container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p>foo</container:p>' ) );
 
 		view.render();
 
@@ -421,7 +421,7 @@ describe( 'MutationObserver', () => {
 	} );
 
 	it( 'should ignore mutation with bogus br inserted on the end of the paragraph while processing text mutations', () => {
-		viewRoot._appendChildren( parse( '<container:p>foo</container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p>foo</container:p>' ) );
 
 		view.render();
 
@@ -438,7 +438,7 @@ describe( 'MutationObserver', () => {
 	} );
 
 	it( 'should ignore child mutations which resulted in no changes – when element contains elements', () => {
-		viewRoot._appendChildren( parse( '<container:p><container:x></container:x></container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p><container:x></container:x></container:p>' ) );
 
 		view.render();
 
@@ -472,7 +472,7 @@ describe( 'MutationObserver', () => {
 	} );
 
 	it( 'should not ignore mutation with br inserted not on the end of the paragraph', () => {
-		viewRoot._appendChildren( parse( '<container:p>foo</container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p>foo</container:p>' ) );
 
 		view.render();
 
@@ -491,7 +491,7 @@ describe( 'MutationObserver', () => {
 	} );
 
 	it( 'should not ignore mutation inserting element different than br on the end of the empty paragraph', () => {
-		viewRoot._appendChildren( parse( '<container:p></container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p></container:p>' ) );
 
 		view.render();
 
@@ -509,7 +509,7 @@ describe( 'MutationObserver', () => {
 	} );
 
 	it( 'should not ignore mutation inserting element different than br on the end of the paragraph with text', () => {
-		viewRoot._appendChildren( parse( '<container:p>foo</container:p>' ) );
+		viewRoot._appendChild( parse( '<container:p>foo</container:p>' ) );
 
 		view.render();
 
@@ -543,7 +543,7 @@ describe( 'MutationObserver', () => {
 
 		beforeEach( () => {
 			const uiElement = createUIElement( 'div' );
-			viewRoot._appendChildren( uiElement );
+			viewRoot._appendChild( uiElement );
 
 			view.render();
 		} );

--- a/tests/view/observer/selectionobserver.js
+++ b/tests/view/observer/selectionobserver.js
@@ -38,7 +38,7 @@ describe( 'SelectionObserver', () => {
 		viewRoot = viewDocument.getRoot();
 
 		view.change( writer => {
-			viewRoot._appendChildren( parse(
+			viewRoot._appendChild( parse(
 				'<container:p>xxx<ui:span></ui:span></container:p>' +
 				'<container:p>yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</container:p>' ) );
 

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -43,7 +43,7 @@ describe( 'Renderer', () => {
 
 			const domRoot = document.createElement( 'p' );
 			domConverter.bindElements( domRoot, viewRoot );
-			viewRoot._appendChildren( new ViewText( 'foo' ) );
+			viewRoot._appendChild( new ViewText( 'foo' ) );
 
 			renderer.markedTexts.clear();
 			renderer.markedAttributes.clear();
@@ -59,7 +59,7 @@ describe( 'Renderer', () => {
 		} );
 
 		it( 'should mark children which need update', () => {
-			viewRoot._appendChildren( new ViewText( 'foo' ) );
+			viewRoot._appendChild( new ViewText( 'foo' ) );
 
 			renderer.markToSync( 'children', viewRoot );
 
@@ -70,7 +70,7 @@ describe( 'Renderer', () => {
 			// Overwrite viewRoot with node without coresponding DOM node.
 			viewRoot = new ViewElement( 'p' );
 
-			viewRoot._appendChildren( new ViewText( 'foo' ) );
+			viewRoot._appendChild( new ViewText( 'foo' ) );
 
 			renderer.markToSync( 'children', viewRoot );
 
@@ -79,7 +79,7 @@ describe( 'Renderer', () => {
 
 		it( 'should mark text which need update', () => {
 			const viewText = new ViewText( 'foo' );
-			viewRoot._appendChildren( viewText );
+			viewRoot._appendChild( viewText );
 			viewText._data = 'bar';
 
 			renderer.markToSync( 'text', viewText );
@@ -92,7 +92,7 @@ describe( 'Renderer', () => {
 			// Overwrite viewRoot with node without coresponding DOM node.
 			viewRoot = new ViewElement( 'p' );
 
-			viewRoot._appendChildren( viewText );
+			viewRoot._appendChild( viewText );
 			viewText._data = 'bar';
 
 			renderer.markToSync( 'text', viewText );
@@ -165,7 +165,7 @@ describe( 'Renderer', () => {
 		} );
 
 		it( 'should add children', () => {
-			viewRoot._appendChildren( new ViewText( 'foo' ) );
+			viewRoot._appendChild( new ViewText( 'foo' ) );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -177,7 +177,7 @@ describe( 'Renderer', () => {
 		} );
 
 		it( 'should remove children', () => {
-			viewRoot._appendChildren( new ViewText( 'foo' ) );
+			viewRoot._appendChild( new ViewText( 'foo' ) );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -197,7 +197,7 @@ describe( 'Renderer', () => {
 
 		it( 'should update text', () => {
 			const viewText = new ViewText( 'foo' );
-			viewRoot._appendChildren( viewText );
+			viewRoot._appendChild( viewText );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -219,7 +219,7 @@ describe( 'Renderer', () => {
 		it( 'should not update text parent child list changed', () => {
 			const viewImg = new ViewElement( 'img' );
 			const viewText = new ViewText( 'foo' );
-			viewRoot._appendChildren( [ viewImg, viewText ] );
+			viewRoot._appendChild( [ viewImg, viewText ] );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.markToSync( 'text', viewText );
@@ -232,7 +232,7 @@ describe( 'Renderer', () => {
 
 		it( 'should not change text if it is the same during text rendering', () => {
 			const viewText = new ViewText( 'foo' );
-			viewRoot._appendChildren( viewText );
+			viewRoot._appendChild( viewText );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -249,7 +249,7 @@ describe( 'Renderer', () => {
 
 		it( 'should not change text if it is the same during children rendering', () => {
 			const viewText = new ViewText( 'foo' );
-			viewRoot._appendChildren( viewText );
+			viewRoot._appendChild( viewText );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -266,7 +266,7 @@ describe( 'Renderer', () => {
 
 		it( 'should not change element if it is the same', () => {
 			const viewImg = new ViewElement( 'img' );
-			viewRoot._appendChildren( viewImg );
+			viewRoot._appendChild( viewImg );
 
 			// This should not be changed during the render.
 			const domImg = document.createElement( 'img' );
@@ -283,14 +283,14 @@ describe( 'Renderer', () => {
 
 		it( 'should change element if it is different', () => {
 			const viewImg = new ViewElement( 'img' );
-			viewRoot._appendChildren( viewImg );
+			viewRoot._appendChild( viewImg );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
 
 			const viewP = new ViewElement( 'p' );
 			viewRoot._removeChildren( 0, 1 );
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -304,7 +304,7 @@ describe( 'Renderer', () => {
 			const viewP = new ViewElement( 'p', null, viewFoo );
 			const viewDiv = new ViewElement( 'div', null, viewP );
 
-			viewRoot._appendChildren( viewDiv );
+			viewRoot._appendChild( viewDiv );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -315,7 +315,7 @@ describe( 'Renderer', () => {
 
 			viewP._removeChildren( 0, 1 );
 
-			viewDiv._appendChildren( viewP );
+			viewDiv._appendChild( viewP );
 			renderer.markToSync( 'children', viewDiv );
 			renderer.render();
 
@@ -337,7 +337,7 @@ describe( 'Renderer', () => {
 			const viewP = new ViewElement( 'p' );
 			const viewDivInner = new ViewElement( 'div', null, viewP );
 			const viewDivOuter = new ViewElement( 'div', null, viewDivInner );
-			viewRoot._appendChildren( viewDivOuter );
+			viewRoot._appendChild( viewDivOuter );
 
 			// Render view tree to DOM.
 			renderer.markToSync( 'children', viewRoot );
@@ -351,7 +351,7 @@ describe( 'Renderer', () => {
 			// Remove p from div "child" -- div "inner" won't be marked because it is in document fragment not view root.
 			viewP._remove();
 			// Add div "outer" back to root.
-			viewRoot._appendChildren( viewDivOuter );
+			viewRoot._appendChild( viewDivOuter );
 			renderer.markToSync( 'children', viewRoot );
 
 			// Render changes, view is: root -> div "outer" -> div "inner".
@@ -376,7 +376,7 @@ describe( 'Renderer', () => {
 			const viewP = new ViewElement( 'p', null, viewFoo );
 			const viewDiv = new ViewElement( 'div', null, viewP );
 
-			viewRoot._appendChildren( viewDiv );
+			viewRoot._appendChild( viewDiv );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -402,7 +402,7 @@ describe( 'Renderer', () => {
 				'<container:p>foo<attribute:b>[]</attribute:b>bar</container:p>' );
 
 			const viewRoot = new ViewElement( 'p' );
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -416,7 +416,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p>foo<attribute:b contenteditable="false">[]</attribute:b>bar</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -438,7 +438,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p contenteditable="false">foo<attribute:b>[]</attribute:b>bar</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -463,7 +463,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p>foo<attribute:b>[]</attribute:b>bar</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -522,7 +522,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p>[]<attribute:b>foo</attribute:b></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -573,7 +573,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p><attribute:b>foo</attribute:b>[]</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -623,7 +623,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p><attribute:b>foo</attribute:b>[]<attribute:b>bar</attribute:b></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -651,7 +651,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p>foo<attribute:b>[]</attribute:b><attribute:i></attribute:i></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -687,7 +687,7 @@ describe( 'Renderer', () => {
 			// Step 1: <p>foo<b>"FILLER{}"</b></p>
 			const { view: viewP, selection: newSelection } = parse( '<container:p>foo<attribute:b>[]</attribute:b></container:p>' );
 			const viewB = viewP.getChild( 1 );
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -702,7 +702,7 @@ describe( 'Renderer', () => {
 
 			// Step 2: Add text node.
 			const viewText = new ViewText( 'x' );
-			viewB._appendChildren( viewText );
+			viewB._appendChild( viewText );
 			selection._setTo( ViewRange.createFromParentsAndOffsets( viewText, 1, viewText, 1 ) );
 
 			renderer.markToSync( 'children', viewB );
@@ -726,7 +726,7 @@ describe( 'Renderer', () => {
 		it( 'should remove filler from a modified DOM in case <p>bar<b>foo</b>[]</p>', () => {
 			// Step 1: <p>bar<b>foo</b>"FILLER{}"</p>
 			const { view: viewP, selection: newSelection } = parse( '<container:p>bar<attribute:b>foo</attribute:b>[]</container:p>' );
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -755,7 +755,7 @@ describe( 'Renderer', () => {
 			const { view: viewFragment, selection: newSelection } = parse(
 				'<container:p><attribute:b>foo</attribute:b>[]<attribute:b>bar</attribute:b></container:p><container:p></container:p>'
 			);
-			viewRoot._appendChildren( viewFragment );
+			viewRoot._appendChild( viewFragment );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -774,7 +774,7 @@ describe( 'Renderer', () => {
 			const viewP2 = viewRoot.getChild( 1 );
 			const removedChildren = viewP._removeChildren( 0, 2 );
 
-			viewP2._appendChildren( removedChildren );
+			viewP2._appendChild( removedChildren );
 
 			selection._setTo( ViewRange.createFromParentsAndOffsets( viewP, 0, viewP, 0 ) );
 
@@ -797,7 +797,7 @@ describe( 'Renderer', () => {
 		it( 'should not break when selection is moved to a new element, when filler exists', () => {
 			// Step 1: <p>bar<b>"FILLER{}"</b></p>
 			const { view: viewP, selection: newSelection } = parse( '<container:p>bar<attribute:b>[]</attribute:b></container:p>' );
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -811,7 +811,7 @@ describe( 'Renderer', () => {
 			viewP._removeChildren( 1 ); // Remove <b>.
 
 			const viewI = parse( '<attribute:i></attribute:i>' );
-			viewP._appendChildren( viewI );
+			viewP._appendChild( viewI );
 
 			selection._setTo( ViewRange.createFromParentsAndOffsets( viewI, 0, viewI, 0 ) );
 
@@ -829,7 +829,7 @@ describe( 'Renderer', () => {
 		it( 'should remove inline filler if selection is before a view element not bound to dom', () => {
 			// Step 1: <p>bar<b>abc</b>"FILLER"{}</p>
 			const { view: viewP, selection: newSelection } = parse( '<container:p>bar<attribute:b>abc</attribute:b>[]</container:p>' );
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -841,7 +841,7 @@ describe( 'Renderer', () => {
 
 			// Step 2: Move selection to a new attribute element.
 			const viewAbc = parse( 'abc' );
-			viewP._appendChildren( viewAbc );
+			viewP._appendChild( viewAbc );
 
 			selection._setTo( ViewRange.createFromParentsAndOffsets( viewP, 3, viewP, 3 ) );
 
@@ -858,7 +858,7 @@ describe( 'Renderer', () => {
 
 			const { view: viewP, selection: newSelection } = parse( '<container:p>[]</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -885,7 +885,7 @@ describe( 'Renderer', () => {
 			domSelection.addRange( domRange );
 
 			const viewText = new ViewText( 'x' );
-			viewP._appendChildren( viewText );
+			viewP._appendChild( viewText );
 			selection._setTo( ViewRange.createFromParentsAndOffsets( viewText, 1, viewText, 1 ) );
 
 			renderer.markToSync( 'children', viewP );
@@ -897,7 +897,7 @@ describe( 'Renderer', () => {
 
 			const { view: viewP, selection: newSelection } = parse( '<container:p>[]</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -915,7 +915,7 @@ describe( 'Renderer', () => {
 
 			// Add text node only in View <p>x{}</p>
 			const viewText = new ViewText( 'x' );
-			viewP._appendChildren( viewText );
+			viewP._appendChild( viewText );
 			selection._setTo( ViewRange.createFromParentsAndOffsets( viewText, 1, viewText, 1 ) );
 
 			renderer.markToSync( 'children', viewP );
@@ -935,7 +935,7 @@ describe( 'Renderer', () => {
 
 			const { view: viewP, selection: newSelection } = parse( '<container:p>x{}</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -977,7 +977,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p><attribute:b>[]</attribute:b>foo</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -1013,7 +1013,7 @@ describe( 'Renderer', () => {
 			domSelection.addRange( domRange );
 
 			const viewText = new ViewText( 'x' );
-			viewB._appendChildren( viewText );
+			viewB._appendChild( viewText );
 			selection._setTo( ViewRange.createFromParentsAndOffsets( viewText, 1, viewText, 1 ) );
 
 			renderer.markToSync( 'children', viewP );
@@ -1028,7 +1028,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p><attribute:b>[]</attribute:b>foo</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -1056,7 +1056,7 @@ describe( 'Renderer', () => {
 			// 3. Add text node only to the view: <p><b>x{}</b>foo</p>.
 
 			const viewText = new ViewText( 'x' );
-			viewB._appendChildren( viewText );
+			viewB._appendChild( viewText );
 			selection._setTo( ViewRange.createFromParentsAndOffsets( viewText, 1, viewText, 1 ) );
 
 			renderer.markToSync( 'children', viewB );
@@ -1091,7 +1091,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p><attribute:b>[]</attribute:b>foo</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -1119,7 +1119,7 @@ describe( 'Renderer', () => {
 			// 3. Add text node only to the view: <p><b>x{}</b>foo</p>.
 
 			const viewText = new ViewText( 'x' );
-			viewB._appendChildren( viewText );
+			viewB._appendChild( viewText );
 			selection._setTo( ViewRange.createFromParentsAndOffsets( viewText, 1, viewText, 1 ) );
 
 			renderer.markToSync( 'text', viewText );
@@ -1142,7 +1142,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p>fo{o<attribute:b>b}ar</attribute:b></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -1180,7 +1180,7 @@ describe( 'Renderer', () => {
 
 			const { view: viewP, selection: newSelection } = parse( '<container:p>fo{o}</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.render();
@@ -1222,7 +1222,7 @@ describe( 'Renderer', () => {
 
 			const { view: viewP, selection: newSelection } = parse( '<container:p>fo{o}</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.render();
@@ -1251,7 +1251,7 @@ describe( 'Renderer', () => {
 		it( 'should not add inline filler after text node', () => {
 			const { view: viewP, selection: newSelection } = parse( '<container:p>foo[]</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -1266,7 +1266,7 @@ describe( 'Renderer', () => {
 			const { view: viewP, selection: newSelection } = parse(
 				'<container:p>foo<attribute:b>[]</attribute:b>bar</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -1299,7 +1299,7 @@ describe( 'Renderer', () => {
 
 			const { view: view, selection: newSelection } = parse( inputView );
 
-			viewRoot._appendChildren( view );
+			viewRoot._appendChild( view );
 			selection._setTo( newSelection );
 
 			renderer.markToSync( 'children', viewRoot );
@@ -1312,7 +1312,7 @@ describe( 'Renderer', () => {
 			const viewLi = view.getChild( 0 );
 			const viewLiIndented = view._removeChildren( 1, 1 ); // Array with one element.
 			const viewUl = new ViewContainerElement( 'ul', null, viewLiIndented );
-			viewLi._appendChildren( viewUl );
+			viewLi._appendChild( viewUl );
 
 			// 4. Mark changed items and render the view.
 			renderer.markToSync( 'children', view );
@@ -1360,7 +1360,7 @@ describe( 'Renderer', () => {
 				const { view: viewP, selection: newSelection } = parse(
 					'<container:p>[foo bar]</container:p>'
 				);
-				viewRoot._appendChildren( viewP );
+				viewRoot._appendChild( viewP );
 				selection._setTo( newSelection );
 				renderer.markToSync( 'children', viewRoot );
 				renderer.render();
@@ -1550,7 +1550,7 @@ describe( 'Renderer', () => {
 				const { view: viewP, selection: newSelection } = parse(
 					'<container:p>foo{}<attribute:b>bar</attribute:b></container:p>' );
 
-				viewRoot._appendChildren( viewP );
+				viewRoot._appendChild( viewP );
 				selection._setTo( newSelection );
 
 				renderer.markToSync( 'children', viewRoot );
@@ -1590,7 +1590,7 @@ describe( 'Renderer', () => {
 				const { view: viewP, selection: newSelection } = parse(
 					'<container:p>foo<attribute:b>[]</attribute:b></container:p>' );
 
-				viewRoot._appendChildren( viewP );
+				viewRoot._appendChild( viewP );
 				selection._setTo( newSelection );
 
 				renderer.markToSync( 'children', viewRoot );
@@ -1629,7 +1629,7 @@ describe( 'Renderer', () => {
 				const { view: viewP, selection: newSelection } = parse(
 					'<container:p>fo{o}<attribute:b>bar</attribute:b></container:p>' );
 
-				viewRoot._appendChildren( viewP );
+				viewRoot._appendChild( viewP );
 				selection._setTo( newSelection );
 
 				renderer.markToSync( 'children', viewRoot );
@@ -1668,7 +1668,7 @@ describe( 'Renderer', () => {
 
 				const { view: viewP, selection: newSelection } = parse( '<container:p>foo[]<ui:span></ui:span></container:p>' );
 
-				viewRoot._appendChildren( viewP );
+				viewRoot._appendChild( viewP );
 				selection._setTo( newSelection );
 
 				renderer.markToSync( 'children', viewRoot );
@@ -1710,7 +1710,7 @@ describe( 'Renderer', () => {
 				const { view: viewP, selection: newSelection } = parse(
 					'<container:p>foo<attribute:b>{ba}r</attribute:b></container:p>' );
 
-				viewRoot._appendChildren( viewP );
+				viewRoot._appendChild( viewP );
 				selection._setTo( newSelection );
 
 				renderer.markToSync( 'children', viewRoot );
@@ -1748,7 +1748,7 @@ describe( 'Renderer', () => {
 				const { view: viewP, selection: newSelection } = parse(
 					'<container:p>foo<attribute:b>b{ar}</attribute:b>baz</container:p>' );
 
-				viewRoot._appendChildren( viewP );
+				viewRoot._appendChild( viewP );
 				selection._setTo( newSelection );
 
 				renderer.markToSync( 'children', viewRoot );
@@ -1786,7 +1786,7 @@ describe( 'Renderer', () => {
 				const { view: viewP, selection: newSelection } = parse(
 					'<container:p>foo<attribute:b><attribute:i>{ba}r</attribute:i></attribute:b></container:p>' );
 
-				viewRoot._appendChildren( viewP );
+				viewRoot._appendChild( viewP );
 				selection._setTo( newSelection );
 
 				renderer.markToSync( 'children', viewRoot );
@@ -1824,7 +1824,7 @@ describe( 'Renderer', () => {
 				const { view: viewP, selection: newSelection } = parse(
 					'<container:p>f{oo<attribute:b><attribute:i>bar}</attribute:i></attribute:b>baz</container:p>' );
 
-				viewRoot._appendChildren( viewP );
+				viewRoot._appendChild( viewP );
 				selection._setTo( newSelection );
 
 				renderer.markToSync( 'children', viewRoot );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1359,7 +1359,7 @@ describe( 'Renderer', () => {
 		it( 'should render NBSP as first space in inline element after another space', () => {
 			const viewP = parse( '<container:p>x <attribute:b>y</attribute:b></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -1374,7 +1374,7 @@ describe( 'Renderer', () => {
 			// Insert space resulting in '<p>x <b> y</b></p>'.
 			const viewB = viewP.getChild( 1 );
 			viewB._removeChildren( 0 );
-			viewB._appendChildren( new ViewText( ' y' ) );
+			viewB._appendChild( new ViewText( ' y' ) );
 
 			renderer.markToSync( 'children', viewP );
 			renderer.render();
@@ -1387,7 +1387,7 @@ describe( 'Renderer', () => {
 		it( 'should update sibling after, when node before is removed', () => {
 			const viewP = parse( '<container:p>x<attribute:b> y</attribute:b></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -1412,7 +1412,7 @@ describe( 'Renderer', () => {
 		it( 'should update sibling before, when node after is removed', () => {
 			const viewP = parse( '<container:p>x <attribute:b>y</attribute:b></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -1438,7 +1438,7 @@ describe( 'Renderer', () => {
 		it( 'should update siblings after space is inserted in element before - text-element', () => {
 			const viewP = parse( '<container:p>x<attribute:b> y</attribute:b></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -1466,7 +1466,7 @@ describe( 'Renderer', () => {
 		it( 'should update siblings after space is inserted in element before - element-text', () => {
 			const viewP = parse( '<container:p><attribute:b>x</attribute:b> y</container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -1495,7 +1495,7 @@ describe( 'Renderer', () => {
 		it( 'should update siblings after space is inserted in element before - element-element', () => {
 			const viewP = parse( '<container:p><attribute:b>x</attribute:b><attribute:i> y</attribute:i></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -1555,7 +1555,7 @@ describe( 'Renderer', () => {
 					'</container:ul>' +
 				'</container:blockquote>' );
 
-			viewRoot._appendChildren( viewContent );
+			viewRoot._appendChild( viewContent );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -1639,7 +1639,7 @@ describe( 'Renderer', () => {
 				'</container:blockquote>'
 			);
 
-			viewRoot._appendChildren( viewContent );
+			viewRoot._appendChild( viewContent );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -1650,7 +1650,7 @@ describe( 'Renderer', () => {
 			);
 
 			viewRoot._removeChildren( 0, viewRoot.childCount );
-			viewRoot._appendChildren( newViewContent );
+			viewRoot._appendChild( newViewContent );
 
 			renderer.markToSync( 'children', viewRoot );
 			renderer.render();
@@ -2352,7 +2352,7 @@ describe( 'Renderer', () => {
 		it( 'should handle element nodes', () => {
 			const viewP = parse( '<container:p>foo<attribute:b>bar<attribute:i>baz</attribute:i></attribute:b></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer._markDescendantTextToSync( viewP );
 
@@ -2364,7 +2364,7 @@ describe( 'Renderer', () => {
 		it( 'should handle text nodes', () => {
 			const viewP = parse( '<container:p><attribute:b>bar<attribute:i>baz</attribute:i></attribute:b></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer._markDescendantTextToSync( viewP.getChild( 0 ).getChild( 0 ) );
 
@@ -2386,7 +2386,7 @@ describe( 'Renderer', () => {
 		it( 'should handle empty element nodes', () => {
 			const viewP = parse( '<container:p></container:p>' );
 
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 
 			renderer._markDescendantTextToSync( viewP );
 

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1452,7 +1452,7 @@ describe( 'Renderer', () => {
 
 			// Insert space resulting in '<p>x <b> y</b></p>'.
 			viewP._removeChildren( 0 );
-			viewP._insertChildren( 0, new ViewText( 'x ' ) );
+			viewP._insertChild( 0, new ViewText( 'x ' ) );
 
 			renderer.markToSync( 'children', viewP );
 			renderer.render();
@@ -1481,7 +1481,7 @@ describe( 'Renderer', () => {
 			// Insert space resulting in '<p><b>x </b> y</p>'.
 			const viewB = viewP.getChild( 0 );
 			viewB._removeChildren( 0 );
-			viewB._insertChildren( 0, new ViewText( 'x ' ) );
+			viewB._insertChild( 0, new ViewText( 'x ' ) );
 
 			renderer.markToSync( 'children', viewP );
 			renderer.render();
@@ -1511,7 +1511,7 @@ describe( 'Renderer', () => {
 			// Insert space resulting in '<p><b>x </b><i> y</i></p>'.
 			const viewB = viewP.getChild( 0 );
 			viewB._removeChildren( 0 );
-			viewB._insertChildren( 0, new ViewText( 'x ' ) );
+			viewB._insertChild( 0, new ViewText( 'x ' ) );
 
 			renderer.markToSync( 'children', viewP );
 			renderer.render();
@@ -1563,7 +1563,7 @@ describe( 'Renderer', () => {
 			// '<h2>He<i>ading 1</i></h2>' -> '<h2>Heading 2</h2>'
 			const viewHeading = viewRoot.getChild( 0 );
 			viewHeading._removeChildren( 0, viewHeading.childCount );
-			viewHeading._insertChildren( 0, new ViewText( 'Heading 2' ) );
+			viewHeading._insertChild( 0, new ViewText( 'Heading 2' ) );
 
 			// Usually whole subtree is marked to sync so we mark root, changed element and all its direct children.
 			renderer.markToSync( 'children', viewRoot );
@@ -1575,7 +1575,7 @@ describe( 'Renderer', () => {
 			// '<p>Ph <i><strong>Italic</strong></i> <a><strong>L</strong>ink 1</a></p>'
 			const viewP = viewRoot.getChild( 1 );
 			viewP._removeChildren( 0, viewP.childCount );
-			viewP._insertChildren(
+			viewP._insertChild(
 				0,
 				parse(
 					'Ph <attribute:i><attribute:strong>Italic</attribute:strong></attribute:i> ' +
@@ -1594,7 +1594,7 @@ describe( 'Renderer', () => {
 			// -> '<blockquote><p>Qu<strong>ote</strong></p><ul><li><strong>Quoted item 1</strong></li></ul></blockquote>'
 			const viewBq = viewRoot.getChild( 2 );
 			viewBq._removeChildren( 0, viewBq.childCount );
-			viewBq._insertChildren(
+			viewBq._insertChild(
 				0,
 				parse(
 					'<container:p>Qu<attribute:strong>ote</attribute:strong></container:p>' +

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -951,7 +951,7 @@ describe( 'Selection', () => {
 			selection.setTo( viewDocument.selection );
 			const root = createViewRoot( viewDocument, 'div', 'main' );
 			const element = new Element( 'p' );
-			root._appendChildren( element );
+			root._appendChild( element );
 
 			selection.setTo( Range.createFromParentsAndOffsets( element, 0, element, 0 ) );
 

--- a/tests/view/treewalker.js
+++ b/tests/view/treewalker.js
@@ -42,7 +42,7 @@ describe( 'TreeWalker', () => {
 		paragraph = new ContainerElement( 'p', null, [ bold, charY, img2, charX ] );
 		img1 = new ContainerElement( 'img1' );
 
-		root._insertChildren( 0, [ img1, paragraph ] );
+		root._insertChild( 0, [ img1, paragraph ] );
 
 		rootBeginning = new Position( root, 0 );
 		rootEnding = new Position( root, 2 );

--- a/tests/view/uielement.js
+++ b/tests/view/uielement.js
@@ -66,18 +66,18 @@ describe( 'UIElement', () => {
 		} );
 	} );
 
-	describe( '_appendChildren()', () => {
+	describe( '_appendChild()', () => {
 		it( 'should throw when try to append new child element', () => {
 			expect( () => {
-				uiElement._appendChildren( new Element( 'i' ) );
+				uiElement._appendChild( new Element( 'i' ) );
 			} ).to.throw( CKEditorError, 'view-uielement-cannot-add: Cannot add child nodes to UIElement instance.' );
 		} );
 	} );
 
-	describe( '_insertChildren()', () => {
+	describe( '_insertChild()', () => {
 		it( 'should throw when try to insert new child element', () => {
 			expect( () => {
-				uiElement._insertChildren( 0, new Element( 'i' ) );
+				uiElement._insertChild( 0, new Element( 'i' ) );
 			} ).to.throw( CKEditorError, 'view-uielement-cannot-add: Cannot add child nodes to UIElement instance.' );
 		} );
 	} );

--- a/tests/view/view/jumpoverinlinefiller.js
+++ b/tests/view/view/jumpoverinlinefiller.js
@@ -114,7 +114,7 @@ describe( 'View', () => {
 				// Do this both in the view and in the DOM to simulate typing and to avoid rendering (which would remove the filler).
 				const viewB = writer.document.selection.getFirstPosition().parent;
 				const viewTextX = parse( 'x' );
-				viewB._appendChildren( viewTextX );
+				viewB._appendChild( viewTextX );
 				writer.setSelection( viewTextX, 1 );
 
 				const domB = view.getDomRoot( 'main' ).querySelector( 'b' );

--- a/tests/view/view/jumpoveruielement.js
+++ b/tests/view/view/jumpoveruielement.js
@@ -89,7 +89,7 @@ describe( 'View', () => {
 			it( 'do nothing when another key is pressed', () => {
 				// <container:p>foo<ui:span>xxx</ui:span>{}bar</container:p>
 				const p = new ViewContainerElement( 'p', null, [ foo, ui, bar ] );
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( [ ViewRange.createFromParentsAndOffsets( bar, 0, bar, 0 ) ] );
@@ -107,7 +107,7 @@ describe( 'View', () => {
 			it( 'jump over ui element when right arrow is pressed before ui element - directly before ui element', () => {
 				// <container:p>foo[]<ui:span>xxx</ui:span>bar</container:p>
 				const p = new ViewContainerElement( 'p', null, [ foo, ui, bar ] );
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( [ ViewRange.createFromParentsAndOffsets( p, 1, p, 1 ) ] );
@@ -127,7 +127,7 @@ describe( 'View', () => {
 			it( 'jump over ui element when right arrow is pressed before ui element - not directly before ui element', () => {
 				// <container:p>foo{}<ui:span>xxx</ui:span>bar</container:p>
 				const p = new ViewContainerElement( 'p', null, [ foo, ui, bar ] );
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( [ ViewRange.createFromParentsAndOffsets( foo, 3, foo, 3 ) ] );
@@ -147,7 +147,7 @@ describe( 'View', () => {
 			it( 'jump over multiple ui elements when right arrow is pressed before ui element', () => {
 				// <container:p>foo{}<ui:span>xxx</ui:span><ui:span>yyy</ui:span>bar</container:p>'
 				const p = new ViewContainerElement( 'p', null, [ foo, ui, ui2, bar ] );
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( [ ViewRange.createFromParentsAndOffsets( foo, 3, foo, 3 ) ] );
@@ -170,8 +170,8 @@ describe( 'View', () => {
 				const div = new ViewContainerElement( 'div' );
 
 				view.change( writer => {
-					viewRoot._appendChildren( p );
-					viewRoot._appendChildren( div );
+					viewRoot._appendChild( p );
+					viewRoot._appendChild( div );
 					writer.setSelection( [ ViewRange.createFromParentsAndOffsets( foo, 3, foo, 3 ) ] );
 				} );
 
@@ -190,7 +190,7 @@ describe( 'View', () => {
 				// <container:p><attribute:b>foo{}</attribute:b><ui:span>xxx</ui:span>bar</container:p>
 				const b = new ViewAttribtueElement( 'b', null, foo );
 				const p = new ViewContainerElement( 'p', null, [ b, ui, bar ] );
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( ViewRange.createFromParentsAndOffsets( foo, 3, foo, 3 ) );
@@ -211,7 +211,7 @@ describe( 'View', () => {
 				// <container:p><attribute:b>foo[]</attribute:b><ui:span>xxx</ui:span>bar</container:p>
 				const b = new ViewAttribtueElement( 'b', null, foo );
 				const p = new ViewContainerElement( 'p', null, [ b, ui, bar ] );
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( ViewRange.createFromParentsAndOffsets( b, 1, b, 1 ) );
@@ -242,7 +242,7 @@ describe( 'View', () => {
 				const i = new ViewAttribtueElement( 'i', null, b );
 				const p = new ViewContainerElement( 'p', null, [ i, ui, bar ] );
 
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( ViewRange.createFromParentsAndOffsets( foo, 3, foo, 3 ) );
@@ -272,7 +272,7 @@ describe( 'View', () => {
 				const b2 = new ViewAttribtueElement( 'b' );
 				const p = new ViewContainerElement( 'p', null, [ foo, b1, ui, ui2, b2, bar ] );
 
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( ViewRange.createFromParentsAndOffsets( foo, 3, foo, 3 ) );
@@ -303,7 +303,7 @@ describe( 'View', () => {
 				const b2 = new ViewAttribtueElement( 'b' );
 				const p = new ViewContainerElement( 'p', null, [ foo, b1, ui, ui2, b2, bar ] );
 
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( ViewRange.createFromParentsAndOffsets( foo, 3, foo, 3 ) );
@@ -382,7 +382,7 @@ describe( 'View', () => {
 				// <container:p>fo{o}<ui:span>xxx</ui:span>bar</container:p>
 				const p = new ViewContainerElement( 'p', null, [ foo, ui, bar ] );
 
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( ViewRange.createFromParentsAndOffsets( foo, 2, foo, 3 ) );
@@ -410,7 +410,7 @@ describe( 'View', () => {
 				const b = new ViewAttribtueElement( 'b', null, foo );
 				const i = new ViewAttribtueElement( 'i', null, b );
 				const p = new ViewContainerElement( 'p', null, [ i, ui, bar ] );
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( ViewRange.createFromParentsAndOffsets( foo, 2, foo, 3 ) );
@@ -439,7 +439,7 @@ describe( 'View', () => {
 				const b1 = new ViewAttribtueElement( 'b' );
 				const b2 = new ViewAttribtueElement( 'b' );
 				const p = new ViewContainerElement( 'p', null, [ foo, b1, ui, ui2, b2, bar ] );
-				viewRoot._appendChildren( p );
+				viewRoot._appendChild( p );
 
 				view.change( writer => {
 					writer.setSelection( ViewRange.createFromParentsAndOffsets( foo, 2, foo, 3 ) );

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -410,7 +410,7 @@ describe( 'view', () => {
 			createRoot( 'div', 'main', viewDocument );
 			view.attachDomRoot( domDiv );
 
-			viewDocument.getRoot()._appendChildren( new ViewElement( 'p' ) );
+			viewDocument.getRoot()._appendChild( new ViewElement( 'p' ) );
 			view.render();
 
 			expect( domDiv.childNodes.length ).to.equal( 1 );
@@ -429,7 +429,7 @@ describe( 'view', () => {
 			view.attachDomRoot( domRoot );
 
 			const viewP = new ViewElement( 'p', { class: 'foo' } );
-			viewRoot._appendChildren( viewP );
+			viewRoot._appendChild( viewP );
 			view.render();
 
 			expect( domRoot.childNodes.length ).to.equal( 1 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Renamed plural method names to singular and singular attribute names to plural. See ckeditor/ckeditor5#742.

BREAKING CHANGES: Properties in `module:engine/view/matcher~MatcherPattern` have been renamed: `class` to `classes`, `style` to `styles`, `attribute` to `attributes`.

NOTE: Keys of `engine/conversion/viewconsumable~ViewElementConsumables#_consumables` have been renamed from singular to plural.

NOTE: All protected `_insertChildren()` and `_appendChildren()` methods have been renamed to `_insertChild()` and `_appendChild()`.

---

Should be merged together with:
- https://github.com/ckeditor/ckeditor5-basic-styles/pull/67
- https://github.com/ckeditor/ckeditor5-font/pull/13
- https://github.com/ckeditor/ckeditor5-heading/pull/103
- https://github.com/ckeditor/ckeditor5-highlight/pull/22
- https://github.com/ckeditor/ckeditor5-image/pull/196
- https://github.com/ckeditor/ckeditor5-link/pull/188
