### PR TITLE
T/1436: Fixing selection that cross limit node boundaries.

### DIFF
--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -582,14 +582,16 @@ export default class Schema {
 		}, { priority: 'high' } );
 	}
 
+	/* eslint-disable max-len */
 	/**
 	 * Returns the lowest {@link module:engine/model/schema~Schema#isLimit limit element} containing the entire
 	 * selection or the root otherwise.
 	 *
-	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selectionOrRangeOrPosition
+	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection|module:engine/model/range~Range|module:engine/model/position~Position} selectionOrRangeOrPosition
 	 * Selection which returns the common ancestor.
 	 * @returns {module:engine/model/element~Element}
 	 */
+	/* eslint-enable max-len */
 	getLimitElement( selectionOrRangeOrPosition ) {
 		let element;
 

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -586,22 +586,32 @@ export default class Schema {
 	 * Returns the lowest {@link module:engine/model/schema~Schema#isLimit limit element} containing the entire
 	 * selection or the root otherwise.
 	 *
-	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
+	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selectionOrRangeOrPosition
 	 * Selection which returns the common ancestor.
 	 * @returns {module:engine/model/element~Element}
 	 */
-	getLimitElement( selection ) {
-		// Find the common ancestor for all selection's ranges.
-		let element = Array.from( selection.getRanges() )
-			.reduce( ( element, range ) => {
-				const rangeCommonAncestor = range.getCommonAncestor();
+	getLimitElement( selectionOrRangeOrPosition ) {
+		let element;
 
-				if ( !element ) {
-					return rangeCommonAncestor;
-				}
+		if ( selectionOrRangeOrPosition instanceof Position ) {
+			element = selectionOrRangeOrPosition.parent;
+		} else {
+			const ranges = selectionOrRangeOrPosition instanceof Range ?
+				[ selectionOrRangeOrPosition ] :
+				Array.from( selectionOrRangeOrPosition.getRanges() );
 
-				return element.getCommonAncestor( rangeCommonAncestor, { includeSelf: true } );
-			}, null );
+			// Find the common ancestor for all selection's ranges.
+			element = ranges
+				.reduce( ( element, range ) => {
+					const rangeCommonAncestor = range.getCommonAncestor();
+
+					if ( !element ) {
+						return rangeCommonAncestor;
+					}
+
+					return element.getCommonAncestor( rangeCommonAncestor, { includeSelf: true } );
+				}, null );
+		}
 
 		while ( !this.isLimit( element ) ) {
 			if ( element.parent ) {

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -494,9 +494,9 @@ describe( 'downcast-selection-converters', () => {
 
 	describe( 'table cell selection converter', () => {
 		beforeEach( () => {
-			model.schema.register( 'table' );
-			model.schema.register( 'tr' );
-			model.schema.register( 'td' );
+			model.schema.register( 'table', { isLimit: true } );
+			model.schema.register( 'tr', { isLimit: true } );
+			model.schema.register( 'td', { isLimit: true } );
 
 			model.schema.extend( 'table', { allowIn: '$root' } );
 			model.schema.extend( 'tr', { allowIn: 'table' } );
@@ -519,16 +519,16 @@ describe( 'downcast-selection-converters', () => {
 				}
 
 				for ( const range of selection.getRanges() ) {
-					const node = range.start.nodeAfter;
+					const node = range.start.parent;
 
-					if ( node == range.end.nodeBefore && node instanceof ModelElement && node.name == 'td' ) {
+					if ( node instanceof ModelElement && node.name == 'td' ) {
 						conversionApi.consumable.consume( selection, 'selection' );
 
 						const viewNode = conversionApi.mapper.toViewElement( node );
 						conversionApi.writer.addClass( 'selected', viewNode );
 					}
 				}
-			} );
+			}, { priority: 'high' } );
 		} );
 
 		it( 'should not be used to convert selection that is not on table cell', () => {
@@ -542,7 +542,7 @@ describe( 'downcast-selection-converters', () => {
 		it( 'should add a class to the selected table cell', () => {
 			test(
 				// table tr#0 |td#0, table tr#0 td#0|
-				[ [ 0, 0, 0 ], [ 0, 0, 1 ] ],
+				[ [ 0, 0, 0, 0 ], [ 0, 0, 0, 3 ] ],
 				'<table><tr><td>foo</td></tr><tr><td>bar</td></tr></table>',
 				'<table><tr><td class="selected">foo</td></tr><tr><td>bar</td></tr></table>'
 			);
@@ -551,9 +551,9 @@ describe( 'downcast-selection-converters', () => {
 		it( 'should not be used if selection contains more than just a table cell', () => {
 			test(
 				// table tr td#1, table tr#2
-				[ [ 0, 0, 0, 1 ], [ 0, 0, 2 ] ],
+				[ [ 0, 0, 0, 1 ], [ 0, 0, 1, 3 ] ],
 				'<table><tr><td>foo</td><td>bar</td></tr></table>',
-				'<table><tr><td>f{oo</td><td>bar</td>]</tr></table>'
+				'[<table><tr><td>foo</td><td>bar</td></tr></table>]'
 			);
 		} );
 	} );

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -541,7 +541,7 @@ describe( 'downcast-selection-converters', () => {
 
 		it( 'should add a class to the selected table cell', () => {
 			test(
-				// table tr#0 |td#0, table tr#0 td#0|
+				// table tr#0 td#0 [foo, table tr#0 td#0 bar]
 				[ [ 0, 0, 0, 0 ], [ 0, 0, 0, 3 ] ],
 				'<table><tr><td>foo</td></tr><tr><td>bar</td></tr></table>',
 				'<table><tr><td class="selected">foo</td></tr><tr><td>bar</td></tr></table>'
@@ -550,7 +550,7 @@ describe( 'downcast-selection-converters', () => {
 
 		it( 'should not be used if selection contains more than just a table cell', () => {
 			test(
-				// table tr td#1, table tr#2
+				// table tr td#1 f{oo bar, table tr#2 bar]
 				[ [ 0, 0, 0, 1 ], [ 0, 0, 1, 3 ] ],
 				'<table><tr><td>foo</td><td>bar</td></tr></table>',
 				'[<table><tr><td>foo</td><td>bar</td></tr></table>]'

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -17,7 +17,7 @@ import Position from '../../src/model/position';
 import Range from '../../src/model/range';
 import Selection from '../../src/model/selection';
 
-import { getData, setData, stringify } from '../../src/dev-utils/model';
+import { getData, setData, stringify, parse } from '../../src/dev-utils/model';
 
 import AttributeDelta from '../../src/model/delta/attributedelta';
 
@@ -1124,7 +1124,7 @@ describe( 'Schema', () => {
 			} );
 
 			// Parse data string to model.
-			const parsedResult = setData._parse( '[<p>foo<img />bar</p>]', model.schema, { context: [ root.name ] } );
+			const parsedResult = parse( '[<p>foo<img />bar</p>]', model.schema, { context: [ root.name ] } );
 
 			// Set parsed model data to prevent selection post-fixer from running.
 			model.change( writer => {

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -983,6 +983,28 @@ describe( 'Schema', () => {
 
 			expect( schema.getLimitElement( doc.selection ) ).to.equal( root );
 		} );
+
+		it( 'accepts range as an argument', () => {
+			schema.extend( 'article', { isLimit: true } );
+			schema.extend( 'section', { isLimit: true } );
+
+			setData( model, '<div><section><article><paragraph>foo[]bar</paragraph></article></section></div>' );
+
+			const article = root.getNodeByPath( [ 0, 0, 0 ] );
+
+			expect( schema.getLimitElement( new Range( new Position( root, [ 0, 0, 0, 0, 2 ] ) ) ) ).to.equal( article );
+		} );
+
+		it( 'accepts position as an argument', () => {
+			schema.extend( 'article', { isLimit: true } );
+			schema.extend( 'section', { isLimit: true } );
+
+			setData( model, '<div><section><article><paragraph>foo[]bar</paragraph></article></section></div>' );
+
+			const article = root.getNodeByPath( [ 0, 0, 0 ] );
+
+			expect( schema.getLimitElement( new Position( root, [ 0, 0, 0, 0, 2 ] ) ) ).to.equal( article );
+		} );
 	} );
 
 	describe( 'checkAttributeInSelection()', () => {

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -17,7 +17,7 @@ import Position from '../../src/model/position';
 import Range from '../../src/model/range';
 import Selection from '../../src/model/selection';
 
-import { setData, getData, stringify } from '../../src/dev-utils/model';
+import { getData, setData, stringify } from '../../src/dev-utils/model';
 
 import AttributeDelta from '../../src/model/delta/attributedelta';
 
@@ -1123,7 +1123,13 @@ describe( 'Schema', () => {
 				}
 			} );
 
-			setData( model, '<p>foo<img />bar</p>' );
+			// Parse data string to model.
+			const parsedResult = setData._parse( '[<p>foo<img />bar</p>]', model.schema, { context: [ root.name ] } );
+
+			// Set parsed model data to prevent selection post-fixer from running.
+			model.change( writer => {
+				writer.insert( parsedResult.model, root );
+			} );
 
 			ranges = [ Range.createOn( root.getChild( 0 ) ) ];
 		} );

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -988,7 +988,12 @@ describe( 'Schema', () => {
 			schema.extend( 'article', { isLimit: true } );
 			schema.extend( 'section', { isLimit: true } );
 
-			setData( model, '<div><section><article><paragraph>foo[]bar</paragraph></article></section></div>' );
+			const data = '<div><section><article><paragraph>foobar</paragraph></article></section></div>';
+			const parsedModel = parse( data, model.schema, { context: [ root.name ] } );
+
+			model.change( writer => {
+				writer.insert( parsedModel, root );
+			} );
 
 			const article = root.getNodeByPath( [ 0, 0, 0 ] );
 
@@ -999,7 +1004,12 @@ describe( 'Schema', () => {
 			schema.extend( 'article', { isLimit: true } );
 			schema.extend( 'section', { isLimit: true } );
 
-			setData( model, '<div><section><article><paragraph>foo[]bar</paragraph></article></section></div>' );
+			const data = '<div><section><article><paragraph>foobar</paragraph></article></section></div>';
+			const parsedModel = parse( data, model.schema, { context: [ root.name ] } );
+
+			model.change( writer => {
+				writer.insert( parsedModel, root );
+			} );
 
 			const article = root.getNodeByPath( [ 0, 0, 0 ] );
 
@@ -1124,11 +1134,11 @@ describe( 'Schema', () => {
 			} );
 
 			// Parse data string to model.
-			const parsedResult = parse( '[<p>foo<img />bar</p>]', model.schema, { context: [ root.name ] } );
+			const parsedModel = parse( '<p>foo<img />bar</p>', model.schema, { context: [ root.name ] } );
 
 			// Set parsed model data to prevent selection post-fixer from running.
 			model.change( writer => {
-				writer.insert( parsedResult.model, root );
+				writer.insert( parsedModel, root );
 			} );
 
 			ranges = [ Range.createOn( root.getChild( 0 ) ) ];

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -1123,12 +1123,12 @@ describe( 'Schema', () => {
 			schema.extend( 'img', { allowAttributes: 'bold' } );
 			schema.extend( '$text', { allowIn: 'img' } );
 
-			setData( model, '[<p>foo<img>xxx</img>bar</p>]' );
+			setData( model, '<p>[foo<img>xxx</img>bar]</p>' );
 
 			const validRanges = schema.getValidRanges( doc.selection.getRanges(), attribute );
 			const sel = new Selection( validRanges );
 
-			expect( stringify( root, sel ) ).to.equal( '[<p>foo<img>]xxx[</img>bar</p>]' );
+			expect( stringify( root, sel ) ).to.equal( '<p>[foo<img>]xxx[</img>bar]</p>' );
 		} );
 
 		it( 'should return three ranges when attribute is not allowed on one element but is allowed on its child', () => {
@@ -1141,12 +1141,12 @@ describe( 'Schema', () => {
 				}
 			} );
 
-			setData( model, '[<p>foo<img>xxx</img>bar</p>]' );
+			setData( model, '<p>[foo<img>xxx</img>bar]</p>' );
 
 			const validRanges = schema.getValidRanges( doc.selection.getRanges(), attribute );
 			const sel = new Selection( validRanges );
 
-			expect( stringify( root, sel ) ).to.equal( '[<p>foo]<img>[xxx]</img>[bar</p>]' );
+			expect( stringify( root, sel ) ).to.equal( '<p>[foo]<img>[xxx]</img>[bar]</p>' );
 		} );
 
 		it( 'should not leak beyond the given ranges', () => {

--- a/tests/model/utils/deletecontent.js
+++ b/tests/model/utils/deletecontent.js
@@ -669,7 +669,7 @@ describe( 'DataController utils', () => {
 					new Position( doc.getRoot( 'bodyRoot' ), [ 3 ] )
 				);
 
-				deleteContent( model, range );
+				deleteContent( model, new Selection( range ) );
 
 				expect( getData( model, { rootName: 'bodyRoot', withoutSelection: true } ) )
 					.to.equal( '<paragraph>x</paragraph><paragraph></paragraph><paragraph>z</paragraph>' );

--- a/tests/model/utils/deletecontent.js
+++ b/tests/model/utils/deletecontent.js
@@ -608,7 +608,7 @@ describe( 'DataController utils', () => {
 			it( 'creates a paragraph when text is not allowed (custom selection)', () => {
 				setData(
 					model,
-					'[<paragraph>x</paragraph>]<paragraph>yyy</paragraph><paragraph>z</paragraph>',
+					'<paragraph>[x]</paragraph><paragraph>yyy</paragraph><paragraph>z</paragraph>',
 					{ rootName: 'bodyRoot' }
 				);
 
@@ -640,45 +640,39 @@ describe( 'DataController utils', () => {
 			it( 'creates paragraph when text is not allowed (heading selected)', () => {
 				setData(
 					model,
-					'<paragraph>x</paragraph>[<heading1>yyy</heading1>]<paragraph>z</paragraph>',
+					'<paragraph>x</paragraph><heading1>yyy</heading1><paragraph>z</paragraph>',
 					{ rootName: 'bodyRoot' }
 				);
 
-				model.change( writer => {
-					// Set selection to[<heading1>yyy</heading1>] in change() block due to selection post-fixer.
-					const range = new Range(
-						new Position( doc.getRoot( 'bodyRoot' ), [ 1 ] ),
-						new Position( doc.getRoot( 'bodyRoot' ), [ 2 ] )
-					);
-					writer.setSelection( range );
+				// [<heading1>yyy</heading1>]
+				const range = new Range(
+					new Position( doc.getRoot( 'bodyRoot' ), [ 1 ] ),
+					new Position( doc.getRoot( 'bodyRoot' ), [ 2 ] )
+				);
 
-					deleteContent( model, doc.selection );
-				} );
+				deleteContent( model, new Selection( range ) );
 
-				expect( getData( model, { rootName: 'bodyRoot' } ) )
-					.to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>z</paragraph>' );
+				expect( getData( model, { rootName: 'bodyRoot', withoutSelection: true } ) )
+					.to.equal( '<paragraph>x</paragraph><paragraph></paragraph><paragraph>z</paragraph>' );
 			} );
 
 			it( 'creates paragraph when text is not allowed (two blocks selected)', () => {
 				setData(
 					model,
-					'<paragraph>x</paragraph>[<heading1>yyy</heading1><paragraph>yyy</paragraph>]<paragraph>z</paragraph>',
+					'<paragraph>x</paragraph><heading1>yyy</heading1><paragraph>yyy</paragraph><paragraph>z</paragraph>',
 					{ rootName: 'bodyRoot' }
 				);
 
-				model.change( writer => {
-					// Set selection to[<heading1>yyy</heading1><paragraph>yyy</paragraph>] in change() block due to selection post-fixer.
-					const range = new Range(
-						new Position( doc.getRoot( 'bodyRoot' ), [ 1 ] ),
-						new Position( doc.getRoot( 'bodyRoot' ), [ 3 ] )
-					);
-					writer.setSelection( range );
+				// [<heading1>yyy</heading1><paragraph>yyy</paragraph>]
+				const range = new Range(
+					new Position( doc.getRoot( 'bodyRoot' ), [ 1 ] ),
+					new Position( doc.getRoot( 'bodyRoot' ), [ 3 ] )
+				);
 
-					deleteContent( model, doc.selection );
-				} );
+				deleteContent( model, range );
 
-				expect( getData( model, { rootName: 'bodyRoot' } ) )
-					.to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>z</paragraph>' );
+				expect( getData( model, { rootName: 'bodyRoot', withoutSelection: true } ) )
+					.to.equal( '<paragraph>x</paragraph><paragraph></paragraph><paragraph>z</paragraph>' );
 			} );
 
 			it( 'creates paragraph when text is not allowed (all content selected)', () => {

--- a/tests/model/utils/deletecontent.js
+++ b/tests/model/utils/deletecontent.js
@@ -562,7 +562,7 @@ describe( 'DataController utils', () => {
 				schema.register( 'image', { allowWhere: '$text' } );
 				schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 				schema.register( 'heading1', { inheritAllFrom: '$block' } );
-				schema.register( 'blockWidget' );
+				schema.register( 'blockWidget', { isLimit: true } );
 				schema.register( 'restrictedRoot', {
 					isLimit: true
 				} );
@@ -621,7 +621,7 @@ describe( 'DataController utils', () => {
 				deleteContent( model, selection );
 
 				expect( getData( model, { rootName: 'bodyRoot' } ) )
-					.to.equal( '[<paragraph>x</paragraph>]<paragraph></paragraph><paragraph>z</paragraph>' );
+					.to.equal( '<paragraph>[x]</paragraph><paragraph></paragraph><paragraph>z</paragraph>' );
 			} );
 
 			it( 'creates a paragraph when text is not allowed (block widget selected)', () => {
@@ -644,7 +644,16 @@ describe( 'DataController utils', () => {
 					{ rootName: 'bodyRoot' }
 				);
 
-				deleteContent( model, doc.selection );
+				model.change( writer => {
+					// Set selection to[<heading1>yyy</heading1>] in change() block due to selection post-fixer.
+					const range = new Range(
+						new Position( doc.getRoot( 'bodyRoot' ), [ 1 ] ),
+						new Position( doc.getRoot( 'bodyRoot' ), [ 2 ] )
+					);
+					writer.setSelection( range );
+
+					deleteContent( model, doc.selection );
+				} );
 
 				expect( getData( model, { rootName: 'bodyRoot' } ) )
 					.to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>z</paragraph>' );
@@ -657,7 +666,16 @@ describe( 'DataController utils', () => {
 					{ rootName: 'bodyRoot' }
 				);
 
-				deleteContent( model, doc.selection );
+				model.change( writer => {
+					// Set selection to[<heading1>yyy</heading1><paragraph>yyy</paragraph>] in change() block due to selection post-fixer.
+					const range = new Range(
+						new Position( doc.getRoot( 'bodyRoot' ), [ 1 ] ),
+						new Position( doc.getRoot( 'bodyRoot' ), [ 3 ] )
+					);
+					writer.setSelection( range );
+
+					deleteContent( model, doc.selection );
+				} );
 
 				expect( getData( model, { rootName: 'bodyRoot' } ) )
 					.to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>z</paragraph>' );

--- a/tests/model/utils/getselectedcontent.js
+++ b/tests/model/utils/getselectedcontent.js
@@ -129,7 +129,7 @@ describe( 'DataController utils', () => {
 
 				schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 				schema.register( 'heading1', { inheritAllFrom: '$block' } );
-				schema.register( 'blockImage' );
+				schema.register( 'blockImage', { isObject: true } );
 				schema.register( 'caption' );
 				schema.register( 'image', { allowWhere: '$text' } );
 

--- a/tests/model/utils/selection-post-fixer.js
+++ b/tests/model/utils/selection-post-fixer.js
@@ -26,6 +26,7 @@ describe( 'Selection post-fixer', () => {
 			modelRoot = model.document.createRoot();
 
 			model.schema.register( 'paragraph', { inheritAllFrom: '$block' } );
+
 			model.schema.register( 'table', {
 				allowWhere: '$block',
 				isObject: true,
@@ -43,13 +44,16 @@ describe( 'Selection post-fixer', () => {
 				isLimit: true
 			} );
 
-			setModelData( model,
-				'<paragraph>[]foo</paragraph>' +
-				'<table>' +
-					'<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>' +
-				'</table>' +
-				'<paragraph>bar</paragraph>'
-			);
+			model.schema.register( 'image', {
+				allowIn: '$root',
+				isObject: true
+			} );
+
+			model.schema.register( 'caption', {
+				allowIn: 'image',
+				allowContentOf: '$block',
+				isLimit: true
+			} );
 		} );
 
 		it( 'should not crash if there is no correct position for model selection', () => {
@@ -59,37 +63,41 @@ describe( 'Selection post-fixer', () => {
 		} );
 
 		it( 'should react to structure changes', () => {
+			setModelData( model, '<paragraph>[]foo</paragraph><image></image>' );
+
 			model.change( writer => {
 				writer.remove( modelRoot.getChild( 0 ) );
 			} );
 
-			expect( getModelData( model ) ).to.equal(
-				'[<table>' +
-					'<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>' +
-				'</table>]' +
-				'<paragraph>bar</paragraph>'
-			);
+			expect( getModelData( model ) ).to.equal( '[<image></image>]' );
 		} );
 
 		it( 'should react to selection changes', () => {
-			// <paragraph>foo</paragraph>[]<table>...
+			setModelData( model, '<paragraph>[]foo</paragraph><image></image>' );
+
+			// <paragraph>foo</paragraph>[]<image></image>
 			model.change( writer => {
 				writer.setSelection(
 					ModelRange.createFromParentsAndOffsets( modelRoot, 1, modelRoot, 1 )
 				);
 			} );
 
-			expect( getModelData( model ) ).to.equal(
-				'<paragraph>foo[]</paragraph>' +
-				'<table>' +
-					'<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>' +
-				'</table>' +
-				'<paragraph>bar</paragraph>'
-			);
+			expect( getModelData( model ) ).to.equal( '<paragraph>foo[]</paragraph><image></image>' );
 		} );
 
-		describe( 'not collapsed selection', () => {
+		describe( 'non-collapsed selection - table scenarios', () => {
+			beforeEach( () => {
+				setModelData( model,
+					'<paragraph>[]foo</paragraph>' +
+					'<table>' +
+						'<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>' +
+					'</table>' +
+					'<paragraph>bar</paragraph>'
+				);
+			} );
+
 			it( 'should fix #1', () => {
+				// <paragraph>f[oo</paragraph><table><tableRow><tableCell></tableCell>]<tableCell>...
 				model.change( writer => {
 					writer.setSelection( ModelRange.createFromParentsAndOffsets(
 						modelRoot.getChild( 0 ), 1,
@@ -107,6 +115,7 @@ describe( 'Selection post-fixer', () => {
 			} );
 
 			it( 'should fix #2', () => {
+				// ...<table><tableRow><tableCell></tableCell>[<tableCell></tableCell></tableRow></table><paragraph>b]ar</paragraph>
 				model.change( writer => {
 					writer.setSelection( ModelRange.createFromParentsAndOffsets(
 						modelRoot.getChild( 1 ).getChild( 0 ), 1,
@@ -124,6 +133,7 @@ describe( 'Selection post-fixer', () => {
 			} );
 
 			it( 'should fix #3', () => {
+				// <paragraph>f[oo</paragraph><table>]<tableRow>...
 				model.change( writer => {
 					writer.setSelection( ModelRange.createFromParentsAndOffsets(
 						modelRoot.getChild( 0 ), 1,
@@ -141,6 +151,7 @@ describe( 'Selection post-fixer', () => {
 			} );
 
 			it( 'should fix #4', () => {
+				// <paragraph>foo</paragraph><table><tableRow><tableCell>a[aa</tableCell><tableCell>b]bb</tableCell>
 				model.change( writer => {
 					writer.setSelection( ModelRange.createFromParentsAndOffsets(
 						modelRoot.getChild( 1 ).getChild( 0 ).getChild( 0 ), 1,
@@ -163,7 +174,8 @@ describe( 'Selection post-fixer', () => {
 					'<table>' +
 						'<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>' +
 					'</table>' +
-					'[]<table>' +
+					'[]' +
+					'<table>' +
 						'<tableRow><tableCell>xxx</tableCell><tableCell>yyy</tableCell></tableRow>' +
 					'</table>' +
 					'<paragraph>baz</paragraph>'
@@ -177,6 +189,75 @@ describe( 'Selection post-fixer', () => {
 					'<table>' +
 						'<tableRow><tableCell>xxx</tableCell><tableCell>yyy</tableCell></tableRow>' +
 					'</table>' +
+					'<paragraph>baz</paragraph>'
+				);
+			} );
+
+			// There's a chance that this and the following test will not be up to date with
+			// how the table feature is really implemented once we'll introduce row/cells/columns selection
+			// in which case all these elements will need to be marked as objects.
+			it( 'should fix #6 (element selection of not an object)', () => {
+				setModelData( model,
+					'<paragraph>foo</paragraph>' +
+					'<table>' +
+						'[<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>]' +
+					'</table>' +
+					'<paragraph>baz</paragraph>'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>foo</paragraph>' +
+					'[<table>' +
+						'<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>' +
+					'</table>]' +
+					'<paragraph>baz</paragraph>'
+				);
+			} );
+
+			it( 'should fix #7 (element selection of non-objects)', () => {
+				setModelData( model,
+					'<paragraph>foo</paragraph>' +
+					'<table>' +
+						'[<tableRow><tableCell>1</tableCell><tableCell>2</tableCell></tableRow>' +
+						'<tableRow><tableCell>3</tableCell><tableCell>4</tableCell>]</tableRow>' +
+						'<tableRow><tableCell>5</tableCell><tableCell>6</tableCell></tableRow>' +
+					'</table>' +
+					'<paragraph>baz</paragraph>'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>foo</paragraph>' +
+					'[<table>' +
+						'<tableRow><tableCell>1</tableCell><tableCell>2</tableCell></tableRow>' +
+						'<tableRow><tableCell>3</tableCell><tableCell>4</tableCell></tableRow>' +
+						'<tableRow><tableCell>5</tableCell><tableCell>6</tableCell></tableRow>' +
+					'</table>]' +
+					'<paragraph>baz</paragraph>'
+				);
+			} );
+
+			it( 'should fix #8 (cross-limit selection which starts in a non-limit elements)', () => {
+				model.schema.extend( 'paragraph', { allowIn: 'tableCell' } );
+
+				setModelData( model,
+					'<paragraph>foo</paragraph>' +
+					'<table>' +
+						'<tableRow>' +
+							'<tableCell><paragraph>f[oo</paragraph></tableCell>' +
+							'<tableCell><paragraph>b]ar</paragraph></tableCell>' +
+						'</tableRow>' +
+					'</table>' +
+					'<paragraph>baz</paragraph>'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>foo</paragraph>' +
+					'[<table>' +
+						'<tableRow>' +
+							'<tableCell><paragraph>foo</paragraph></tableCell>' +
+							'<tableCell><paragraph>bar</paragraph></tableCell>' +
+						'</tableRow>' +
+					'</table>]' +
 					'<paragraph>baz</paragraph>'
 				);
 			} );
@@ -283,7 +364,182 @@ describe( 'Selection post-fixer', () => {
 			} );
 		} );
 
+		describe( 'non-collapsed selection - image scenarios', () => {
+			beforeEach( () => {
+				setModelData( model,
+					'<paragraph>[]foo</paragraph>' +
+					'<image>' +
+						'<caption>xxx</caption>' +
+					'</image>' +
+					'<paragraph>bar</paragraph>'
+				);
+			} );
+
+			it( 'should fix #1 (crossing object and limit boundaries)', () => {
+				model.change( writer => {
+					// <paragraph>f[oo</paragraph><image><caption>x]xx</caption>...
+					writer.setSelection( ModelRange.createFromParentsAndOffsets(
+						modelRoot.getChild( 0 ), 1,
+						modelRoot.getChild( 1 ).getChild( 0 ), 1
+					) );
+				} );
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>f[oo</paragraph>' +
+					'<image>' +
+						'<caption>xxx</caption>' +
+					'</image>]' +
+					'<paragraph>bar</paragraph>'
+				);
+			} );
+
+			it( 'should fix #2 (crossing object boundary)', () => {
+				model.change( writer => {
+					// <paragraph>f[oo</paragraph><image>]<caption>xxx</caption>...
+					writer.setSelection( ModelRange.createFromParentsAndOffsets(
+						modelRoot.getChild( 0 ), 1,
+						modelRoot.getChild( 1 ), 0
+					) );
+				} );
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>f[oo</paragraph>' +
+					'<image>' +
+						'<caption>xxx</caption>' +
+					'</image>]' +
+					'<paragraph>bar</paragraph>'
+				);
+			} );
+
+			it( 'should fix #3 (crossing object boundary)', () => {
+				model.change( writer => {
+					// <paragraph>f[oo</paragraph><image><caption>xxx</caption>]</image>...
+					writer.setSelection( ModelRange.createFromParentsAndOffsets(
+						modelRoot.getChild( 0 ), 1,
+						modelRoot.getChild( 1 ), 1
+					) );
+				} );
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>f[oo</paragraph>' +
+					'<image>' +
+						'<caption>xxx</caption>' +
+					'</image>]' +
+					'<paragraph>bar</paragraph>'
+				);
+			} );
+
+			it( 'should fix #4 (element selection of not an object)', () => {
+				model.change( writer => {
+					// <paragraph>foo</paragraph><image>[<caption>xxx</caption>]</image>...
+					writer.setSelection( ModelRange.createFromParentsAndOffsets(
+						modelRoot.getChild( 1 ), 0,
+						modelRoot.getChild( 1 ), 1
+					) );
+				} );
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>foo</paragraph>' +
+					'[<image>' +
+						'<caption>xxx</caption>' +
+					'</image>]' +
+					'<paragraph>bar</paragraph>'
+				);
+			} );
+
+			it( 'should not fix #1 (element selection of an object)', () => {
+				model.change( writer => {
+					// <paragraph>foo</paragraph>[<image><caption>xxx</caption></image>]...
+					writer.setSelection( ModelRange.createFromParentsAndOffsets(
+						modelRoot, 1,
+						modelRoot, 2
+					) );
+				} );
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>foo</paragraph>' +
+					'[<image>' +
+						'<caption>xxx</caption>' +
+					'</image>]' +
+					'<paragraph>bar</paragraph>'
+				);
+			} );
+
+			it( 'should not fix #2 (inside a limit)', () => {
+				model.change( writer => {
+					const caption = modelRoot.getChild( 1 ).getChild( 0 );
+
+					// <paragraph>foo</paragraph><image><caption>[xxx]</caption></image>...
+					writer.setSelection( ModelRange.createFromParentsAndOffsets(
+						caption, 0,
+						caption, 3
+					) );
+				} );
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>foo</paragraph>' +
+					'<image>' +
+						'<caption>[xxx]</caption>' +
+					'</image>' +
+					'<paragraph>bar</paragraph>'
+				);
+			} );
+		} );
+
+		describe( 'non-collapsed selection - other scenarios', () => {
+			it( 'should fix #1 (element selection of not an object)', () => {
+				setModelData( model,
+					'<paragraph>aaa</paragraph>' +
+					'[<paragraph>bbb</paragraph>]' +
+					'<paragraph>ccc</paragraph>'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>aaa</paragraph>' +
+					'<paragraph>[bbb]</paragraph>' +
+					'<paragraph>ccc</paragraph>'
+				);
+			} );
+
+			it( 'should fix #2 (elements selection of not an object)', () => {
+				setModelData( model,
+					'<paragraph>aaa</paragraph>' +
+					'[<paragraph>bbb</paragraph>' +
+					'<paragraph>ccc</paragraph>]'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>aaa</paragraph>' +
+					'<paragraph>[bbb</paragraph>' +
+					'<paragraph>ccc]</paragraph>'
+				);
+			} );
+
+			it( 'should fix #3 (selection must not cross a limit element; starts in a non-limit)', () => {
+				model.schema.register( 'a', { isLimit: true, allowIn: '$root' } );
+				model.schema.register( 'b', { isLimit: true, allowIn: 'a' } );
+				model.schema.register( 'c', { allowIn: 'b' } );
+				model.schema.extend( '$text', { allowIn: 'c' } );
+
+				setModelData( model,
+					'<a><b><c>[</c></b></a>]'
+				);
+
+				expect( getModelData( model ) ).to.equal( '[<a><b><c></c></b></a>]' );
+			} );
+		} );
+
 		describe( 'collapsed selection', () => {
+			beforeEach( () => {
+				setModelData( model,
+					'<paragraph>[]foo</paragraph>' +
+					'<table>' +
+						'<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>' +
+					'</table>' +
+					'<paragraph>bar</paragraph>'
+				);
+			} );
+
 			it( 'should fix #1', () => {
 				// <table>[]<tableRow>...
 				model.change( writer => {

--- a/tests/model/utils/selection-post-fixer.js
+++ b/tests/model/utils/selection-post-fixer.js
@@ -369,7 +369,7 @@ describe( 'Selection post-fixer', () => {
 					'<table>' +
 						'<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>' +
 					'</table>' +
-					'<paragraph>b]a[r]</paragraph>'
+					'<paragraph>bar]</paragraph>'
 				);
 			} );
 		} );
@@ -746,7 +746,7 @@ describe( 'Selection post-fixer', () => {
 			} );
 
 			it( 'should fix multiple ranges #1', () => {
-				// []<paragraph></paragraph>[]<table>...
+				// []<paragraph>foo</paragraph>[]<table>...
 				model.change( writer => {
 					writer.setSelection(
 						[
@@ -757,7 +757,7 @@ describe( 'Selection post-fixer', () => {
 				} );
 
 				expect( getModelData( model ) ).to.equal(
-					'<paragraph>[]foo[]</paragraph>' +
+					'<paragraph>[foo]</paragraph>' +
 					'<table>' +
 						'<tableRow><tableCell>aaa</tableCell><tableCell>bbb</tableCell></tableRow>' +
 					'</table>' +

--- a/tests/model/utils/selection-post-fixer.js
+++ b/tests/model/utils/selection-post-fixer.js
@@ -54,6 +54,16 @@ describe( 'Selection post-fixer', () => {
 				allowContentOf: '$block',
 				isLimit: true
 			} );
+
+			model.schema.register( 'inlineWidget', {
+				isObject: true,
+				allowIn: [ '$block', '$clipboardHolder' ]
+			} );
+
+			model.schema.register( 'figure', {
+				allowIn: '$root',
+				allowAttributes: [ 'name', 'title' ]
+			} );
 		} );
 
 		it( 'should not crash if there is no correct position for model selection', () => {
@@ -524,6 +534,16 @@ describe( 'Selection post-fixer', () => {
 					'<paragraph>bar</paragraph>'
 				);
 			} );
+
+			it( 'should not fix #5 (selection in root on non limit element that doesn\'t allow text)', () => {
+				setModelData( model,
+					'[<figure></figure>]'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'[<figure></figure>]'
+				);
+			} );
 		} );
 
 		describe( 'non-collapsed selection - other scenarios', () => {
@@ -555,7 +575,49 @@ describe( 'Selection post-fixer', () => {
 				);
 			} );
 
-			it( 'should fix #3 (selection must not cross a limit element; starts in a root)', () => {
+			it( 'should fix #3 (partial selection of not an object)', () => {
+				setModelData( model,
+					'<paragraph>aaa</paragraph>' +
+					'[<paragraph>bbb</paragraph>' +
+					'<paragraph>ccc]</paragraph>'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>aaa</paragraph>' +
+					'<paragraph>[bbb</paragraph>' +
+					'<paragraph>ccc]</paragraph>'
+				);
+			} );
+
+			it( 'should fix #4 (partial selection of not an object)', () => {
+				setModelData( model,
+					'<paragraph>aaa</paragraph>' +
+					'<paragraph>b[bb</paragraph>]' +
+					'<paragraph>ccc</paragraph>'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>aaa</paragraph>' +
+					'<paragraph>b[bb]</paragraph>' +
+					'<paragraph>ccc</paragraph>'
+				);
+			} );
+
+			it( 'should fix #5 (partial selection of not an object)', () => {
+				setModelData( model,
+					'<paragraph>aaa</paragraph>' +
+					'[<paragraph>bb]b</paragraph>' +
+					'<paragraph>ccc</paragraph>'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>aaa</paragraph>' +
+					'<paragraph>[bb]b</paragraph>' +
+					'<paragraph>ccc</paragraph>'
+				);
+			} );
+
+			it( 'should fix #6 (selection must not cross a limit element; starts in a root)', () => {
 				model.schema.register( 'a', { isLimit: true, allowIn: '$root' } );
 				model.schema.register( 'b', { isLimit: true, allowIn: 'a' } );
 				model.schema.register( 'c', { allowIn: 'b' } );
@@ -568,7 +630,7 @@ describe( 'Selection post-fixer', () => {
 				expect( getModelData( model ) ).to.equal( '[<a><b><c></c></b></a>]' );
 			} );
 
-			it( 'should fix #5 (selection must not cross a limit element; ends in a root)', () => {
+			it( 'should fix #7 (selection must not cross a limit element; ends in a root)', () => {
 				model.schema.register( 'a', { isLimit: true, allowIn: '$root' } );
 				model.schema.register( 'b', { isLimit: true, allowIn: 'a' } );
 				model.schema.register( 'c', { allowIn: 'b' } );
@@ -581,7 +643,7 @@ describe( 'Selection post-fixer', () => {
 				expect( getModelData( model ) ).to.equal( '[<a><b><c></c></b></a>]' );
 			} );
 
-			it( 'should fix #4 (selection must not cross a limit element; starts in a non-limit)', () => {
+			it( 'should fix #8 (selection must not cross a limit element; starts in a non-limit)', () => {
 				model.schema.register( 'div', { allowIn: '$root' } );
 				model.schema.register( 'a', { isLimit: true, allowIn: 'div' } );
 				model.schema.register( 'b', { isLimit: true, allowIn: 'a' } );
@@ -595,7 +657,7 @@ describe( 'Selection post-fixer', () => {
 				expect( getModelData( model ) ).to.equal( '<div>[<a><b><c></c></b></a>]</div>' );
 			} );
 
-			it( 'should fix #6 (selection must not cross a limit element; ends in a non-limit)', () => {
+			it( 'should fix #9 (selection must not cross a limit element; ends in a non-limit)', () => {
 				model.schema.register( 'div', { allowIn: '$root' } );
 				model.schema.register( 'a', { isLimit: true, allowIn: 'div' } );
 				model.schema.register( 'b', { isLimit: true, allowIn: 'a' } );
@@ -609,10 +671,30 @@ describe( 'Selection post-fixer', () => {
 				expect( getModelData( model ) ).to.equal( '<div>[<a><b><c></c></b></a>]</div>' );
 			} );
 
-			it( 'should not fix #7 (selection on text node)', () => {
+			it( 'should not fix #1 (selection on text node)', () => {
 				setModelData( model, '<paragraph>foob[a]r</paragraph>', { lastRangeBackward: true } );
 
 				expect( getModelData( model ) ).to.equal( '<paragraph>foob[a]r</paragraph>' );
+			} );
+
+			it( 'should not fix #2', () => {
+				setModelData( model,
+					'<paragraph>[<inlineWidget></inlineWidget>]</paragraph>'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>[<inlineWidget></inlineWidget>]</paragraph>'
+				);
+			} );
+
+			it( 'should not fix #3', () => {
+				setModelData( model,
+					'<paragraph>fo[o<inlineWidget></inlineWidget>b]ar</paragraph>'
+				);
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>fo[o<inlineWidget></inlineWidget>b]ar</paragraph>'
+				);
 			} );
 		} );
 

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -2375,12 +2375,12 @@ describe( 'Writer', () => {
 		} );
 
 		it( 'should change document selection ranges', () => {
-			const range = new Range( new Position( root, [ 1 ] ), new Position( root, [ 2, 2 ] ) );
+			const range = new Range( new Position( root, [ 1, 0 ] ), new Position( root, [ 2, 2 ] ) );
 
 			setSelection( range, { backward: true } );
 
 			expect( model.document.selection._ranges.length ).to.equal( 1 );
-			expect( model.document.selection._ranges[ 0 ].start.path ).to.deep.equal( [ 1 ] );
+			expect( model.document.selection._ranges[ 0 ].start.path ).to.deep.equal( [ 1, 0 ] );
 			expect( model.document.selection._ranges[ 0 ].end.path ).to.deep.equal( [ 2, 2 ] );
 			expect( model.document.selection.isBackward ).to.be.true;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Fixing selection that cross limit node boundaries. Closes #1436.

Other: The `schema.getLimitElement()` method now accepts also `Range` and `Position` as a parameter.

---

### Additional information

This PR comes with some fixes in other repos all branches are available at https://github.com/ckeditor/ckeditor5/tree/%23t/ckeditor5-engine/1436:

* https://github.com/ckeditor/ckeditor5-enter/pull/55
* https://github.com/ckeditor/ckeditor5-list/pull/106
* https://github.com/ckeditor/ckeditor5-table/pull/81
* https://github.com/ckeditor/ckeditor5-undo/pull/87
* https://github.com/ckeditor/ckeditor5-widget/pull/45
