### PR TITLE
Fix links in API docs

### DIFF
--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -795,7 +795,7 @@ export default class Writer {
 	 * markers managed by operations and not-managed by operations.
 	 *
 	 * The `options.affectsData` parameter, which defaults to `false`, allows you to define if a marker affects the data. It should be
-	 * `true` when the marker change changes the data returned by {@link module:core/editor/editor~Editor#getData} method.
+	 * `true` when the marker change changes the data returned by {@link module:core/editor/utils/dataapimixin~DataApi#getData} method.
 	 * When set to `true` it fires the {@link module:engine/model/document~Document#event:change:data `change:data`} event.
 	 * When set to `false` it fires the {@link module:engine/model/document~Document#event:change `change`} event.
 	 *
@@ -880,7 +880,7 @@ export default class Writer {
 	 * markers managed by operations and not-managed by operations. It is possible to change this option for an existing marker.
 	 *
 	 * The `options.affectsData` parameter, which defaults to `false`, allows you to define if a marker affects the data. It should be
-	 * `true` when the marker change changes the data returned by {@link module:core/editor/editor~Editor#getData} method.
+	 * `true` when the marker change changes the data returned by {@link module:core/editor/utils/dataapimixin~DataApi#getData} method.
 	 * When set to `true` it fires the {@link module:engine/model/document~Document#event:change:data `change:data`} event.
 	 * When set to `false` it fires the {@link module:engine/model/document~Document#event:change `change`} event.
 	 *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed links in the `Writer` API docs. Closes #1434.
