### PR TITLE
Element to attribute upcast should set attribute on all the elements inside the converted element

### DIFF
--- a/tests/conversion/upcast-converters.js
+++ b/tests/conversion/upcast-converters.js
@@ -349,6 +349,27 @@ describe( 'upcast-helpers', () => {
 				'<$text attribB="true" bold="true">foo</$text>'
 			);
 		} );
+
+		// #1443.
+		it( 'should set attributes on the element\'s children', () => {
+			const helperBold = upcastElementToAttribute( {
+				model: 'bold',
+				view: { name: 'strong' }
+			} );
+
+			const helperP = upcastElementToElement( { view: 'p', model: 'paragraph' } );
+
+			conversion.for( 'upcast' ).add( helperP ).add( helperBold );
+
+			expectResult(
+				new ViewAttributeElement(
+					'strong',
+					null,
+					new ViewContainerElement( 'p', null, new ViewText( 'Foo' ) )
+				),
+				'<paragraph><$text bold="true">Foo</$text></paragraph>'
+			);
+		} );
 	} );
 
 	describe( 'upcastAttributeToAttribute', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Element to attribute upcast should set attribute on all the elements inside the converted element.

---

### Additional information

This PR provides a fix after tests started to fail in `ckedior5-basic-styles` after merging #1443. As of now, element to attribute upcast will set attribute on all children of the element, while attribute to attribute upcast will set the attribute only on the element.

So:

`<strong><p>Foo</p></strong>` will convert to `<paragraph><$text bold="true">Foo</$text></paragraph>`

while (assuming a plugin handling `class` attribute):

`<div class="dark"><div>Foo</div></div>` will convert to `<div class="dark"><div>Foo</div></div>`

even though inside `<div>` could accept `class` attribute dark.