### PR TITLE
Remove by remove change transformation in Differ was incorrect

### DIFF
--- a/src/model/differ.js
+++ b/src/model/differ.js
@@ -645,13 +645,11 @@ export default class Differ {
 				}
 
 				if ( old.type == 'remove' ) {
-					if ( inc.offset + inc.howMany <= old.offset ) {
+					if ( incEnd <= old.offset ) {
 						old.offset -= inc.howMany;
 					} else if ( inc.offset < old.offset ) {
-						old.offset = inc.offset;
-						old.howMany += inc.nodesToHandle;
-
-						inc.nodesToHandle = 0;
+						inc.nodesToHandle += old.howMany;
+						old.howMany = 0;
 					}
 				}
 

--- a/tests/model/differ.js
+++ b/tests/model/differ.js
@@ -1321,6 +1321,23 @@ describe( 'Differ', () => {
 				] );
 			} );
 		} );
+
+		// #1392.
+		it( 'remove is correctly transformed by multiple affecting changes', () => {
+			root._appendChildren( new Element( 'paragraph', null, new Text( 'xyz' ) ) );
+
+			model.change( () => {
+				rename( root.getChild( 1 ), 'heading' );
+				rename( root.getChild( 2 ), 'heading' );
+				remove( Position.createAt( root, 0 ), 3 );
+
+				expectChanges( [
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ) },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ) },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ) }
+				] );
+			} );
+		} );
 	} );
 
 	describe( 'getChanges()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `model.Differ` should not throw when multiple, intersecting remove changes were buffered. Closes #1392.

---

### Additional information

I checked all the transformations and AFAICS only remove x remove has a troubling swallowing. Hence not a lot of changes in this PR.