### PR TITLE
Second parameter of LiveRange#event:change is now deletionPosition not operation that changed the range

### DIFF
--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -750,14 +750,14 @@ class LiveSelection extends Selection {
 
 		const liveRange = LiveRange.createFromRange( range );
 
-		liveRange.on( 'change:range', ( evt, oldRange, operation ) => {
+		liveRange.on( 'change:range', ( evt, oldRange, deletionPosition ) => {
 			this._hasChangedRange = true;
 
 			// If `LiveRange` is in whole moved to the graveyard, save necessary data. It will be fixed on `Model#applyOperation` event.
 			if ( liveRange.root == this._document.graveyard ) {
 				this._fixGraveyardRangesData.push( {
 					liveRange,
-					sourcePosition: operation.sourcePosition
+					sourcePosition: deletionPosition
 				} );
 			}
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Second parameter of `LiveRange#event:change` is now `deletionPosition` not the operation that changed the range. Closes #1463.