### PR TITLE
Replace `ckeditor5-uitls/src/lib/lodash` imports with `lodash-es`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "framework"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-utils": "^10.2.0"
+    "@ckeditor/ckeditor5-utils": "^10.2.0",
+    "lodash-es": "^4.17.10"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^10.0.2",

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -11,7 +11,7 @@ import ViewAttributeElement from '../view/attributeelement';
 import ViewRange from '../view/range';
 import DocumentSelection from '../model/documentselection';
 
-import cloneDeep from '@ckeditor/ckeditor5-utils/src/lib/lodash/cloneDeep';
+import { cloneDeep } from 'lodash-es';
 
 /**
  * Contains downcast (model-to-view) converters for {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher}.

--- a/src/conversion/downcastdispatcher.js
+++ b/src/conversion/downcastdispatcher.js
@@ -11,7 +11,7 @@ import Consumable from './modelconsumable';
 import Range from '../model/range';
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
-import extend from '@ckeditor/ckeditor5-utils/src/lib/lodash/extend';
+import { extend } from 'lodash-es';
 
 /**
  * `DowncastDispatcher` is a central point of downcasting (conversion from model to view), which is a process of reacting to changes

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -8,7 +8,7 @@ import Matcher from '../view/matcher';
 import ModelRange from '../model/range';
 import ModelPosition from '../model/position';
 
-import cloneDeep from '@ckeditor/ckeditor5-utils/src/lib/lodash/cloneDeep';
+import { cloneDeep } from 'lodash-es';
 
 /**
  * Contains {@link module:engine/view/view view} to {@link module:engine/model/model model} converters for

--- a/src/conversion/viewconsumable.js
+++ b/src/conversion/viewconsumable.js
@@ -7,7 +7,7 @@
  * @module engine/conversion/viewconsumable
  */
 
-import isArray from '@ckeditor/ckeditor5-utils/src/lib/lodash/isArray';
+import { isArray } from 'lodash-es';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**

--- a/src/dev-utils/model.js
+++ b/src/dev-utils/model.js
@@ -34,7 +34,7 @@ import {
 } from '../conversion/downcast-selection-converters';
 import { insertText, insertElement, wrap, insertUIElement } from '../conversion/downcast-converters';
 
-import isPlainObject from '@ckeditor/ckeditor5-utils/src/lib/lodash/isPlainObject';
+import { isPlainObject } from 'lodash-es';
 import toMap from '@ckeditor/ckeditor5-utils/src/tomap';
 
 /**

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -14,11 +14,11 @@ import RootElement from './rootelement';
 import History from './history';
 import DocumentSelection from './documentselection';
 import Collection from '@ckeditor/ckeditor5-utils/src/collection';
-import clone from '@ckeditor/ckeditor5-utils/src/lib/lodash/clone';
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import { isInsideSurrogatePair, isInsideCombinedSymbol } from '@ckeditor/ckeditor5-utils/src/unicode';
+import { clone } from 'lodash-es';
 
 const graveyardName = '$graveyard';
 

--- a/src/model/operation/attributeoperation.js
+++ b/src/model/operation/attributeoperation.js
@@ -11,7 +11,7 @@ import Operation from './operation';
 import Range from '../range';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import { _setAttribute } from './utils';
-import isEqual from '@ckeditor/ckeditor5-utils/src/lib/lodash/isEqual';
+import { isEqual } from 'lodash-es';
 
 /**
  * Operation to change nodes' attribute.

--- a/src/model/operation/operation.js
+++ b/src/model/operation/operation.js
@@ -7,7 +7,7 @@
  * @module engine/model/operation/operation
  */
 
-import clone from '@ckeditor/ckeditor5-utils/src/lib/lodash/clone';
+import { clone } from 'lodash-es';
 
 /**
  * Abstract base operation class.

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -8,10 +8,10 @@
  */
 
 import TreeWalker from './treewalker';
-import last from '@ckeditor/ckeditor5-utils/src/lib/lodash/last';
 import compareArrays from '@ckeditor/ckeditor5-utils/src/comparearrays';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Text from './text';
