### PR TITLE
Avoid unnecessary DOM structure updates in renderer

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -237,15 +237,17 @@ export default class Renderer {
 	}
 
 	/**
-	 * Updates viewElement children mappings. Children which were replaced in the view structure by the similar
-	 * element (same tag name) are treated as 'replaced'. Their mappings are rebind to the corresponding,
-	 * existing DOM element so they will not be replaced by a new DOM element during rendering.
+	 * Updates mapping of `viewElement`'s children.
+	 *
+	 * Children which were replaced in the view structure by similar elements (same tag name) are treated as 'replaced'.
+	 * This means that we can update their mappings so the new view elements are mapped to the existing DOM elements.
+	 * Thanks to that we won't need to re-render these elements completely.
 	 *
 	 * @private
 	 * @param {module:engine/view/node~Node} viewElement The view element which children mappings will be updated.
 	 */
 	_updateChildrenMappings( viewElement ) {
-		// We do not perform any operations on DOM here so there is no need to bind view element or convert its children.
+		// We're diffing only so we don't have to bind anything.
 		const diff = this._diffElementChildren( viewElement, { bind: false, withChildren: false } );
 
 		if ( diff ) {

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -181,11 +181,6 @@ export default class Renderer {
 	render() {
 		let inlineFillerPosition;
 
-		if ( this.markedChildren.size > 1 ) {
-			// Sort `this.markedChildren` by nesting level.
-			this.markedChildren = this._sortElementsByNestingLevel( this.markedChildren );
-		}
-
 		// Refresh mappings.
 		for ( const element of this.markedChildren ) {
 			this._updateChildrenMappings( element );
@@ -252,45 +247,6 @@ export default class Renderer {
 		this.markedTexts.clear();
 		this.markedAttributes.clear();
 		this.markedChildren.clear();
-	}
-
-	/**
-	 * Sorts elements set based on their nesting level. The outermost elements are placed first.
-	 * It check only for 2 element types: `containerElement` and `attributeElement`. Elements of these types
-	 * are sorted (from `containerElement` to `attributeElement`) and any other type (e.g. `rootElement` or
-	 * `documentFragment`) have higher priority so is placed higher in the sorted set.
-	 * Additionally if elements are of the same type, they are both checked if one is another parent so proper
-	 * order can be established between them (parent first).
-	 *
-	 * @private
-	 * @param {Set.<module:engine/view/node~Node>} elements Elements to be sorted.
-	 * @returns {Set.<module:engine/view/node~Node>} Sorted elements.
-	 */
-	_sortElementsByNestingLevel( elements ) {
-		function getPriority( node ) {
-			let priority = 2;
-			if ( node.is( 'containerElement' ) ) {
-				priority = 1;
-			} else if ( node.is( 'attributeElement' ) ) {
-				priority = 0;
-			}
-			return priority;
-		}
-
-		const elementsArray = Array.from( elements );
-		elementsArray.sort( ( node1, node2 ) => {
-			let priority = getPriority( node2 ) - getPriority( node1 );
-			if ( priority === 0 ) {
-				if ( node1.parent === node2 ) {
-					priority = 1;
-				} else if ( node2.parent === node1 ) {
-					priority = -1;
-				}
-			}
-			return priority;
-		} );
-
-		return new Set( elementsArray );
 	}
 
 	/**

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -697,21 +697,27 @@ export default class Renderer {
 		}
 
 		let newActions = [];
+		let skipActions = [];
 		let actualSlice = [];
 		let expectedSlice = [];
 
 		const counter = { equal: 0, insert: 0, delete: 0 };
 		for ( const action of actions ) {
 			if ( action === 'insert' ) {
+				skipActions.push( 'insert' );
 				expectedSlice.push( expectedDom[ counter.equal + counter.insert ] );
 			} else if ( action === 'delete' ) {
+				skipActions.push( 'delete' );
 				actualSlice.push( actualDom[ counter.equal + counter.delete ] );
 			} else { // equal
 				if ( expectedSlice.length && actualSlice.length ) {
 					newActions = newActions.concat( calculateReplaceActions( actualSlice, expectedSlice ) );
+				} else if ( expectedSlice.length || actualSlice.length ) {
+					newActions = newActions.concat( skipActions );
 				}
 				newActions.push( 'equal' );
 				// Reset stored elements on 'equal'.
+				skipActions = [];
 				actualSlice = [];
 				expectedSlice = [];
 			}

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -182,7 +182,7 @@ export default class Renderer {
 		let inlineFillerPosition;
 
 		if ( this.markedChildren.size > 1 ) {
-			// Sort `this.markedChildren` by the nesting level.
+			// Sort `this.markedChildren` by nesting level.
 			this.markedChildren = this._sortElementsByNestingLevel( this.markedChildren );
 		}
 
@@ -255,12 +255,12 @@ export default class Renderer {
 	}
 
 	/**
-	 * Sorts elements set based on their nesting. The outermost elements are placed first.
-	 * It check only for 2 element types: `containerElement` and `attributeElement`. Those elements
-	 * are sorted in such order (from `containerElement` to `attributeElement`). Any other type (e.g. `rootElement` or
-	 * `documentFragment`) have higher priority and is placed higher in the sorted set.
+	 * Sorts elements set based on their nesting level. The outermost elements are placed first.
+	 * It check only for 2 element types: `containerElement` and `attributeElement`. Elements of these types
+	 * are sorted (from `containerElement` to `attributeElement`) and any other type (e.g. `rootElement` or
+	 * `documentFragment`) have higher priority so is placed higher in the sorted set.
 	 * Additionally if elements are of the same type, they are both checked if one is another parent so proper
-	 * order can be established (parent first).
+	 * order can be established between them (parent first).
 	 *
 	 * @private
 	 * @param {Set.<module:engine/view/node~Node>} elements Elements to be sorted.
@@ -294,12 +294,12 @@ export default class Renderer {
 	}
 
 	/**
-	 * Updates element children mappings. Children which were replaced in the view structure by the similar
+	 * Updates viewElement children mappings. Children which were replaced in the view structure by the similar
 	 * element (same tag name) are treated as 'replaced'. Their mappings are rebind to the corresponding,
-	 * existing DOM element so they will not be replaced by new DOM element during rerendering.
+	 * existing DOM element so they will not be replaced by a new DOM element during rendering.
 	 *
 	 * @private
-	 * @param {module:engine/view/node~Node} viewElement View element which children mappings will be updated.
+	 * @param {module:engine/view/node~Node} viewElement The view element which children mappings will be updated.
 	 */
 	_updateChildrenMappings( viewElement ) {
 		// We do not perform any operations on DOM here so there is no need to bind view element or convert its' children.
@@ -319,7 +319,7 @@ export default class Renderer {
 						if ( viewChild ) {
 							this.domConverter.unbindDomElement( diff.actualDomChildren[ deleteIndex ] );
 							this.domConverter.bindElements( diff.actualDomChildren[ deleteIndex ], viewChild );
-							// View element may have children which needs to be updated but are not marked, mark them to update.
+							// View element may have children which needs to be updated, but are not marked, mark them to update.
 							this.markedChildren.add( viewChild );
 						}
 
@@ -600,8 +600,8 @@ export default class Renderer {
 	}
 
 	/**
-	 * Compares element actual and expected children and finds list of actions which can be used to transform
-	 * actual children to expected ones.
+	 * Compares viewElement actual and expected children and actions sequence which can be used to transform
+	 * actual children into expected ones.
 	 *
 	 * @private
 	 * @param viewElement
@@ -615,7 +615,6 @@ export default class Renderer {
 	 * @returns {Node} result.domElement ViewElement corresponding DOM element.
 	 * @returns {Array} result.actualDomChildren Current viewElement DOM children.
 	 * @returns {Array} result.expectedDomChildren Expected viewElement DOM children.
-	 *
 	 */
 	_diffElementChildren( viewElement, options ) {
 		const domConverter = this.domConverter;
@@ -623,7 +622,7 @@ export default class Renderer {
 
 		if ( !domElement ) {
 			// If there is no `domElement` it means that it was already removed from DOM.
-			// There is no need to update it. It will be updated when re-inserted.
+			// There is no need to process it. It will be processed when re-inserted.
 			return null;
 		}
 
@@ -667,8 +666,8 @@ export default class Renderer {
 	}
 
 	/**
-	 * Finds DOM nodes which were replaced with the similar nodes (same tag name) in the `insert`/`delete`
-	 * action groups (based on actual and expected DOM). For example:
+	 * Finds DOM nodes which were replaced with the similar nodes (same tag name) in the view. All nodes are compared
+	 * within one `insert`/`delete` action group, for example:
 	 *
 	 * 		Actual DOM:		<p><b>Foo</b>Bar<i>Baz</i><b>Bax</b></p>
 	 * 		Expected DOM:	<p>Bar<b>123</b><i>Baz</i><b>456</b></p>

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -116,7 +116,7 @@ export default class Renderer {
 	}
 
 	/**
-	 * Marks node to be synchronized with the DOM.
+	 * Marks node to be updated in the DOM by {@link #render `render()`}.
 	 *
 	 * Note that only view nodes which parents have corresponding DOM elements need to be marked to be synchronized.
 	 *

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -316,10 +316,12 @@ export default class Renderer {
 						const deleteIndex = counter.equal + counter.delete;
 						const viewChild = viewElement.getChild( insertIndex );
 
-						this.domConverter.unbindDomElement( diff.actualDomChildren[ deleteIndex ] );
-						this.domConverter.bindElements( diff.actualDomChildren[ deleteIndex ], viewChild );
-						// View element may have children which needs to be updated but are not marked, mark them to update.
-						this.markedChildren.add( viewChild );
+						if ( viewChild ) {
+							this.domConverter.unbindDomElement( diff.actualDomChildren[ deleteIndex ] );
+							this.domConverter.bindElements( diff.actualDomChildren[ deleteIndex ], viewChild );
+							// View element may have children which needs to be updated but are not marked, mark them to update.
+							this.markedChildren.add( viewChild );
+						}
 
 						remove( diff.expectedDomChildren[ insertIndex ] );
 						counter.equal++;

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -116,7 +116,7 @@ export default class Renderer {
 	}
 
 	/**
-	 * Marks node to be updated in the DOM by {@link #render `render()`}.
+	 * Marks a view node to be updated in the DOM by {@link #render `render()`}.
 	 *
 	 * Note that only view nodes which parents have corresponding DOM elements need to be marked to be synchronized.
 	 *

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -12,6 +12,7 @@ import ViewAttributeElement from '../../src/view/attributeelement';
 import ViewText from '../../src/view/text';
 import ViewRange from '../../src/view/range';
 import ViewPosition from '../../src/view/position';
+import UIElement from '../../src/view/uielement';
 import DocumentSelection from '../../src/view/documentselection';
 import DomConverter from '../../src/view/domconverter';
 import Renderer from '../../src/view/renderer';
@@ -2947,6 +2948,40 @@ describe( 'Renderer', () => {
 					'<ol><li style="color:#FFF;">Foo</li>' +
 					'<li style="font-weight:bold;">Ba1 <i style="color:#000;border-width:1px;">Ba3 ' +
 					'<b style="font-size:15px;">Ba2</b></i></li></ol>' ) );
+			} );
+
+			it( 'should handle uiElement rendering', () => {
+				function createUIElement( id, text ) {
+					const element = new UIElement( 'span' );
+					element.render = function( domDocument ) {
+						const domElement = this.toDomElement( domDocument );
+						domElement.innerText = `<span id="${ id }"><b>${ text }</b></span>`;
+						return domElement;
+					};
+
+					return element;
+				}
+
+				const ui1 = createUIElement( 'id1', 'UI1' );
+				const ui2 = createUIElement( 'id2', 'UI2' );
+				const viewP = new ViewContainerElement( 'p', null, [ new ViewText( 'Foo ' ), ui1, new ViewText( 'Bar' ) ] );
+				viewRoot._appendChild( viewP );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( normalizeHtml(
+					'<p>Foo <span><span id="id1"><b>UI1</b></span></span>Bar</p>' ) );
+
+				viewP._removeChildren( 0, viewP.childCount );
+				viewP._insertChild( 0, [ new ViewText( 'Foo' ), ui2, new ViewText( ' Bar' ) ] );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.markToSync( 'children', viewP );
+				renderer.render();
+
+				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( normalizeHtml(
+					'<p>Foo<span><span id="id2"><b>UI2</b></span></span> Bar</p>' ) );
 			} );
 		} );
 	} );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -2757,6 +2757,30 @@ describe( 'Renderer', () => {
 					'<blockquote>Foo Bar Baz</blockquote>' +
 					'<ul><li>Item <strong>1</strong></li><li><a href="https://ckeditor.com">Item</a> 2</li></ul>' );
 			} );
+
+			it( 'should properly handle br elements while refreshing bindings', () => {
+				const expected = `<p>Foo Bar</p><p>${ BR_FILLER( document ).outerHTML }</p>`; // eslint-disable-line new-cap
+
+				viewRoot._appendChild( parse( '<container:p>Foo Bar</container:p><container:p></container:p>' ) );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				expect( domRoot.innerHTML ).to.equal( expected );
+
+				// There is a case in Safari that during accent panel navigation on macOS our 'BR_FILLER' is replaced with
+				// just '<br>' element which breaks accent composition in an empty paragraph. It also throws an error while
+				// refreshing mappings in a renderer. Simulate such behaviour (#1354).
+				domRoot.childNodes[ 1 ].innerHTML = '<br>';
+
+				viewRoot._removeChildren( 1 );
+				viewRoot._insertChild( 1, parse( '<container:p></container:p>' ) );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				expect( domRoot.innerHTML ).to.equal( expected );
+			} );
 		} );
 	} );
 

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -2983,6 +2983,30 @@ describe( 'Renderer', () => {
 				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( normalizeHtml(
 					'<p>Foo<span><span id="id2"><b>UI2</b></span></span> Bar</p>' ) );
 			} );
+
+			it( 'should handle linking entire content', () => {
+				viewRoot._appendChild( parse( '<container:p>Foo<attribute:i>Bar</attribute:i></container:p>' ) );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				expect( domRoot.innerHTML ).to.equal( '<p>Foo<i>Bar</i></p>' );
+
+				const viewP = viewRoot.getChild( 0 );
+				// While linking, the existing DOM children are moved to a new `a` element during binding
+				// inside the `domConverter.viewToDom()` method. It happens because of a modified view structure
+				// where view elements were moved to a newly created link view element.
+				const viewA = new ViewAttributeElement( 'a', { href: '#href' }, [ new ViewText( 'Foo' ), viewP.getChild( 1 ) ] );
+
+				viewP._removeChildren( 0, viewP.childCount );
+				viewP._insertChild( 0, viewA );
+
+				renderer.markToSync( 'children', viewRoot );
+				renderer.markToSync( 'children', viewP );
+				renderer.render();
+
+				expect( domRoot.innerHTML ).to.equal( '<p><a href="#href">Foo<i>Bar</i></a></p>' );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Avoid unnecessary DOM structure updates in `Renderer`. Closes #1417. Closes #1409. Closes #1349. Closes #1334. Closes #898. Closes ckeditor/ckeditor5-typing#129. Closes ckeditor/ckeditor5-typing#89. Closes #1427.

---

### Additional information

See the extensive comment about the implemented solution in https://github.com/ckeditor/ckeditor5-engine/issues/1417#issuecomment-393845235.

There is also one issue which I'm unable to reproduce (from the beginning) so we should definitely ping the person who reported it to recheck after this PR gets merged - https://github.com/ckeditor/ckeditor5/issues/748.