### PR TITLE
t/1301: The bindTwoStepCaretToAttribute should not fail in more complex cases

### DIFF
--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -400,10 +400,14 @@ export default class DocumentSelection {
 	}
 
 	/**
-	 * Temporarily changes the gravity of the selection from left to right. The gravity defines from which direction
-	 * the selection inherits its attributes. If it's the default left gravity, the selection (after being moved by
-	 * the user) inherits attributes from its left hand side. This method allows to temporarily override this behavior
-	 * by forcing the gravity to the right.
+	 * Temporarily changes the gravity of the selection from the left to the right.
+	 *
+	 * The gravity defines from which direction the selection inherits its attributes. If it's the default left
+	 * gravity, the selection (after being moved by the the user) inherits attributes from its left hand side.
+	 * This method allows to temporarily override this behavior by forcing the gravity to the right.
+	 *
+	 * It returns an unique identifier which is required to restore the gravity. It guarantees the symmetry
+	 * of the process.
 	 *
 	 * @see module:engine/model/writer~Writer#overrideSelectionGravity
 	 * @protected
@@ -414,9 +418,11 @@ export default class DocumentSelection {
 	}
 
 	/**
-	 * Restores {@link ~DocumentSelection#_overrideGravity overridden gravity}.
+	 * Restores the {@link ~DocumentSelection#_overrideGravity overridden gravity}.
 	 *
-	 * Note that gravity remains overridden as long as won't be restored the same number of times as was overridden.
+	 * Restoring the gravity is only possible using the unique identifier returned by
+	 * {@link ~DocumentSelection#_overrideGravity}. Note that the gravity remains overridden as long as won't be restored
+	 * the same number of times it was overridden.
 	 *
 	 * @see module:engine/model/writer~Writer#restoreSelectionGravity
 	 * @protected
@@ -683,7 +689,17 @@ class LiveSelection extends Selection {
 
 	restoreGravity( uid ) {
 		if ( !this._overriddenGravityRegister.has( uid ) ) {
-			throw 'Restoring gravity for unknown id ' + uid;
+			/**
+			 * Restoring gravity for an unknown UID is not possible. Make sure you are using a correct
+			 * UID obtained from the {@link module:engine/model/writer~Writer#overrideSelectionGravity} to restore.
+			 *
+			 * @error document-selection-gravity-wrong-restore
+			 * @param {String} uid The unique identifier returned by {@link #overrideGravity}.
+			 */
+			throw new CKEditorError(
+				'document-selection-gravity-wrong-restore: Attempting to restore the selection gravity for an unknown UID.',
+				{ uid }
+			);
 		}
 
 		this._overriddenGravityRegister.delete( uid );

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -1112,6 +1112,9 @@ export default class Writer {
 	 * * Default gravity: selection will have the `bold` and `linkHref` attributes.
 	 * * Overridden gravity: selection will have `bold` attribute.
 	 *
+	 * **Note**: It returns an unique identifier which is required to restore the gravity. It guarantees the symmetry
+	 * of the process.
+	 *
 	 * @returns {String} The unique id which allows restoring the gravity.
 	 */
 	overrideSelectionGravity() {
@@ -1121,9 +1124,11 @@ export default class Writer {
 	/**
 	 * Restores {@link ~Writer#overrideSelectionGravity} gravity to default.
 	 *
-	 * Note that the gravity remains overridden as long as will not be restored the same number of times as it was overridden.
+	 * Restoring the gravity is only possible using the unique identifier returned by
+	 * {@link ~Writer#overrideSelectionGravity}. Note that the gravity remains overridden as long as won't be restored
+	 * the same number of times it was overridden.
 	 *
-	 * @param {String} uid The unique id returned by {@link #overrideSelectionGravity}.
+	 * @param {String} uid The unique id returned by {@link ~Writer#overrideSelectionGravity}.
 	 */
 	restoreSelectionGravity( uid ) {
 		this.model.document.selection._restoreGravity( uid );

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -1112,29 +1112,21 @@ export default class Writer {
 	 * * Default gravity: selection will have the `bold` and `linkHref` attributes.
 	 * * Overridden gravity: selection will have `bold` attribute.
 	 *
-	 * By default the selection's gravity is automatically restored just after a direct selection change (when user
-	 * moved the caret) but you can pass `customRestore = true` in which case you will have to call
-	 * {@link ~Writer#restoreSelectionGravity} manually.
-	 *
-	 * When the selection's gravity is overridden more than once without being restored in the meantime then it needs
-	 * to be restored the same number of times. This is to prevent conflicts when
-	 * more than one feature want to independently override and restore the selection's gravity.
-	 *
-	 * @param {Boolean} [customRestore=false] When `true` then gravity won't be restored until
-	 * {@link ~Writer#restoreSelectionGravity} will be called directly. When `false` then gravity is restored
-	 * after selection is moved by user.
+	 * @returns {String} The unique id which allows restoring the gravity.
 	 */
-	overrideSelectionGravity( customRestore ) {
-		this.model.document.selection._overrideGravity( customRestore );
+	overrideSelectionGravity() {
+		return this.model.document.selection._overrideGravity();
 	}
 
 	/**
 	 * Restores {@link ~Writer#overrideSelectionGravity} gravity to default.
 	 *
 	 * Note that the gravity remains overridden as long as will not be restored the same number of times as it was overridden.
+	 *
+	 * @param {String} uid The unique id returned by {@link #overrideSelectionGravity}.
 	 */
-	restoreSelectionGravity() {
-		this.model.document.selection._restoreGravity();
+	restoreSelectionGravity( uid ) {
+		this.model.document.selection._restoreGravity( uid );
 	}
 
 	/**

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -225,7 +225,7 @@ class TwoStepCaretHandler {
 
 		// DON'T ENGAGE 2-SCM if gravity is already overridden. It means that we just entered
 		//
-		// 		<paragraph>foo{}<$text attribute>bar</$text>baz</paragraph>
+		// 		<paragraph>foo<$text attribute>{}bar</$text>baz</paragraph>
 		//
 		// or left the attribute
 		//
@@ -236,7 +236,8 @@ class TwoStepCaretHandler {
 			return;
 		}
 
-		// DON'T ENGAGE 2-SCM when the selection is at the beginning of an attribute AND already has it:
+		// DON'T ENGAGE 2-SCM when the selection is at the beginning of the block AND already has the
+		// attribute:
 		// * when the selection was initially set there using the mouse,
 		// * when the editor has just started
 		//
@@ -257,26 +258,28 @@ class TwoStepCaretHandler {
 		if ( isBetweenDifferentValues( position, attribute ) && this._hasAttribute ) {
 			this._preventCaretMovement( data );
 			this._removeSelectionAttribute();
-		} else {
-			// ENGAGE 2-SCM when entering an attribute:
-			//
-			// 		<paragraph>foo{}<$text attribute>bar</$text>baz</paragraph>
-			//
-			if ( isAtStartBoundary( position, attribute ) ) {
-				this._preventCaretMovement( data );
-				this._overrideGravity();
 
-				return;
-			}
+			return;
+		}
 
-			// ENGAGE 2-SCM when leaving an attribute:
-			//
-			//		<paragraph>foo<$text attribute>bar{}</$text>baz</paragraph>
-			//
-			if ( isAtEndBoundary( position, attribute ) && this._hasAttribute ) {
-				this._preventCaretMovement( data );
-				this._overrideGravity();
-			}
+		// ENGAGE 2-SCM when entering an attribute:
+		//
+		// 		<paragraph>foo{}<$text attribute>bar</$text>baz</paragraph>
+		//
+		if ( isAtStartBoundary( position, attribute ) ) {
+			this._preventCaretMovement( data );
+			this._overrideGravity();
+
+			return;
+		}
+
+		// ENGAGE 2-SCM when leaving an attribute:
+		//
+		//		<paragraph>foo<$text attribute>bar{}</$text>baz</paragraph>
+		//
+		if ( isAtEndBoundary( position, attribute ) && this._hasAttribute ) {
+			this._preventCaretMovement( data );
+			this._overrideGravity();
 		}
 	}
 

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -380,8 +380,6 @@ class TwoStepCaretHandler {
 			if ( position.isAtStart && isAtBoundary( position, attribute ) ) {
 				if ( this._hasSelectionAttribute ) {
 					this._removeSelectionAttribute();
-
-					return;
 				}
 
 				return;

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -345,14 +345,26 @@ class TwoStepCaretHandler {
 				return;
 			}
 
-			// DON'T ENGAGE 2-SCM if gravity is already overridden. It means that we have already entered
+			// End of block boundary cases:
 			//
 			// 		<paragraph><$text attribute>bar{}</$text></paragraph>
+			// 		<paragraph><$text attribute>bar</$text>{}</paragraph>
 			//
 			if ( position.isAtEnd && isAtBoundary( position, attribute ) ) {
+				// DON'T ENGAGE 2-SCM if gravity is already overridden. The selection has the attribute already.
+				// This is a common selection if set using the mouse.
+				//
+				// 		<paragraph><$text attribute>bar{}</$text></paragraph>
+				//
 				if ( this._hasSelectionAttribute ) {
 					return;
-				} else {
+				}
+				// ENGAGE 2-SCM if the selection has no attribute. This may happen when the user
+				// left the attribute using a FORWARD 2-SCM.
+				//
+				// 		<paragraph><$text attribute>bar</$text>{}</paragraph>
+				//
+				else {
 					this._preventCaretMovement( data );
 					this._setSelectionAttributeFromTheNodeBefore( position );
 

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -531,28 +531,28 @@ function isAtBoundary( position, attribute ) {
 // @param {String} attribute
 function isAtStartBoundary( position, attribute ) {
 	const { nodeBefore, nodeAfter } = position;
-	const isAttrBefore = nodeAfter ? nodeAfter.hasAttribute( attribute ) : false;
-	const isAttrAfter = nodeBefore ? nodeBefore.hasAttribute( attribute ) : false;
-
-	return isAttrBefore && ( !isAttrAfter || nodeBefore.getAttribute( attribute ) !== nodeAfter.getAttribute( attribute ) );
-}
-
-// @param {module:engine/model/position~Position} position
-// @param {String} attribute
-function isAtEndBoundary( position, attribute ) {
-	const { nodeBefore, nodeAfter } = position;
-	const isAttrBefore = nodeAfter ? nodeAfter.hasAttribute( attribute ) : false;
-	const isAttrAfter = nodeBefore ? nodeBefore.hasAttribute( attribute ) : false;
+	const isAttrBefore = nodeBefore ? nodeBefore.hasAttribute( attribute ) : false;
+	const isAttrAfter = nodeAfter ? nodeAfter.hasAttribute( attribute ) : false;
 
 	return isAttrAfter && ( !isAttrBefore || nodeBefore.getAttribute( attribute ) !== nodeAfter.getAttribute( attribute ) );
 }
 
 // @param {module:engine/model/position~Position} position
 // @param {String} attribute
+function isAtEndBoundary( position, attribute ) {
+	const { nodeBefore, nodeAfter } = position;
+	const isAttrBefore = nodeBefore ? nodeBefore.hasAttribute( attribute ) : false;
+	const isAttrAfter = nodeAfter ? nodeAfter.hasAttribute( attribute ) : false;
+
+	return isAttrBefore && ( !isAttrAfter || nodeBefore.getAttribute( attribute ) !== nodeAfter.getAttribute( attribute ) );
+}
+
+// @param {module:engine/model/position~Position} position
+// @param {String} attribute
 function isBetweenDifferentValues( position, attribute ) {
 	const { nodeBefore, nodeAfter } = position;
-	const isAttrBefore = nodeAfter ? nodeAfter.hasAttribute( attribute ) : false;
-	const isAttrAfter = nodeBefore ? nodeBefore.hasAttribute( attribute ) : false;
+	const isAttrBefore = nodeBefore ? nodeBefore.hasAttribute( attribute ) : false;
+	const isAttrAfter = nodeAfter ? nodeAfter.hasAttribute( attribute ) : false;
 
 	if ( !isAttrAfter || !isAttrBefore ) {
 		return;

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -230,6 +230,7 @@ class TwoStepCaretHandler {
 	 *
 	 * @param {module:engine/model/position~Position} position The model position at the moment of the key press.
 	 * @param {module:engine/view/observer/domeventdata~DomEventData} data Data of the key press.
+	 * @returns {Boolean} `true` when the handler prevented caret movement
 	 */
 	handleForwardMovement( position, data ) {
 		const attribute = this.attribute;
@@ -302,6 +303,7 @@ class TwoStepCaretHandler {
 	 *
 	 * @param {module:engine/model/position~Position} position The model position at the moment of the key press.
 	 * @param {module:engine/view/observer/domeventdata~DomEventData} data Data of the key press.
+	 * @returns {Boolean} `true` when the handler prevented caret movement
 	 */
 	handleBackwardMovement( position, data ) {
 		const attribute = this.attribute;
@@ -418,7 +420,9 @@ class TwoStepCaretHandler {
 				this._skipNextAutomaticGravityRestoration();
 				this._overrideGravity();
 
-				return true;
+				// Don't return "true" here because we didn't call preventPrevent.
+				// Returning here will destabilize the filler logic, which also listens to
+				// keydown (and it will be stopped).
 			}
 		}
 	}

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -499,44 +499,33 @@ function isAtBoundary( position, attribute ) {
 // @param {module:engine/model/position~Position} position
 // @param {String} attribute
 function isAtStartBoundary( position, attribute ) {
-	const prevNode = position.nodeBefore;
-	const nextNode = position.nodeAfter;
-	const isAttrInNext = nextNode ? nextNode.hasAttribute( attribute ) : false;
-	const isAttrInPrev = prevNode ? prevNode.hasAttribute( attribute ) : false;
+	const { nodeBefore, nodeAfter } = position;
+	const isAttrBefore = nodeAfter ? nodeAfter.hasAttribute( attribute ) : false;
+	const isAttrAfter = nodeBefore ? nodeBefore.hasAttribute( attribute ) : false;
 
-	if ( ( !isAttrInPrev && isAttrInNext ) || isBetweenDifferentValues( position, attribute ) ) {
-		return true;
-	}
-
-	return false;
+	return isAttrBefore && ( !isAttrAfter || nodeBefore.getAttribute( attribute ) !== nodeAfter.getAttribute( attribute ) );
 }
 
 // @param {module:engine/model/position~Position} position
 // @param {String} attribute
 function isAtEndBoundary( position, attribute ) {
-	const prevNode = position.nodeBefore;
-	const nextNode = position.nodeAfter;
-	const isAttrInNext = nextNode ? nextNode.hasAttribute( attribute ) : false;
-	const isAttrInPrev = prevNode ? prevNode.hasAttribute( attribute ) : false;
+	const { nodeBefore, nodeAfter } = position;
+	const isAttrBefore = nodeAfter ? nodeAfter.hasAttribute( attribute ) : false;
+	const isAttrAfter = nodeBefore ? nodeBefore.hasAttribute( attribute ) : false;
 
-	if ( ( isAttrInPrev && !isAttrInNext ) || isBetweenDifferentValues( position, attribute ) ) {
-		return true;
-	}
-
-	return false;
+	return isAttrAfter && ( !isAttrBefore || nodeBefore.getAttribute( attribute ) !== nodeAfter.getAttribute( attribute ) );
 }
 
 // @param {module:engine/model/position~Position} position
 // @param {String} attribute
 function isBetweenDifferentValues( position, attribute ) {
-	const prevNode = position.nodeBefore;
-	const nextNode = position.nodeAfter;
-	const isAttrInNext = nextNode ? nextNode.hasAttribute( attribute ) : false;
-	const isAttrInPrev = prevNode ? prevNode.hasAttribute( attribute ) : false;
+	const { nodeBefore, nodeAfter } = position;
+	const isAttrBefore = nodeAfter ? nodeAfter.hasAttribute( attribute ) : false;
+	const isAttrAfter = nodeBefore ? nodeBefore.hasAttribute( attribute ) : false;
 
-	if ( !isAttrInPrev || !isAttrInNext ) {
+	if ( !isAttrAfter || !isAttrBefore ) {
 		return;
 	}
 
-	return nextNode.getAttribute( attribute ) !== prevNode.getAttribute( attribute );
+	return nodeAfter.getAttribute( attribute ) !== nodeBefore.getAttribute( attribute );
 }

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -420,7 +420,7 @@ class TwoStepCaretHandler {
 				this._skipNextAutomaticGravityRestoration();
 				this._overrideGravity();
 
-				// Don't return "true" here because we didn't call preventPrevent.
+				// Don't return "true" here because we didn't call preventDefault.
 				// Returning here will destabilize the filler logic, which also listens to
 				// keydown (and it will be stopped).
 			}

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -350,7 +350,7 @@ class TwoStepCaretHandler {
 			// 		<paragraph><$text attribute>bar{}</$text></paragraph>
 			// 		<paragraph><$text attribute>bar</$text>{}</paragraph>
 			//
-			if ( position.isAtEnd && isAtBoundary( position, attribute ) ) {
+			if ( position.isAtEnd && isAtEndBoundary( position, attribute ) ) {
 				// DON'T ENGAGE 2-SCM if gravity is already overridden. The selection has the attribute already.
 				// This is a common selection if set using the mouse.
 				//
@@ -377,7 +377,7 @@ class TwoStepCaretHandler {
 			//
 			// 		<paragraph>{}<$text attribute>bar</$text></paragraph>
 			//
-			if ( position.isAtStart && isAtBoundary( position, attribute ) ) {
+			if ( position.isAtStart ) {
 				if ( this._hasSelectionAttribute ) {
 					this._removeSelectionAttribute();
 				}

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -87,7 +87,14 @@ export default function bindTwoStepCaretToAttribute( view, model, emitter, attri
 	const twoStepCaretHandler = new TwoStepCaretHandler( model, emitter, attribute );
 	const modelSelection = model.document.selection;
 
-	// Listen to keyboard events and handle cursor before the move.
+	// Listen to keyboard events and handle the caret movement according to the 2-step caret logic.
+	//
+	// Note: This listener has the "high" priority. This because of the filler logic
+	// implemented in the renderer which also engages on #keydown. When the gravity is overridden
+	// the attributes of the (model) selection attributes are reset. It may end up with the
+	// filler kicking in and breaking the selection.
+	//
+	// Find out more in https://github.com/ckeditor/ckeditor5-engine/issues/1301.
 	emitter.listenTo( view.document, 'keydown', ( evt, data ) => {
 		// This implementation works only for collapsed selection.
 		if ( !modelSelection.isCollapsed ) {
@@ -115,7 +122,7 @@ export default function bindTwoStepCaretToAttribute( view, model, emitter, attri
 		} else {
 			twoStepCaretHandler.handleBackwardMovement( position, data );
 		}
-	} );
+	}, { priority: 'high' } );
 }
 
 /**

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -243,7 +243,7 @@ class TwoStepCaretHandler {
 		//
 		//		<paragraph><$text attribute>{}bar</$text>baz</paragraph>
 		//
-		if ( position.isAtStart && this._hasAttribute ) {
+		if ( position.isAtStart && this._hasSelectionAttribute ) {
 			return;
 		}
 
@@ -255,7 +255,7 @@ class TwoStepCaretHandler {
 		//
 		// 		<paragraph><$text attribute="1">foo</$text>{}<$text attribute="2">bar</$text></paragraph>
 		//
-		if ( isBetweenDifferentValues( position, attribute ) && this._hasAttribute ) {
+		if ( isBetweenDifferentValues( position, attribute ) && this._hasSelectionAttribute ) {
 			this._preventCaretMovement( data );
 			this._removeSelectionAttribute();
 
@@ -277,7 +277,7 @@ class TwoStepCaretHandler {
 		//
 		//		<paragraph>foo<$text attribute>bar{}</$text>baz</paragraph>
 		//
-		if ( isAtEndBoundary( position, attribute ) && this._hasAttribute ) {
+		if ( isAtEndBoundary( position, attribute ) && this._hasSelectionAttribute ) {
 			this._preventCaretMovement( data );
 			this._overrideGravity();
 		}
@@ -304,7 +304,7 @@ class TwoStepCaretHandler {
 			//
 			// 		<paragraph><$text attribute="1">foo</$text>{}<$text attribute="2">bar</$text></paragraph>
 			//
-			if ( isBetweenDifferentValues( position, attribute ) && this._hasAttribute ) {
+			if ( isBetweenDifferentValues( position, attribute ) && this._hasSelectionAttribute ) {
 				this._preventCaretMovement( data );
 				this._restoreGravity();
 				this._removeSelectionAttribute();
@@ -338,7 +338,7 @@ class TwoStepCaretHandler {
 			//
 			// 		<paragraph><$text attribute="1">foo</$text>{}<$text attribute="2">bar</$text></paragraph>
 			//
-			if ( isBetweenDifferentValues( position, attribute ) && !this._hasAttribute ) {
+			if ( isBetweenDifferentValues( position, attribute ) && !this._hasSelectionAttribute ) {
 				this._preventCaretMovement( data );
 				this._setSelectionAttributeFromTheNodeBefore( position );
 
@@ -350,7 +350,7 @@ class TwoStepCaretHandler {
 			// 		<paragraph><$text attribute>bar{}</$text></paragraph>
 			//
 			if ( position.isAtEnd && isAtBoundary( position, attribute ) ) {
-				if ( this._hasAttribute ) {
+				if ( this._hasSelectionAttribute ) {
 					return;
 				} else {
 					this._preventCaretMovement( data );
@@ -366,7 +366,7 @@ class TwoStepCaretHandler {
 			// 		<paragraph>{}<$text attribute>bar</$text></paragraph>
 			//
 			if ( position.isAtStart && isAtBoundary( position, attribute ) ) {
-				if ( this._hasAttribute ) {
+				if ( this._hasSelectionAttribute ) {
 					this._removeSelectionAttribute();
 
 					return;
@@ -409,7 +409,7 @@ class TwoStepCaretHandler {
 	 * @private
 	 * @type {Boolean}
 	 */
-	get _hasAttribute() {
+	get _hasSelectionAttribute() {
 		return this._modelSelection.hasAttribute( this.attribute );
 	}
 

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -122,7 +122,7 @@ export default function bindTwoStepCaretToAttribute( view, model, emitter, attri
 		} else {
 			twoStepCaretHandler.handleBackwardMovement( position, data );
 		}
-	}, { priority: 'high' } );
+	}, { priority: 'highest' } );
 }
 
 /**

--- a/src/utils/bindtwostepcarettoattribute.js
+++ b/src/utils/bindtwostepcarettoattribute.js
@@ -397,6 +397,7 @@ class TwoStepCaretHandler {
 			if ( position.isAtStart ) {
 				if ( this._hasSelectionAttribute ) {
 					this._removeSelectionAttribute();
+					this._preventCaretMovement( data );
 
 					return true;
 				}

--- a/tests/manual/tickets/1301/1.html
+++ b/tests/manual/tickets/1301/1.html
@@ -1,0 +1,3 @@
+<div id="editor">
+	<p><b>bold</b><i>i</i></p>
+</div>

--- a/tests/manual/tickets/1301/1.js
+++ b/tests/manual/tickets/1301/1.js
@@ -1,0 +1,28 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global console, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+
+import bindTwoStepCaretToAttribute from '../../../../src/utils/bindtwostepcarettoattribute';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ Essentials, Paragraph, Bold, Italic ],
+		toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ]
+	} )
+	.then( editor => {
+		const bold = editor.plugins.get( Bold );
+
+		bindTwoStepCaretToAttribute( editor.editing.view, editor.model, bold, 'bold' );
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/tests/manual/tickets/1301/1.md
+++ b/tests/manual/tickets/1301/1.md
@@ -1,0 +1,8 @@
+## Two-steps caret movement [#1301](https://github.com/ckeditor/ckeditor5-engine/issues/1301)
+
+1. Put the selection at the end of the content.
+2. Press the <kbd>←</kbd> key 3 times.
+
+## Expected:
+
+The selection should be `<b>bol{}d</b><i>i</i>` (after "l" but before "d").

--- a/tests/manual/two-step-caret.md
+++ b/tests/manual/two-step-caret.md
@@ -1,4 +1,4 @@
-## Two-steps caret movment [#1286](https://github.com/ckeditor/ckeditor5-engine/issues/1289)
+## Two-steps caret movement [#1286](https://github.com/ckeditor/ckeditor5-engine/issues/1289)
 
 ### Moving right
 1. Put selection one character before the underline

--- a/tests/utils/bindtwostepcarettoattribute.js
+++ b/tests/utils/bindtwostepcarettoattribute.js
@@ -598,7 +598,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 		} );
 	} );
 
-	it( 'should listen with the high priority on view.document#keydown', () => {
+	it( 'should listen with the highest priority on view.document#keydown', () => {
 		const highestPrioritySpy = sinon.spy();
 		const highPrioritySpy = sinon.spy();
 		const normalPrioritySpy = sinon.spy();
@@ -615,8 +615,8 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 		} );
 
 		sinon.assert.callOrder(
-			highestPrioritySpy,
 			preventDefaultSpy,
+			highestPrioritySpy,
 			highPrioritySpy,
 			normalPrioritySpy );
 	} );

--- a/tests/utils/bindtwostepcarettoattribute.js
+++ b/tests/utils/bindtwostepcarettoattribute.js
@@ -398,6 +398,96 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 		} );
 	} );
 
+	describe( 'multiple attributes', () => {
+		beforeEach( () => {
+			bindTwoStepCaretToAttribute( editor.editing.view, editor.model, emitter, 'c' );
+		} );
+
+		it( 'should work with the two-step caret movement (moving right)', () => {
+			setData( model, 'fo[]o<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux' );
+
+			testTwoStepCaretMovement( [
+				// fo[]o<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 0 },
+				'→',
+				// foo[]<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 0 },
+				'→',
+				// foo<$text a="true">[]foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 1 },
+				'→',
+				'→',
+				'→',
+				// foo<$text a="true">foo[]</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 1 },
+				'→',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">[]bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [ 'a', 'c' ], isGravityOverridden: true, preventDefault: 2 },
+				'→',
+				'→',
+				'→',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar[]</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [ 'a', 'c' ], isGravityOverridden: false, preventDefault: 2 },
+				'→',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">[]baz</$text>qux
+				{ selectionAttributes: [ 'c' ], isGravityOverridden: true, preventDefault: 3 },
+				'→',
+				'→',
+				'→',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz[]</$text>qux
+				{ selectionAttributes: [ 'c' ], isGravityOverridden: false, preventDefault: 3 },
+				'→',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>[]qux
+				{ selectionAttributes: [], isGravityOverridden: true, preventDefault: 4 },
+				'→',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>q[]ux
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 4 },
+			] );
+		} );
+
+		it( 'should work with the two-step caret movement (moving left)', () => {
+			setData( model, 'foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>q[]ux' );
+
+			testTwoStepCaretMovement( [
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>q[]ux
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 0 },
+				'←',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>[]qux
+				{ selectionAttributes: [], isGravityOverridden: true, preventDefault: 0 },
+				'←',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz[]</$text>qux
+				{ selectionAttributes: [ 'c' ], isGravityOverridden: false, preventDefault: 1 },
+				'←',
+				'←',
+				'←',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">[]baz</$text>qux
+				{ selectionAttributes: [ 'c' ], isGravityOverridden: true, preventDefault: 1 },
+				'←',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">bar[]</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [ 'a', 'c' ], isGravityOverridden: false, preventDefault: 2 },
+				'←',
+				'←',
+				'←',
+				// foo<$text a="true">foo</$text><$text a="true" c="true">[]bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [ 'a', 'c' ], isGravityOverridden: true, preventDefault: 2 },
+				'←',
+				// foo<$text a="true">foo[]</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 3 },
+				'←',
+				'←',
+				'←',
+				// foo<$text a="true">[]foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 3 },
+				'←',
+				// foo[]<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 4 },
+				'←',
+				// fo[]o<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 4 },
+			] );
+		} );
+	} );
+
 	describe( 'mouse', () => {
 		it( 'should not override gravity when selection is placed at the beginning of text', () => {
 			setData( model, '<$text a="true">[]foo</$text>' );

--- a/tests/utils/bindtwostepcarettoattribute.js
+++ b/tests/utils/bindtwostepcarettoattribute.js
@@ -461,6 +461,24 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 		expect( selection.isGravityOverridden ).to.false;
 	} );
 
+	it( 'should do nothing when the not a direct selection change but at the attribute boundary', () => {
+		setData( model, '<$text a="true">foo[]</$text>bar' );
+
+		testTwoStepCaretMovement( [
+			{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 0 },
+			'→',
+			{ selectionAttributes: [], isGravityOverridden: true, preventDefault: 1 },
+		] );
+
+		// Simulate an external text insertion BEFORE the user selection to trigger #change:range.
+		model.enqueueChange( 'transparent', writer => {
+			writer.insertText( 'x', selection.getFirstPosition().getShiftedBy( -2 ) );
+		} );
+
+		expect( selection.isGravityOverridden ).to.true;
+		expect( getSelectionAttributesArray( selection ) ).to.have.members( [] );
+	} );
+
 	const keyMap = {
 		'→': 'arrowright',
 		'←': 'arrowleft'

--- a/tests/utils/bindtwostepcarettoattribute.js
+++ b/tests/utils/bindtwostepcarettoattribute.js
@@ -128,6 +128,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			] );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1301
 		it( 'should handle passing through the only character in the block', () => {
 			setData( model, '[]<$text a="1">x</$text>' );
 
@@ -142,6 +143,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			] );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1301
 		it( 'should handle passing through the only character in the block (no attribute in the initial selection)', () => {
 			setData( model, '[]<$text a="1">x</$text>' );
 
@@ -160,6 +162,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			] );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1301
 		it( 'should handle passing through the only-child with an attribute (multiple characters)', () => {
 			setData( model, '[]<$text a="1">xyz</$text>' );
 
@@ -288,6 +291,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			] );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1301
 		it( 'should handle passing through the only-child with an attribute (single character)', () => {
 			setData( model, '<$text a="1">x</$text>[]' );
 
@@ -305,6 +309,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			] );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1301
 		it( 'should handle passing through the only character in the block (no attribute in the initial selection)', () => {
 			setData( model, '<$text a="1">x</$text>[]' );
 
@@ -323,6 +328,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			] );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1301
 		it( 'should handle passing through the only-child with an attribute (multiple characters)', () => {
 			setData( model, '<$text a="1">xyz</$text>[]' );
 
@@ -397,8 +403,42 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			] );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1346
+		// https://github.com/ckeditor/ckeditor5/issues/946
+		it( 'should correctly re-renter the attribute', () => {
+			setData( model, 'fo[]o <$text a="1">bar</$text>' );
+
+			testTwoStepCaretMovement( [
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 0 },
+				'→',
+				// foo[] <$text a="1">bar</$text>
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 0 },
+				'→',
+				// foo []<$text a="1">bar</$text>
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 0 },
+				'→',
+				// foo <$text a="1">[]bar</$text>
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 1 },
+				'→',
+				// foo <$text a="1">b[]ar</$text>
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 1 },
+				'←',
+				// foo <$text a="1">[]bar</$text>
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 1 },
+				'←',
+				// foo []<$text a="1">bar</$text>
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2 },
+				'←',
+				// foo[] <$text a="1">bar</$text>
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2 },
+				'←',
+				// fo[]o <$text a="1">bar</$text>
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2 },
+			] );
+		} );
+
 		// https://github.com/ckeditor/ckeditor5/issues/922
-		it( 'should not lose the new attribute (after)', () => {
+		it( 'should not lose the new attribute when typing (after)', () => {
 			setData( model, '<$text a="1">x[]</$text>' );
 
 			testTwoStepCaretMovement( [
@@ -426,7 +466,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 		} );
 
 		// https://github.com/ckeditor/ckeditor5/issues/922
-		it( 'should not lose the new attribute (before)', () => {
+		it( 'should not lose the new attribute when typing (before)', () => {
 			setData( model, '<$text a="1">[]x</$text>' );
 
 			testTwoStepCaretMovement( [

--- a/tests/utils/bindtwostepcarettoattribute.js
+++ b/tests/utils/bindtwostepcarettoattribute.js
@@ -221,11 +221,11 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				{ selectionAttributes: [ 'c' ], isGravityOverridden: false, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// Caret movement was not blocked but the gravity is overridden.
-				{ selectionAttributes: [ 'c' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 1 },
+				{ selectionAttributes: [ 'c' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 0 },
 				'←',
-				{ selectionAttributes: [ 'a', 'b' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 2 },
+				{ selectionAttributes: [ 'a', 'b' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
 				'←',
-				{ selectionAttributes: [ 'a', 'b' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 2 },
+				{ selectionAttributes: [ 'a', 'b' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
 			] );
 		} );
 
@@ -237,11 +237,11 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				{ selectionAttributes: [ 'a', 'b' ], isGravityOverridden: false, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// Caret movement was not blocked.
-				{ selectionAttributes: [ 'a', 'b' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 1 },
+				{ selectionAttributes: [ 'a', 'b' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 0 },
 				'←',
-				{ selectionAttributes: [ 'c' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 2 },
+				{ selectionAttributes: [ 'c' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
 				'←',
-				{ selectionAttributes: [ 'c' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 2 }
+				{ selectionAttributes: [ 'c' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 }
 			] );
 		} );
 
@@ -286,16 +286,16 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// <$text a="2">foo</$text><$text a="1">[]bar</$text>
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 1 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// <$text a="2">foo</$text>[]<$text a="1">bar</$text>
-				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 2 },
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
 				'←',
 				// <$text a="2">foo[]</$text><$text a="1">bar</$text>
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 3 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 },
 				'←',
 				// <$text a="2">fo[]o</$text><$text a="1">bar</$text>
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 3 }
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 }
 			] );
 		} );
 
@@ -367,13 +367,13 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// <$text a="1">{}xyz</$text>
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 1 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// {}<$text a="1">xyz</$text>
-				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 2 },
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
 				'←',
 				// {}<$text a="1">xyz</$text>
-				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 2 }
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 }
 			] );
 		} );
 
@@ -407,13 +407,13 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
 				'←',
 				// <$text a="1">xy</$text>[]z
-				{ selectionAttributes: [], isGravityOverridden: true, preventDefault: 1, evtStopCalled: 2 },
+				{ selectionAttributes: [], isGravityOverridden: true, preventDefault: 1, evtStopCalled: 1 },
 				'←',
 				// <$text a="1">xy[]</$text>z
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 3 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 },
 				'w',
 				// <$text a="1">xyw[]</$text>
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 3 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 },
 			] );
 		} );
 
@@ -461,16 +461,16 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
 				'←',
 				// foo <$text a="1">[]bar</$text>
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 1, evtStopCalled: 2 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 1, evtStopCalled: 1 },
 				'←',
 				// foo []<$text a="1">bar</$text>
-				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 3 },
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 },
 				'←',
 				// foo[] <$text a="1">bar</$text>
-				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 3 },
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 },
 				'←',
 				// fo[]o <$text a="1">bar</$text>
-				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 3 },
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 },
 			] );
 		} );
 
@@ -586,37 +586,37 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>[]qux
-				{ selectionAttributes: [], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 1 },
+				{ selectionAttributes: [], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz[]</$text>qux
-				{ selectionAttributes: [ 'c' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 2 },
+				{ selectionAttributes: [ 'c' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
 				'←',
 				'←',
 				'←',
 				// foo<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">[]baz</$text>qux
-				{ selectionAttributes: [ 'c' ], isGravityOverridden: true, preventDefault: 1, evtStopCalled: 3 },
+				{ selectionAttributes: [ 'c' ], isGravityOverridden: true, preventDefault: 1, evtStopCalled: 1 },
 				'←',
 				// foo<$text a="true">foo</$text><$text a="true" c="true">bar[]</$text><$text c="true">baz</$text>qux
-				{ selectionAttributes: [ 'a', 'c' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 4 },
+				{ selectionAttributes: [ 'a', 'c' ], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 },
 				'←',
 				'←',
 				'←',
 				// foo<$text a="true">foo</$text><$text a="true" c="true">[]bar</$text><$text c="true">baz</$text>qux
-				{ selectionAttributes: [ 'a', 'c' ], isGravityOverridden: true, preventDefault: 2, evtStopCalled: 5 },
+				{ selectionAttributes: [ 'a', 'c' ], isGravityOverridden: true, preventDefault: 2, evtStopCalled: 2 },
 				'←',
 				// foo<$text a="true">foo[]</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 3, evtStopCalled: 6 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 3, evtStopCalled: 3 },
 				'←',
 				'←',
 				'←',
 				// foo<$text a="true">[]foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 3, evtStopCalled: 7 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 3, evtStopCalled: 3 },
 				'←',
 				// foo[]<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
-				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 4, evtStopCalled: 8 },
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 4, evtStopCalled: 4 },
 				'←',
 				// fo[]o<$text a="true">foo</$text><$text a="true" c="true">bar</$text><$text c="true">baz</$text>qux
-				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 4, evtStopCalled: 8 },
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 4, evtStopCalled: 4 },
 			] );
 		} );
 	} );

--- a/tests/utils/bindtwostepcarettoattribute.js
+++ b/tests/utils/bindtwostepcarettoattribute.js
@@ -396,6 +396,62 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 1 },
 			] );
 		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/922
+		it( 'should not lose the new attribute (after)', () => {
+			setData( model, '<$text a="1">x[]</$text>' );
+
+			testTwoStepCaretMovement( [
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 0 },
+				'→',
+				// <$text a="1">x</$text>[]
+				{ selectionAttributes: [], isGravityOverridden: true, preventDefault: 1 }
+			] );
+
+			model.change( writer => {
+				writer.setSelectionAttribute( 'b', 1 );
+			} );
+
+			// <$text a="1">x</$text><$text b="1">[]</$text>
+			expect( selection.isGravityOverridden ).to.be.true;
+			expect( getSelectionAttributesArray( selection ) ).to.have.members( [ 'b' ] );
+
+			model.change( writer => {
+				writer.insertText( 'yz', selection.getAttributes(), selection.getFirstPosition() );
+			} );
+
+			// <$text a="1">x</$text><$text b="1">yz[]</$text>
+			expect( selection.isGravityOverridden ).to.be.false;
+			expect( getSelectionAttributesArray( selection ) ).to.have.members( [ 'b' ] );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/922
+		it( 'should not lose the new attribute (before)', () => {
+			setData( model, '<$text a="1">[]x</$text>' );
+
+			testTwoStepCaretMovement( [
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 0 },
+				'←',
+				// []<$text a="1">x</$text>
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 0 }
+			] );
+
+			model.change( writer => {
+				writer.setSelectionAttribute( 'b', 1 );
+			} );
+
+			// <$text b="1">[]</$text><$text a="1">x</$text>
+			expect( selection.isGravityOverridden ).to.be.false;
+			expect( getSelectionAttributesArray( selection ) ).to.have.members( [ 'b' ] );
+
+			model.change( writer => {
+				writer.insertText( 'yz', selection.getAttributes(), selection.getFirstPosition() );
+			} );
+
+			// <$text b="1">yz[]</$text><$text a="1">x</$text>
+			expect( selection.isGravityOverridden ).to.be.false;
+			expect( getSelectionAttributesArray( selection ) ).to.have.members( [ 'b' ] );
+		} );
 	} );
 
 	describe( 'multiple attributes', () => {
@@ -492,13 +548,13 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 		it( 'should not override gravity when selection is placed at the beginning of text', () => {
 			setData( model, '<$text a="true">[]foo</$text>' );
 
-			expect( selection.isGravityOverridden ).to.false;
+			expect( selection.isGravityOverridden ).to.be.false;
 		} );
 
 		it( 'should not override gravity when selection is placed at the end of text', () => {
 			setData( model, '<$text a="true">foo[]</$text>' );
 
-			expect( selection.isGravityOverridden ).to.false;
+			expect( selection.isGravityOverridden ).to.be.false;
 		} );
 	} );
 
@@ -515,7 +571,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 
 		fireKeyDownEvent( { keyCode: keyCodes.arrowright } );
 
-		expect( selection.isGravityOverridden ).to.false;
+		expect( selection.isGravityOverridden ).to.be.false;
 	} );
 
 	it( 'should do nothing when shift key is pressed', () => {
@@ -526,7 +582,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			shiftKey: true
 		} );
 
-		expect( selection.isGravityOverridden ).to.false;
+		expect( selection.isGravityOverridden ).to.be.false;
 	} );
 
 	it( 'should do nothing when alt key is pressed', () => {
@@ -537,7 +593,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			altKey: true
 		} );
 
-		expect( selection.isGravityOverridden ).to.false;
+		expect( selection.isGravityOverridden ).to.be.false;
 	} );
 
 	it( 'should do nothing when ctrl key is pressed', () => {
@@ -548,7 +604,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			ctrlKey: true
 		} );
 
-		expect( selection.isGravityOverridden ).to.false;
+		expect( selection.isGravityOverridden ).to.be.false;
 	} );
 
 	it( 'should do nothing when the not a direct selection change but at the attribute boundary', () => {
@@ -565,7 +621,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			writer.insertText( 'x', selection.getFirstPosition().getShiftedBy( -2 ) );
 		} );
 
-		expect( selection.isGravityOverridden ).to.true;
+		expect( selection.isGravityOverridden ).to.be.true;
 		expect( getSelectionAttributesArray( selection ) ).to.have.members( [] );
 	} );
 

--- a/tests/utils/bindtwostepcarettoattribute.js
+++ b/tests/utils/bindtwostepcarettoattribute.js
@@ -598,6 +598,29 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 		} );
 	} );
 
+	it( 'should listen with the high priority on view.document#keydown', () => {
+		const highestPrioritySpy = sinon.spy();
+		const highPrioritySpy = sinon.spy();
+		const normalPrioritySpy = sinon.spy();
+
+		setData( model, '<$text c="true">foo[]</$text><$text a="true" b="true">bar</$text>' );
+
+		emitter.listenTo( viewDoc, 'keydown', highestPrioritySpy, { priority: 'highest' } );
+		emitter.listenTo( viewDoc, 'keydown', highPrioritySpy, { priority: 'high' } );
+		emitter.listenTo( viewDoc, 'keydown', normalPrioritySpy, { priority: 'normal' } );
+
+		fireKeyDownEvent( {
+			keyCode: keyCodes.arrowright,
+			preventDefault: preventDefaultSpy
+		} );
+
+		sinon.assert.callOrder(
+			highestPrioritySpy,
+			preventDefaultSpy,
+			highPrioritySpy,
+			normalPrioritySpy );
+	} );
+
 	it( 'should do nothing when key other then arrow left and right is pressed', () => {
 		setData( model, '<$text a="true">foo[]</$text>' );
 

--- a/tests/utils/bindtwostepcarettoattribute.js
+++ b/tests/utils/bindtwostepcarettoattribute.js
@@ -324,7 +324,7 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// <$text a="1">{}x</$text>
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 0, evtStopCalled: 0 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 0 },
 				'←',
 				// {}<$text a="1">x</$text> (because it's a first-child)
 				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
@@ -345,11 +345,29 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 				'←',
 				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
 				'←',
-				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 1, evtStopCalled: 1 },
 				'←',
 				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 },
 				'←',
 				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 2, evtStopCalled: 2 }
+			] );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1301
+		it( 'should handle passing through the only-child with an attribute (single character, text before)', () => {
+			setData( model, 'abc<$text a="1">x</$text>[]' );
+
+			testTwoStepCaretMovement( [
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: false, preventDefault: 0, evtStopCalled: 0 },
+				'←',
+				// abc<$text a="1">{}x</$text>
+				{ selectionAttributes: [ 'a' ], isGravityOverridden: true, preventDefault: 0, evtStopCalled: 0 },
+				'←',
+				// abc{}<$text a="1">x</$text> (because it's a first-child)
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 },
+				'←',
+				// abc{}<$text a="1">x</$text>
+				{ selectionAttributes: [], isGravityOverridden: false, preventDefault: 1, evtStopCalled: 1 }
 			] );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `bindTwoStepCaretToAttribute` behavioral helper should not fail in more complex cases. Closes #1301. Closes #1346. Closes ckeditor/ckeditor5#937.  Closes ckeditor/ckeditor5#922.  Closes ckeditor/ckeditor5#946.

---

### Additional information

**Note**: A thorough testing required before merging. @Mgsy?
