### PR TITLE
Unit test covering edge case related to 'withChildren' parameter inside Renderer added

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -256,7 +256,7 @@ export default class Renderer {
 
 		const actualDomChildren = this.domConverter.mapViewToDom( viewElement ).childNodes;
 		const expectedDomChildren = Array.from(
-			this.domConverter.viewChildrenToDom( viewElement, domElement.ownerDocument )
+			this.domConverter.viewChildrenToDom( viewElement, domElement.ownerDocument, { withChildren: false } )
 		);
 		const diff = this._diffNodeLists( actualDomChildren, expectedDomChildren );
 		const actions = this._findReplaceActions( diff, actualDomChildren, expectedDomChildren );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1683,6 +1683,36 @@ describe( 'Renderer', () => {
 			);
 		} );
 
+		// #1451
+		it( 'should correctly render changed children even if direct parent is not marked to sync', () => {
+			const inputView =
+				'<container:ul>' +
+					'<container:li>Foo</container:li>' +
+					'<container:li><attribute:b>Bar</attribute:b></container:li>' +
+				'</container:ul>';
+
+			const view = parse( inputView );
+
+			viewRoot._appendChild( view );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			expect( domRoot.innerHTML ).to.equal( '<ul><li>Foo</li><li><b>Bar</b></li></ul>' );
+
+			const viewLi = view.getChild( 0 );
+			const viewLiIndented = view._removeChildren( 1, 1 ); // Array with one element.
+			viewLiIndented[ 0 ]._appendChild( parse( '<attribute:i>Baz</attribute:i>' ) );
+			const viewUl = new ViewContainerElement( 'ul', null, viewLiIndented );
+			viewLi._appendChild( viewUl );
+
+			renderer.markToSync( 'children', view );
+			renderer.markToSync( 'children', viewLi );
+			renderer.render();
+
+			expect( domRoot.innerHTML ).to.equal( '<ul><li>Foo<ul><li><b>Bar</b><i>Baz</i></li></ul></li></ul>' );
+		} );
+
 		describe( 'fake selection', () => {
 			beforeEach( () => {
 				const { view: viewP, selection: newSelection } = parse(


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added `withChildren: false` parameter missing after refactoring and unit test covering that case. Closes #1451. Closes #1452.

---

### Additional information

What happens depending on `withChildren` value is described in more details in https://github.com/ckeditor/ckeditor5-engine/issues/1451#issuecomment-401356437. Added unit test shows the situation in which `withChildren: true` behaviour results in incorrect DOM structure after rendering.

I have added `Closes #1425` as #1452 is a previous PR related to this topic, so if we decided to merge this one, #1452 should be closed.
