### PR TITLE
Expand selection will work correctly with inline elements

### DIFF
--- a/src/model/utils/modifyselection.js
+++ b/src/model/utils/modifyselection.js
@@ -172,7 +172,7 @@ function getCorrectWordBreakPosition( walker, isForward ) {
 			// should expand to : 'foofoo [bar<$text bold="true">bar</$text>] bazbaz'.
 			const nextNode = isForward ? walker.position.nodeAfter : walker.position.nodeBefore;
 
-			// `nextNode` can be an inline element which is an invalid node in this case.
+			// Scan only text nodes. Ignore inline elements (like `<softBreak>`).
 			if ( nextNode && nextNode.is( 'text' ) ) {
 				// Check boundary char of an adjacent text node.
 				const boundaryChar = nextNode.data.charAt( isForward ? 0 : nextNode.data.length - 1 );

--- a/src/model/utils/modifyselection.js
+++ b/src/model/utils/modifyselection.js
@@ -172,7 +172,8 @@ function getCorrectWordBreakPosition( walker, isForward ) {
 			// should expand to : 'foofoo [bar<$text bold="true">bar</$text>] bazbaz'.
 			const nextNode = isForward ? walker.position.nodeAfter : walker.position.nodeBefore;
 
-			if ( nextNode ) {
+			// `nextNode` can be an inline element which is an invalid node in this case.
+			if ( nextNode && nextNode.is( 'text' ) ) {
 				// Check boundary char of an adjacent text node.
 				const boundaryChar = nextNode.data.charAt( isForward ? 0 : nextNode.data.length - 1 );
 

--- a/tests/model/utils/modifyselection.js
+++ b/tests/model/utils/modifyselection.js
@@ -18,6 +18,7 @@ describe( 'DataController utils', () => {
 		model.schema.register( 'p', { inheritAllFrom: '$block' } );
 		model.schema.register( 'x', { inheritAllFrom: '$block' } );
 		model.schema.extend( 'x', { allowIn: 'p' } );
+		model.schema.register( 'br', { allowWhere: '$text' } );
 
 		doc.createRoot();
 	} );
@@ -552,6 +553,48 @@ describe( 'DataController utils', () => {
 
 					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal( '<p>[foo\uD83D\uDCA9]</p>' );
 					expect( doc.selection.isBackward ).to.true;
+				} );
+
+				it( 'expands backward selection to the word begin in the paragraph with soft break', () => {
+					setData( model, '<p>Foo<br></br>Bar[]</p>' );
+
+					modifySelection( model, doc.selection, { unit: 'word', direction: 'backward' } );
+
+					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal( '<p>Foo<br></br>[Bar]</p>' );
+				} );
+
+				it( 'expands backward selection to the whole paragraph in the paragraph with soft break', () => {
+					setData( model, '<p>Foo<br></br>Bar[]</p>' );
+
+					modifySelection( model, doc.selection, { unit: 'word', direction: 'backward' } );
+					modifySelection( model, doc.selection, { unit: 'word', direction: 'backward' } );
+
+					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal( '<p>Foo[<br></br>Bar]</p>' );
+
+					modifySelection( model, doc.selection, { unit: 'word', direction: 'backward' } );
+
+					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal( '<p>[Foo<br></br>Bar]</p>' );
+				} );
+
+				it( 'expands forward selection to the word end in the paragraph with soft break', () => {
+					setData( model, '<p>[]Foo<br></br>Bar</p>' );
+
+					modifySelection( model, doc.selection, { unit: 'word', direction: 'forward' } );
+
+					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal( '<p>[Foo]<br></br>Bar</p>' );
+				} );
+
+				it( 'expands forward selection to the whole paragraph in the paragraph with soft break', () => {
+					setData( model, '<p>[]Foo<br></br>Bar</p>' );
+
+					modifySelection( model, doc.selection, { unit: 'word', direction: 'forward' } );
+					modifySelection( model, doc.selection, { unit: 'word', direction: 'forward' } );
+
+					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal( '<p>[Foo<br></br>]Bar</p>' );
+
+					modifySelection( model, doc.selection, { unit: 'word', direction: 'forward' } );
+
+					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal( '<p>[Foo<br></br>Bar]</p>' );
 				} );
 
 				function testStopCharacter( stopCharacter ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Expand selection mechanism will work correctly with the inline elements. Closes ckeditor/ckeditor5#1064.

---

An integration test: https://github.com/ckeditor/ckeditor5-typing/pull/164
