### PR TITLE
Error logs should not be visible anymore

### DIFF
--- a/tests/model/operation/transform.js
+++ b/tests/model/operation/transform.js
@@ -59,7 +59,7 @@ describe( 'transform', () => {
 	};
 
 	it( 'error logging', () => {
-		const spy = sinon.spy( log, 'error' );
+		const spy = sinon.stub( log, 'error' );
 
 		const nodeA = new Node();
 		const nodeB = new Node();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Error logs from transform tests should not be visible anymore. Closes ckeditor/ckeditor5#1211.
