### PR TITLE
Fix for placeholder `ck` class removal

### DIFF
--- a/src/view/placeholder.js
+++ b/src/view/placeholder.js
@@ -38,7 +38,7 @@ export function attachPlaceholder( view, element, placeholderText, checkFunction
 		placeholderText,
 		checkFunction,
 
-		// Store information if 'ck' class is already present and don't remove it when detaching placeholder.
+		// Whether to remove the ck class when detaching the placeholder.
 		// https://github.com/ckeditor/ckeditor5-image/issues/198#issuecomment-377542222
 		removeCkClass: !element.hasClass( 'ck' )
 	} );
@@ -55,22 +55,18 @@ export function attachPlaceholder( view, element, placeholderText, checkFunction
  */
 export function detachPlaceholder( view, element ) {
 	const document = element.document;
-	let removeCkClass = false;
 
 	if ( documentPlaceholders.has( document ) ) {
 		const info = documentPlaceholders.get( document ).get( element );
-		removeCkClass = info.removeCkClass;
+		if ( info.removeCkClass ) {
+			view.change( writer => writer.removeClass( 'ck', element ) );
+		}
 
 		documentPlaceholders.get( document ).delete( element );
 	}
 
 	view.change( writer => {
 		writer.removeClass( 'ck-placeholder', element );
-
-		if ( removeCkClass ) {
-			writer.removeClass( 'ck', element );
-		}
-
 		writer.removeAttribute( 'data-placeholder', element );
 	} );
 }

--- a/src/view/placeholder.js
+++ b/src/view/placeholder.js
@@ -54,18 +54,19 @@ export function attachPlaceholder( view, element, placeholderText, checkFunction
  * @param {module:engine/view/element~Element} element
  */
 export function detachPlaceholder( view, element ) {
-	const document = element.document;
-
-	if ( documentPlaceholders.has( document ) ) {
-		const info = documentPlaceholders.get( document ).get( element );
-		if ( info.removeCkClass ) {
-			view.change( writer => writer.removeClass( 'ck', element ) );
-		}
-
-		documentPlaceholders.get( document ).delete( element );
-	}
+	const doc = element.document;
 
 	view.change( writer => {
+		if ( documentPlaceholders.has( doc ) ) {
+			const info = documentPlaceholders.get( doc ).get( element );
+
+			if ( info.removeCkClass ) {
+				writer.removeClass( 'ck', element );
+			}
+
+			documentPlaceholders.get( doc ).delete( element );
+		}
+
 		writer.removeClass( 'ck-placeholder', element );
 		writer.removeAttribute( 'data-placeholder', element );
 	} );

--- a/tests/view/placeholder.js
+++ b/tests/view/placeholder.js
@@ -206,4 +206,30 @@ describe( 'placeholder', () => {
 			expect( element.hasClass( 'ck', 'ck-placeholder' ) ).to.be.false;
 		} );
 	} );
+
+	it( 'should remove ck class when it was added by placeholder', () => {
+		setData( view, '<div></div><div>{another div}</div>' );
+		const element = viewRoot.getChild( 0 );
+
+		attachPlaceholder( view, element, 'foo bar baz' );
+
+		expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+		expect( element.hasClass( 'ck', 'ck-placeholder' ) ).to.be.true;
+
+		detachPlaceholder( view, element );
+		expect( !element.hasClass( 'ck' ) ).to.be.true;
+	} );
+
+	it( 'should not remove ck class when it was applied already', () => {
+		setData( view, '<div class="ck"></div><div>{another div}</div>' );
+		const element = viewRoot.getChild( 0 );
+
+		attachPlaceholder( view, element, 'foo bar baz' );
+
+		expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+		expect( element.hasClass( 'ck', 'ck-placeholder' ) ).to.be.true;
+
+		detachPlaceholder( view, element );
+		expect( element.hasClass( 'ck' ) ).to.be.true;
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Placeholder is removing `ck` CSS class only if it was added by that placeholder. Closes https://github.com/ckeditor/ckeditor5-image/issues/198.
