### PR TITLE
Use Selection.prototype.containsNode for better caret tracking

### DIFF
--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -102,7 +102,7 @@ export default class SelectionObserver extends Observer {
 		}
 
 		this.listenTo( domDocument, 'selectionchange', () => {
-			this._handleSelectionChange( domDocument );
+			this._handleSelectionChange( domElement );
 		} );
 
 		this._documents.add( domDocument );
@@ -124,13 +124,10 @@ export default class SelectionObserver extends Observer {
 	 * and {@link module:engine/view/document~Document#event:selectionChangeDone} when selection stop changing.
 	 *
 	 * @private
-	 * @param {Document} domDocument DOM document.
+	 * @param {Element} domElement DOM element.
 	 */
-	_handleSelectionChange( domDocument ) {
-		// Selection is handled when document is not focused but is read-only. This is because in read-only
-		// mode contenteditable is set as false and editor won't receive focus but we still need to know
-		// selection position.
-		if ( !this.isEnabled || ( !this.document.isFocused && !this.document.isReadOnly ) ) {
+	_handleSelectionChange( domElement ) {
+		if ( !this.isEnabled ) {
 			return;
 		}
 
@@ -139,7 +136,12 @@ export default class SelectionObserver extends Observer {
 
 		// If there were mutations then the view will be re-rendered by the mutation observer and selection
 		// will be updated, so selections will equal and event will not be fired, as expected.
-		const domSelection = domDocument.defaultView.getSelection();
+		const domSelection = domElement.ownerDocument.defaultView.getSelection();
+
+		if ( !domSelection.containsNode( domElement, true ) ) {
+			return;
+		}
+
 		const newViewSelection = this.domConverter.domSelectionToView( domSelection );
 
 		if ( this.selection.isEqual( newViewSelection ) && this.domConverter.isDomSelectionCorrect( domSelection ) ) {


### PR DESCRIPTION
There are a lot of open issues so I am not sure what issues if any this would close, but here is what I've got:

<dl>
<dt>Chrome
<dd>Always fires <code>focus</code> before <code>selectionchange</code>
<dt>Edge
<dd>Always fires <code>focus</code> before <code>selectionchange</code>
<dt>IE
<dd>Always fires <code>focus</code> after <code>selectionchange</code>
<dt>Firefox
<dd>Fires <code>focus</code> after <code>selectionchange</code> when focus was not in the document
<dd>Fires <code>focus</code> after <code>selectionchange</code> when the caret is placed after all nodes in the editor
<dd>Fires <code>focus</code> before <code>selectionchange</code> otherwise
</dl>

The `SelectionObserver` was checking whether or not the editor was focused and using that to decide whether or not it could skip firing the `selectionChange` event for the `Document`. But thanks to the last two browsers on that list, we cannot actually be sure if the `selectionchange` DOM event is irrelevant just by checking whether we have focus. This pull request instead checks whether the resulting DOM selection includes all or part of the editor element, resulting in a better experience in Firefox and IE. Otherwise, every time you click back into the editor, your caret jumps back to where it was the last time the editor had focus. 👎 