### PR TITLE
Fixed view <-> DOM conversion of whitespaces around <br> elements

### DIFF
--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -1034,12 +1034,17 @@ export default class DomConverter {
 		} );
 
 		for ( const value of treeWalker ) {
+			// ViewContainerElement is found on a way to next ViewText node, so given `node` was first/last
+			// text node in its container element.
 			if ( value.item.is( 'containerElement' ) ) {
-				// ViewContainerElement is found on a way to next ViewText node, so given `node` was first/last
-				// text node in its container element.
 				return null;
-			} else if ( value.item.is( 'textProxy' ) ) {
-				// Found a text node in the same container element.
+			}
+			// <br> found – it works like a block boundary, so do not scan further.
+			else if ( value.item.is( 'br' ) ) {
+				return null;
+			}
+			// Found a text node in the same container element.
+			else if ( value.item.is( 'textProxy' ) ) {
 				return value.item;
 			}
 		}

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -948,10 +948,11 @@ export default class DomConverter {
 	 * Takes text data from native `Text` node and processes it to a correct {@link module:engine/view/text~Text view text node} data.
 	 *
 	 * Following changes are done:
+	 *
 	 * * multiple whitespaces are replaced to a single space,
-	 * * space at the beginning of the text node is removed, if it is a first text node in it's container
-	 * element or if previous text node ends by space character,
-	 * * space at the end of the text node is removed, if it is a last text node in it's container.
+	 * * space at the beginning of a text node is removed if it is the first text node in its container
+	 * element or if the previous text node ends with a space character,
+	 * * space at the end of the text node is removed, if it is the last text node in its container.
 	 *
 	 * @param {Node} node DOM text node to process.
 	 * @returns {String} Processed data.

--- a/tests/view/domconverter/whitespace-handling-integration.js
+++ b/tests/view/domconverter/whitespace-handling-integration.js
@@ -5,14 +5,19 @@
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
 
 import { getData } from '../../../src/dev-utils/model';
+
+// NOTE:
+// dev utils' setData() loses white spaces so don't use it for tests here!!!
+// https://github.com/ckeditor/ckeditor5-engine/issues/1428
 
 describe( 'DomConverter – whitespace handling – integration', () => {
 	let editor;
 
 	// See https://github.com/ckeditor/ckeditor5-engine/issues/822.
-	describe( 'data loading', () => {
+	describe( 'normalizing whitespaces around block boundaries (#822)', () => {
 		beforeEach( () => {
 			return VirtualTestEditor
 				.create( { plugins: [ Paragraph ] } )
@@ -143,6 +148,139 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 				.to.equal( '<paragraph>foo</paragraph><paragraph>bar</paragraph>' );
 
 			expect( editor.getData() ).to.equal( '<p>foo</p><p>bar</p>' );
+		} );
+	} );
+
+	// https://github.com/ckeditor/ckeditor5/issues/1024
+	describe( 'whitespaces around <br>s', () => {
+		beforeEach( () => {
+			return VirtualTestEditor
+				.create( { plugins: [ Paragraph, ShiftEnter ] } )
+				.then( newEditor => {
+					editor = newEditor;
+				} );
+		} );
+
+		afterEach( () => {
+			return editor.destroy();
+		} );
+
+		it( 'single spaces around <br>', () => {
+			editor.setData( '<p>foo&nbsp;<br>&nbsp;bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo <softBreak></softBreak> bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo&nbsp;<br>&nbsp;bar</p>' );
+		} );
+
+		it( 'single spaces around <br> (normalization)', () => {
+			editor.setData( '<p>foo&nbsp;<br> bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo <softBreak></softBreak>bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo&nbsp;<br>bar</p>' );
+		} );
+
+		it( 'two spaces before a <br>', () => {
+			editor.setData( '<p>foo &nbsp;<br>bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo  <softBreak></softBreak>bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo &nbsp;<br>bar</p>' );
+		} );
+
+		it( 'two spaces before a <br> (normalization)', () => {
+			editor.setData( '<p>foo&nbsp; <br>bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo  <softBreak></softBreak>bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo &nbsp;<br>bar</p>' );
+		} );
+
+		it( 'two spaces before a <br> (normalization to a model nbsp)', () => {
+			editor.setData( '<p>foo&nbsp;&nbsp;<br>bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo\u00a0 <softBreak></softBreak>bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo&nbsp;&nbsp;<br>bar</p>' );
+		} );
+
+		it( 'single space after a <br>', () => {
+			editor.setData( '<p>foo<br>&nbsp;bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo<softBreak></softBreak> bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo<br>&nbsp;bar</p>' );
+		} );
+
+		it( 'single space after a <br> (normalization)', () => {
+			editor.setData( '<p>foo<br> bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo<softBreak></softBreak>bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo<br>bar</p>' );
+		} );
+
+		it( 'two spaces after a <br>', () => {
+			editor.setData( '<p>foo<br>&nbsp; bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo<softBreak></softBreak>  bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo<br>&nbsp; bar</p>' );
+		} );
+
+		it( 'two spaces after a <br> (normalization)', () => {
+			editor.setData( '<p>foo<br> &nbsp;bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo<softBreak></softBreak> bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo<br>&nbsp;bar</p>' );
+		} );
+
+		it( 'two spaces after a <br> (normalization to a model nbsp)', () => {
+			editor.setData( '<p>foo<br>&nbsp;&nbsp;bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo<softBreak></softBreak> \u00a0bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo<br>&nbsp;&nbsp;bar</p>' );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1429
+		// it( 'space between <br>s', () => {
+		// 	editor.setData( '<p>foo<br>&nbsp;<br>bar</p>' );
+
+		// 	expect( getData( editor.model, { withoutSelection: true } ) )
+		// 		.to.equal( '<paragraph>foo<softBreak></softBreak> <softBreak></softBreak>bar</paragraph>' );
+
+		// 	expect( editor.getData() ).to.equal( '<p>foo<br>&nbsp;<br>bar</p>' );
+		// } );
+
+		it( 'space between <br>s (normalization)', () => {
+			editor.setData( '<p>foo<br> <br>bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo<softBreak></softBreak><softBreak></softBreak>bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo<br><br>bar</p>' );
+		} );
+
+		it( 'two spaces between <br>s', () => {
+			editor.setData( '<p>foo<br>&nbsp;&nbsp;<br>bar</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>foo<softBreak></softBreak>  <softBreak></softBreak>bar</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>foo<br>&nbsp;&nbsp;<br>bar</p>' );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed view <-> DOM conversion of whitespaces around `<br>` elements. Closes ckeditor/ckeditor5#1024.

---

### Additional information

Requires: https://github.com/ckeditor/ckeditor5-enter/pull/54.

One known issue: https://github.com/ckeditor/ckeditor5-engine/issues/1429.