### PR TITLE
Additional improvements in OT

### DIFF
--- a/src/model/operation/mergeoperation.js
+++ b/src/model/operation/mergeoperation.js
@@ -30,7 +30,7 @@ export default class MergeOperation extends Operation {
 	 *
 	 * @param {module:engine/model/position~Position} sourcePosition Position inside the merged element. All nodes from that
 	 * element after that position will be moved to {@link ~#targetPosition}.
-	 * @param {Number} howMany
+	 * @param {Number} howMany Summary offset size of nodes which will be moved from the merged element to the new parent.
 	 * @param {module:engine/model/position~Position} targetPosition Position which the nodes from the merged elements will be moved to.
 	 * @param {module:engine/model/position~Position} graveyardPosition Position in graveyard to which the merged element will be moved.
 	 * @param {Number|null} baseVersion Document {@link module:engine/model/document~Document#version} on which operation

--- a/src/model/operation/mergeoperation.js
+++ b/src/model/operation/mergeoperation.js
@@ -30,12 +30,13 @@ export default class MergeOperation extends Operation {
 	 *
 	 * @param {module:engine/model/position~Position} sourcePosition Position inside the merged element. All nodes from that
 	 * element after that position will be moved to {@link ~#targetPosition}.
+	 * @param {Number} howMany
 	 * @param {module:engine/model/position~Position} targetPosition Position which the nodes from the merged elements will be moved to.
 	 * @param {module:engine/model/position~Position} graveyardPosition Position in graveyard to which the merged element will be moved.
 	 * @param {Number|null} baseVersion Document {@link module:engine/model/document~Document#version} on which operation
 	 * can be applied or `null` if the operation operates on detached (non-document) tree.
 	 */
-	constructor( sourcePosition, targetPosition, graveyardPosition, baseVersion ) {
+	constructor( sourcePosition, howMany, targetPosition, graveyardPosition, baseVersion ) {
 		super( baseVersion );
 
 		/**
@@ -56,6 +57,8 @@ export default class MergeOperation extends Operation {
 		// is it? think about reversed split operations, undo, etc.
 
 		this.graveyardPosition = Position.createFromPosition( graveyardPosition );
+
+		this.howMany = howMany;
 	}
 
 	/**
@@ -94,7 +97,7 @@ export default class MergeOperation extends Operation {
 	 * @returns {module:engine/model/operation/mergeoperation~MergeOperation} Clone of this operation.
 	 */
 	clone() {
-		return new this.constructor( this.sourcePosition, this.targetPosition, this.graveyardPosition, this.baseVersion );
+		return new this.constructor( this.sourcePosition, this.howMany, this.targetPosition, this.graveyardPosition, this.baseVersion );
 	}
 
 	/**
@@ -103,7 +106,7 @@ export default class MergeOperation extends Operation {
 	 * @returns {module:engine/model/operation/splitoperation~SplitOperation}
 	 */
 	getReversed() {
-		return new SplitOperation( this.targetPosition, this.graveyardPosition, this.baseVersion + 1 );
+		return new SplitOperation( this.targetPosition, this.howMany, this.graveyardPosition, this.baseVersion + 1 );
 	}
 
 	/**
@@ -128,6 +131,13 @@ export default class MergeOperation extends Operation {
 			 * @error merge-operation-target-position-invalid
 			 */
 			throw new CKEditorError( 'merge-operation-target-position-invalid: Merge target position is invalid.' );
+		} else if ( this.howMany != sourceElement.maxOffset ) {
+			/**
+			 * Merge operation specifies wrong number of nodes to move.
+			 *
+			 * @error merge-operation-how-many-invalid
+			 */
+			throw new CKEditorError( 'merge-operation-how-many-invalid: Merge operation specifies wrong number of nodes to move.' );
 		}
 	}
 
@@ -161,6 +171,6 @@ export default class MergeOperation extends Operation {
 		const targetPosition = Position.fromJSON( json.targetPosition, document );
 		const graveyardPosition = Position.fromJSON( json.graveyardPosition, document );
 
-		return new this( sourcePosition, targetPosition, graveyardPosition, json.baseVersion );
+		return new this( sourcePosition, json.howMany, targetPosition, graveyardPosition, json.baseVersion );
 	}
 }

--- a/src/model/operation/splitoperation.js
+++ b/src/model/operation/splitoperation.js
@@ -26,12 +26,13 @@ export default class SplitOperation extends Operation {
 	 * Creates a split operation.
 	 *
 	 * @param {module:engine/model/position~Position} position Position at which an element should be split.
+	 * @param {Number}
 	 * @param {module:engine/model/position~Position|null} graveyardPosition Position in graveyard before the element which
 	 * should be used as a parent of the nodes after `position`. If it is not set, a copy of the the `position` parent will be used.
 	 * @param {Number|null} baseVersion Document {@link module:engine/model/document~Document#version} on which operation
 	 * can be applied or `null` if the operation operates on detached (non-document) tree.
 	 */
-	constructor( position, graveyardPosition, baseVersion ) {
+	constructor( position, howMany, graveyardPosition, baseVersion ) {
 		super( baseVersion );
 
 		/**
@@ -47,6 +48,8 @@ export default class SplitOperation extends Operation {
 		if ( this.graveyardPosition ) {
 			this.graveyardPosition.stickiness = 'toNext';
 		}
+
+		this.howMany = howMany;
 	}
 
 	/**
@@ -104,7 +107,7 @@ export default class SplitOperation extends Operation {
 	 * @returns {module:engine/model/operation/splitoperation~SplitOperation} Clone of this operation.
 	 */
 	clone() {
-		return new this.constructor( this.position, this.graveyardPosition, this.baseVersion );
+		return new this.constructor( this.position, this.howMany, this.graveyardPosition, this.baseVersion );
 	}
 
 	/**
@@ -116,7 +119,7 @@ export default class SplitOperation extends Operation {
 		const graveyard = this.position.root.document.graveyard;
 		const graveyardPosition = new Position( graveyard, [ 0 ] );
 
-		return new MergeOperation( this.moveTargetPosition, this.position, graveyardPosition, this.baseVersion + 1 );
+		return new MergeOperation( this.moveTargetPosition, this.howMany, this.position, graveyardPosition, this.baseVersion + 1 );
 	}
 
 	/**
@@ -134,6 +137,13 @@ export default class SplitOperation extends Operation {
 			 * @error split-operation-position-invalid
 			 */
 			throw new CKEditorError( 'split-operation-position-invalid: Split position is invalid.' );
+		} else if ( this.howMany != element.maxOffset - this.position.offset ) {
+			/**
+			 * Split operation specifies wrong number of nodes to move.
+			 *
+			 * @error split-operation-how-many-invalid
+			 */
+			throw new CKEditorError( 'split-operation-how-many-invalid: Split operation specifies wrong number of nodes to move.' );
 		}
 	}
 
@@ -174,6 +184,6 @@ export default class SplitOperation extends Operation {
 		const position = Position.fromJSON( json.position, document );
 		const graveyardPosition = json.graveyardPosition ? Position.fromJSON( json.graveyardPosition, document ) : null;
 
-		return new this( position, graveyardPosition, json.baseVersion );
+		return new this( position, json.howMany, graveyardPosition, json.baseVersion );
 	}
 }

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -1339,7 +1339,14 @@ setTransformation( MoveOperation, MergeOperation, ( a, b, context ) => {
 			//			it would be a move operation that moves 0 nodes, so maybe it is better just to return no-op.
 			//
 			if ( a.howMany == 1 ) {
-				return getNoOp();
+				if ( !context.bWasUndone ) {
+					return getNoOp();
+				} else {
+					a.sourcePosition = Position.createFromPosition( b.graveyardPosition );
+					a.targetPosition = a.targetPosition._getTransformedByMergeOperation( b );
+
+					return [ a ];
+				}
 			}
 		}
 	}

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -1908,7 +1908,7 @@ setTransformation( WrapOperation, WrapOperation, ( a, b, context ) => {
 					// Unwrap:
 					// <p>Foo</p><p>Bar</p><p>Xyz</p>
 					//
-					// Wrap with stronger wrap (`a`):
+					// Wrap with stronger wrap:
 					// <p>Foo</p><div><p>Bar</p><p>Xyz</p></div>
 					//
 					// Re-wrap:

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -437,7 +437,7 @@ setTransformation( AttributeOperation, InsertOperation, ( a, b ) => {
 	}
 
 	// If insert operation is not expanding the attribute operation range, simply transform the range.
-	a.range = a.range._getTransformedByInsertOperation( b )[ 0 ];
+	a.range = a.range._getTransformedByInsertion( b.position, b.howMany, false )[ 0 ];
 
 	return [ a ];
 } );
@@ -681,7 +681,7 @@ setTransformation( AttributeOperation, UnwrapOperation, ( a, b ) => {
 setTransformation( InsertOperation, AttributeOperation, ( a, b ) => {
 	const result = [ a ];
 
-	if ( a.shouldReceiveAttributes && b.range.containsPosition( a.position ) ) {
+	if ( a.shouldReceiveAttributes && a.position.hasSameParentAs( b.range.start ) && b.range.containsPosition( a.position ) ) {
 		result.push( ..._getComplementaryAttributeOperations( a, b.key, b.newValue ) );
 	}
 

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -1540,7 +1540,7 @@ setTransformation( SplitOperation, MergeOperation, ( a, b ) => {
 	a.position = a.position._getTransformedByMergeOperation( b );
 
 	if ( a.graveyardPosition ) {
-		a.graveyardPosition = a.graveyardPosition._getTransformedByInsertion( b.graveyardPosition, 1 );
+		a.graveyardPosition = a.graveyardPosition._getTransformedByMergeOperation( b );
 	}
 
 	return [ a ];

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -496,6 +496,18 @@ export default class Range {
 		let start = this.start._getTransformedByMergeOperation( operation );
 		let end = this.end._getTransformedByMergeOperation( operation );
 
+		if ( start.root != end.root ) {
+			// This happens when only start or end was next to the merged (deleted) element. In this case we need to fix
+			// the range cause its boundaries would be in different roots.
+			if ( start.root != this.root ) {
+				// Fix start position root at it was the only one that was moved.
+				start = this.start;
+			} else {
+				// Fix end position root.
+				end = this.end.getShiftedBy( -1 );
+			}
+		}
+
 		if ( start.isAfter( end ) ) {
 			// This happens in the following two, similar cases:
 			//

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -567,7 +567,7 @@ export default class Writer {
 
 		const version = position.root.document.version;
 
-		const merge = new MergeOperation( sourcePosition, targetPosition, graveyardPosition, version );
+		const merge = new MergeOperation( sourcePosition, position.nodeAfter.maxOffset, targetPosition, graveyardPosition, version );
 
 		this.batch.addOperation( merge );
 		this.model.applyOperation( merge );
@@ -644,7 +644,8 @@ export default class Writer {
 
 		do {
 			const version = splitElement.root.document ? splitElement.root.document.version : null;
-			const split = new SplitOperation( position, null, version );
+			const howMany = splitElement.maxOffset - position.offset;
+			const split = new SplitOperation( position, howMany, null, version );
 
 			this.batch.addOperation( split );
 			this.model.applyOperation( split );

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -1028,7 +1028,7 @@ describe( 'DocumentSelection', () => {
 				} );
 
 				const batch = new Batch();
-				const splitOperation = new SplitOperation( new Position( root, [ 1, 2 ] ), null, 0 );
+				const splitOperation = new SplitOperation( new Position( root, [ 1, 2 ] ), 4, null, 0 );
 
 				batch.addOperation( splitOperation );
 				model.applyOperation( splitOperation );

--- a/tests/model/liverange.js
+++ b/tests/model/liverange.js
@@ -178,6 +178,7 @@ describe( 'LiveRange', () => {
 
 			const merge = new MergeOperation(
 				new Position( root, [ 0, 0 ] ),
+				10,
 				new Position( gy, [ 0, 0 ] ),
 				new Position( gy, [ 0 ] ),
 				model.document.version + 1

--- a/tests/model/operation/transform/attribute.js
+++ b/tests/model/operation/transform/attribute.js
@@ -281,6 +281,18 @@ describe( 'transform', () => {
 
 				expectClients( '<paragraph><$text bold="true">Foxxxo</$text></paragraph>' );
 			} );
+
+			it( 'type inside element which attribute changes', () => {
+				john.setData( '[<paragraph></paragraph>]' );
+				kate.setData( '<paragraph>[]</paragraph>' );
+
+				john.setAttribute( 'bold', true );
+				kate.type( 'x' );
+
+				syncClients();
+
+				expectClients( '<paragraph bold="true">x</paragraph>' );
+			} );
 		} );
 
 		describe( 'by move', () => {

--- a/tests/model/operation/transform/attribute.js
+++ b/tests/model/operation/transform/attribute.js
@@ -263,6 +263,24 @@ describe( 'transform', () => {
 					'<paragraph>Abc</paragraph>'
 				);
 			} );
+
+			it( 'multiple typing', () => {
+				john.setData( '<paragraph>[Foo]</paragraph>' );
+				kate.setData( '<paragraph>Fo[]o</paragraph>' );
+
+				john.setAttribute( 'bold', true );
+
+				kate.setSelection( [ 0, 2 ] );
+				kate.type( 'x' );
+				kate.setSelection( [ 0, 3 ] );
+				kate.type( 'x' );
+				kate.setSelection( [ 0, 4 ] );
+				kate.type( 'x' );
+
+				syncClients();
+
+				expectClients( '<paragraph><$text bold="true">Foxxxo</$text></paragraph>' );
+			} );
 		} );
 
 		describe( 'by move', () => {

--- a/tests/model/operation/transform/delete.js
+++ b/tests/model/operation/transform/delete.js
@@ -39,6 +39,24 @@ describe( 'transform', () => {
 
 				expectClients( '<paragraph>Fobc</paragraph>' );
 			} );
+
+			// https://github.com/ckeditor/ckeditor5-engine/issues/1492
+			it( 'delete same content from a few elements', () => {
+				john.setData( '<paragraph>F[oo</paragraph><paragraph>Bar</paragraph><paragraph>Ab]c</paragraph>' );
+				kate.setData( '<paragraph>F[oo</paragraph><paragraph>Bar</paragraph><paragraph>Ab]c</paragraph>' );
+
+				john.delete();
+				kate.delete();
+
+				syncClients();
+				expectClients( '<paragraph>Fc</paragraph>' );
+
+				john.undo();
+				kate.undo();
+
+				syncClients();
+				expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph><paragraph>Abc</paragraph>' );
+			} );
 		} );
 	} );
 } );

--- a/tests/model/operation/transform/unwrap.js
+++ b/tests/model/operation/transform/unwrap.js
@@ -132,6 +132,21 @@ describe( 'transform', () => {
 					'<paragraph>Bar</paragraph>'
 				);
 			} );
+
+			it( 'unwrap merge target element', () => {
+				john.setData( '<blockQuote>[]<paragraph>Foo</paragraph></blockQuote><blockQuote><paragraph>Bar</paragraph></blockQuote>' );
+				kate.setData( '<blockQuote><paragraph>Foo</paragraph></blockQuote>[]<blockQuote><paragraph>Bar</paragraph></blockQuote>' );
+
+				john.unwrap();
+				kate.merge();
+
+				syncClients();
+
+				expectClients(
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph>Bar</paragraph>'
+				);
+			} );
 		} );
 	} );
 } );

--- a/tests/model/operation/transform/wrap.js
+++ b/tests/model/operation/transform/wrap.js
@@ -80,6 +80,23 @@ describe( 'transform', () => {
 				);
 			} );
 
+			it( 'intersecting wrap #3', () => {
+				john.setData( '[<paragraph>Foo</paragraph><paragraph>Bar</paragraph>]<paragraph>Abc</paragraph>' );
+				kate.setData( '[<paragraph>Foo</paragraph>]<paragraph>Bar</paragraph><paragraph>Abc</paragraph>' );
+
+				john.wrap( 'blockQuote' );
+				kate.wrap( 'div' );
+
+				syncClients();
+				expectClients(
+					'<blockQuote>' +
+						'<paragraph>Foo</paragraph>' +
+						'<paragraph>Bar</paragraph>' +
+					'</blockQuote>' +
+					'<paragraph>Abc</paragraph>'
+				);
+			} );
+
 			it( 'intersecting wrap, then undo #1', () => {
 				john.setData( '[<paragraph>Foo</paragraph><paragraph>Bar</paragraph>]<paragraph>Abc</paragraph>' );
 				kate.setData( '<paragraph>Foo</paragraph>[<paragraph>Bar</paragraph><paragraph>Abc</paragraph>]' );
@@ -133,6 +150,26 @@ describe( 'transform', () => {
 				syncClients();
 
 				expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph><paragraph>Abc</paragraph>' );
+			} );
+
+			it( 'intersecting wrap #3, then undo', () => {
+				john.setData( '[<paragraph>Foo</paragraph><paragraph>Bar</paragraph>]<paragraph>Abc</paragraph>' );
+				kate.setData( '[<paragraph>Foo</paragraph>]<paragraph>Bar</paragraph><paragraph>Abc</paragraph>' );
+
+				john.wrap( 'blockQuote' );
+				kate.wrap( 'div' );
+
+				syncClients();
+
+				john.undo();
+				kate.undo();
+
+				syncClients();
+				expectClients(
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph>Bar</paragraph>' +
+					'<paragraph>Abc</paragraph>'
+				);
 			} );
 
 			it( 'element and text', () => {

--- a/tests/model/operation/transform/wrap.js
+++ b/tests/model/operation/transform/wrap.js
@@ -209,6 +209,39 @@ describe( 'transform', () => {
 					'</blockQuote>'
 				);
 			} );
+
+			it( 'delete all wrapped content', () => {
+				john.setData( '[<paragraph>Foo</paragraph><paragraph>Bar</paragraph><paragraph>Abc</paragraph>]' );
+				kate.setData( '<paragraph>[Foo</paragraph><paragraph>Bar</paragraph><paragraph>Ab]c</paragraph>' );
+
+				john.wrap( 'blockQuote' );
+				kate.delete();
+
+				syncClients();
+				expectClients( '<blockQuote><paragraph>c</paragraph></blockQuote>' );
+			} );
+
+			it.skip( 'delete all wrapped content and undo', () => {
+				john.setData( '[<paragraph>Foo</paragraph><paragraph>Bar</paragraph><paragraph>Abc</paragraph>]' );
+				kate.setData( '<paragraph>[Foo</paragraph><paragraph>Bar</paragraph><paragraph>Ab]c</paragraph>' );
+
+				john.wrap( 'blockQuote' );
+				kate.delete();
+
+				syncClients();
+				expectClients( '<blockQuote><paragraph>c</paragraph></blockQuote>' );
+
+				john.undo();
+
+				// There is a bug in undo for Kate.
+				// Kate's content is: '<blockQuote><paragraph>c</paragraph></blockQuote>'.
+				// Then goes undo and it returns "Foo" paragraph into block quote, but "Bar" goes after it.
+				// There is a move (reinsert) x wrap transformation and the move is not included inside the wrap.
+				kate.undo();
+
+				syncClients();
+				expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph><paragraph>Abc</paragraph>' );
+			} );
 		} );
 
 		describe( 'by remove', () => {

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -944,7 +944,7 @@ describe( 'Range', () => {
 			it( 'split inside range', () => {
 				range = new Range( new Position( root, [ 0, 2 ] ), new Position( root, [ 0, 4 ] ) );
 
-				const op = new SplitOperation( new Position( root, [ 0, 3 ] ), gyPos, 1 );
+				const op = new SplitOperation( new Position( root, [ 0, 3 ] ), 6, gyPos, 1 );
 				const transformed = range.getTransformedByOperation( op );
 
 				expect( transformed.length ).to.equal( 1 );
@@ -955,7 +955,7 @@ describe( 'Range', () => {
 			it( 'split at the beginning of multi-element range', () => {
 				range = new Range( new Position( root, [ 0, 4 ] ), new Position( root, [ 1, 2 ] ) );
 
-				const op = new SplitOperation( new Position( root, [ 0, 4 ] ), gyPos, 1 );
+				const op = new SplitOperation( new Position( root, [ 0, 4 ] ), 5, gyPos, 1 );
 				const transformed = range.getTransformedByOperation( op );
 
 				expect( transformed.length ).to.equal( 1 );
@@ -966,7 +966,7 @@ describe( 'Range', () => {
 			it( 'split inside range which starts at the beginning of split element', () => {
 				range = new Range( new Position( root, [ 0, 0 ] ), new Position( root, [ 0, 4 ] ) );
 
-				const op = new SplitOperation( new Position( root, [ 0, 3 ] ), gyPos, 1 );
+				const op = new SplitOperation( new Position( root, [ 0, 3 ] ), 6, gyPos, 1 );
 				const transformed = range.getTransformedByOperation( op );
 
 				expect( transformed.length ).to.equal( 1 );
@@ -977,7 +977,7 @@ describe( 'Range', () => {
 			it( 'split inside range which end is at the end of split element', () => {
 				range = new Range( new Position( root, [ 0, 3 ] ), new Position( root, [ 0, 6 ] ) );
 
-				const op = new SplitOperation( new Position( root, [ 0, 4 ] ), gyPos, 1 );
+				const op = new SplitOperation( new Position( root, [ 0, 4 ] ), 5, gyPos, 1 );
 				const transformed = range.getTransformedByOperation( op );
 
 				expect( transformed.length ).to.equal( 1 );
@@ -988,7 +988,7 @@ describe( 'Range', () => {
 			it( 'split element which has collapsed range at the end', () => {
 				range = new Range( new Position( root, [ 0, 6 ] ), new Position( root, [ 0, 6 ] ) );
 
-				const op = new SplitOperation( new Position( root, [ 0, 3 ] ), gyPos, 1 );
+				const op = new SplitOperation( new Position( root, [ 0, 3 ] ), 6, gyPos, 1 );
 				const transformed = range.getTransformedByOperation( op );
 
 				expect( transformed.length ).to.equal( 1 );
@@ -1004,6 +1004,7 @@ describe( 'Range', () => {
 
 				const op = new MergeOperation(
 					new Position( root, [ 1, 0 ] ),
+					4,
 					new Position( root, [ 0, 3 ] ),
 					gyPos,
 					1
@@ -1022,6 +1023,7 @@ describe( 'Range', () => {
 
 				const op = new MergeOperation(
 					new Position( root, [ 0, 0 ] ),
+					4,
 					new Position( root, [ 1, 3 ] ),
 					gyPos,
 					1
@@ -1045,6 +1047,7 @@ describe( 'Range', () => {
 
 				const op = new MergeOperation(
 					new Position( root, [ 1, 0 ] ),
+					4,
 					new Position( root, [ 0, 1 ] ),
 					gyPos,
 					1


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added `MergeOperation#howMany` and `SplitOperation#howMany`. Improvements in `Position` and `Range` transforming functions. Improvements in OT algorithms. Closes #1488. Closes #1492. Closes #1499.