+import { last } from 'lodash-es';
 
 /**
  * Represents a position in the model tree.

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -23,7 +23,7 @@ import indexOf from '@ckeditor/ckeditor5-utils/src/dom/indexof';
 import getAncestors from '@ckeditor/ckeditor5-utils/src/dom/getancestors';
 import getCommonAncestor from '@ckeditor/ckeditor5-utils/src/dom/getcommonancestor';
 import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
-import isElement from '@ckeditor/ckeditor5-utils/src/lib/lodash/isElement';
+import { isElement } from 'lodash-es';
 
 /**
  * DomConverter is a set of tools to do transformations between DOM nodes and view nodes. It also handles

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -12,8 +12,8 @@ import Text from './text';
 import TextProxy from './textproxy';
 import objectToMap from '@ckeditor/ckeditor5-utils/src/objecttomap';
 import isIterable from '@ckeditor/ckeditor5-utils/src/isiterable';
-import isPlainObject from '@ckeditor/ckeditor5-utils/src/lib/lodash/isPlainObject';
 import Matcher from './matcher';
+import { isPlainObject } from 'lodash-es';
 
 /**
  * View element.

--- a/src/view/node.js
+++ b/src/view/node.js
@@ -10,8 +10,8 @@
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
-import clone from '@ckeditor/ckeditor5-utils/src/lib/lodash/clone';
 import compareArrays from '@ckeditor/ckeditor5-utils/src/comparearrays';
+import { clone } from 'lodash-es';
 
 /**
  * Abstract tree view node class.

--- a/src/view/observer/domeventdata.js
+++ b/src/view/observer/domeventdata.js
@@ -7,7 +7,7 @@
  * @module engine/view/observer/domeventdata
  */
 
-import extend from '@ckeditor/ckeditor5-utils/src/lib/lodash/extend';
+import { extend } from 'lodash-es';
 
 /**
  * Information about a DOM event in context of the {@link module:engine/view/document~Document}.

--- a/src/view/observer/fakeselectionobserver.js
+++ b/src/view/observer/fakeselectionobserver.js
@@ -10,7 +10,7 @@
 import Observer from './observer';
 import ViewSelection from '../selection';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
-import debounce from '@ckeditor/ckeditor5-utils/src/lib/lodash/debounce';
+import { debounce } from 'lodash-es';
 
 /**
  * Fake selection observer class. If view selection is fake it is placed in dummy DOM container. This observer listens

--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -12,7 +12,7 @@
 import Observer from './observer';
 import ViewSelection from '../selection';
 import { startsWithFiller, getDataWithoutFiller } from '../filler';
-import isEqualWith from '@ckeditor/ckeditor5-utils/src/lib/lodash/isEqualWith';
+import { isEqualWith } from 'lodash-es';
 
 /**
  * Mutation observer class observes changes in the DOM, fires {@link module:engine/view/document~Document#event:mutations} event, mark view

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -12,7 +12,7 @@
 import Observer from './observer';
 import MutationObserver from './mutationobserver';
 import log from '@ckeditor/ckeditor5-utils/src/log';
-import debounce from '@ckeditor/ckeditor5-utils/src/lib/lodash/debounce';
+import { debounce } from 'lodash-es';
 
 /**
  * Selection observer class observes selection changes in the document. If selection changes on the document this

--- a/src/view/writer.js
+++ b/src/view/writer.js
@@ -16,9 +16,9 @@ import Range from './range';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import DocumentFragment from './documentfragment';
 import isIterable from '@ckeditor/ckeditor5-utils/src/isiterable';
-import isPlainObject from '@ckeditor/ckeditor5-utils/src/lib/lodash/isPlainObject';
 import Text from './text';
 import EditableElement from './editableelement';
+import { isPlainObject } from 'lodash-es';
 
 /**
  * View writer class. Provides set of methods used to properly manipulate nodes attached to


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Replaced `ckeditor5-uitls/src/lib/lodash` imports with `lodash-es`.

---

### Additional information

Part of the https://github.com/ckeditor/ckeditor5-utils/pull/252.
