### PR TITLE
Changed long name returned by Operation.className property to the short one

### DIFF
--- a/src/model/operation/attributeoperation.js
+++ b/src/model/operation/attributeoperation.js
@@ -179,7 +179,7 @@ export default class AttributeOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.AttributeOperation';
+		return 'AttributeOperation';
 	}
 
 	/**

--- a/src/model/operation/detachoperation.js
+++ b/src/model/operation/detachoperation.js
@@ -89,6 +89,6 @@ export default class DetachOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.DetachOperation';
+		return 'DetachOperation';
 	}
 }

--- a/src/model/operation/insertoperation.js
+++ b/src/model/operation/insertoperation.js
@@ -144,7 +144,7 @@ export default class InsertOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.InsertOperation';
+		return 'InsertOperation';
 	}
 
 	/**

--- a/src/model/operation/markeroperation.js
+++ b/src/model/operation/markeroperation.js
@@ -126,7 +126,7 @@ export default class MarkerOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.MarkerOperation';
+		return 'MarkerOperation';
 	}
 
 	/**

--- a/src/model/operation/mergeoperation.js
+++ b/src/model/operation/mergeoperation.js
@@ -169,7 +169,7 @@ export default class MergeOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.MergeOperation';
+		return 'MergeOperation';
 	}
 
 	/**

--- a/src/model/operation/moveoperation.js
+++ b/src/model/operation/moveoperation.js
@@ -191,7 +191,7 @@ export default class MoveOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.MoveOperation';
+		return 'MoveOperation';
 	}
 
 	/**

--- a/src/model/operation/nooperation.js
+++ b/src/model/operation/nooperation.js
@@ -49,6 +49,6 @@ export default class NoOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.NoOperation';
+		return 'NoOperation';
 	}
 }

--- a/src/model/operation/operation.js
+++ b/src/model/operation/operation.js
@@ -112,7 +112,7 @@ export default class Operation {
 	 * @type {String}
 	 */
 	static get className() {
-		return 'engine.model.operation.Operation';
+		return 'Operation';
 	}
 
 	/**

--- a/src/model/operation/renameoperation.js
+++ b/src/model/operation/renameoperation.js
@@ -131,7 +131,7 @@ export default class RenameOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.RenameOperation';
+		return 'RenameOperation';
 	}
 
 	/**

--- a/src/model/operation/rootattributeoperation.js
+++ b/src/model/operation/rootattributeoperation.js
@@ -177,7 +177,7 @@ export default class RootAttributeOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.RootAttributeOperation';
+		return 'RootAttributeOperation';
 	}
 
 	/**

--- a/src/model/operation/splitoperation.js
+++ b/src/model/operation/splitoperation.js
@@ -185,7 +185,7 @@ export default class SplitOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.SplitOperation';
+		return 'SplitOperation';
 	}
 
 	/**

--- a/src/model/operation/unwrapoperation.js
+++ b/src/model/operation/unwrapoperation.js
@@ -146,7 +146,7 @@ export default class UnwrapOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.UnwrapOperation';
+		return 'UnwrapOperation';
 	}
 
 	/**

--- a/src/model/operation/wrapoperation.js
+++ b/src/model/operation/wrapoperation.js
@@ -186,7 +186,7 @@ export default class WrapOperation extends Operation {
 	 * @inheritDoc
 	 */
 	static get className() {
-		return 'engine.model.operation.WrapOperation';
+		return 'WrapOperation';
 	}
 
 	/**

--- a/tests/dev-utils/operationreplayer.js
+++ b/tests/dev-utils/operationreplayer.js
@@ -175,7 +175,7 @@ function getFirstOperation() {
 				data: 'The great world of open Web standards'
 			} ]
 		} ],
-		__className: 'engine.model.operation.InsertOperation'
+		__className: 'InsertOperation'
 	};
 }
 
@@ -192,6 +192,6 @@ function getSecondOperation() {
 				data: 'The great world of open Web standards'
 			} ]
 		} ],
-		__className: 'engine.model.operation.InsertOperation'
+		__className: 'InsertOperation'
 	};
 }

--- a/tests/model/operation/attributeoperation.js
+++ b/tests/model/operation/attributeoperation.js
@@ -378,10 +378,10 @@ describe( 'AttributeOperation', () => {
 
 			const serialized = op.toJSON();
 
-			expect( serialized.__className ).to.equal( 'engine.model.operation.AttributeOperation' );
+			expect( serialized.__className ).to.equal( 'AttributeOperation' );
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.AttributeOperation',
+				__className: 'AttributeOperation',
 				baseVersion: 0,
 				key: 'key',
 				newValue: 'newValue',

--- a/tests/model/operation/detachoperation.js
+++ b/tests/model/operation/detachoperation.js
@@ -63,7 +63,7 @@ describe( 'DetachOperation', () => {
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.DetachOperation',
+				__className: 'DetachOperation',
 				baseVersion: null,
 				sourcePosition: position.toJSON(),
 				howMany: 1

--- a/tests/model/operation/insertoperation.js
+++ b/tests/model/operation/insertoperation.js
@@ -225,7 +225,7 @@ describe( 'InsertOperation', () => {
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.InsertOperation',
+				__className: 'InsertOperation',
 				baseVersion: 0,
 				nodes: ( new NodeList( [ new Text( 'x' ) ] ) ).toJSON(),
 				position: position.toJSON(),

--- a/tests/model/operation/markeroperation.js
+++ b/tests/model/operation/markeroperation.js
@@ -137,7 +137,7 @@ describe( 'MarkerOperation', () => {
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.MarkerOperation',
+				__className: 'MarkerOperation',
 				baseVersion: 0,
 				name: 'name',
 				oldRange: null,

--- a/tests/model/operation/moveoperation.js
+++ b/tests/model/operation/moveoperation.js
@@ -272,7 +272,7 @@ describe( 'MoveOperation', () => {
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.MoveOperation',
+				__className: 'MoveOperation',
 				baseVersion: 0,
 				howMany: 1,
 				sourcePosition: op.sourcePosition.toJSON(),

--- a/tests/model/operation/nooperation.js
+++ b/tests/model/operation/nooperation.js
@@ -38,7 +38,7 @@ describe( 'NoOperation', () => {
 			const serialized = noop.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.NoOperation',
+				__className: 'NoOperation',
 				baseVersion: 0
 			} );
 		} );

--- a/tests/model/operation/operation.js
+++ b/tests/model/operation/operation.js
@@ -34,7 +34,7 @@ describe( 'Operation', () => {
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.Operation',
+				__className: 'Operation',
 				baseVersion: 4
 			} );
 		} );
@@ -47,7 +47,7 @@ describe( 'Operation', () => {
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.Operation',
+				__className: 'Operation',
 				baseVersion: 4
 			} );
 		} );

--- a/tests/model/operation/operationfactory.js
+++ b/tests/model/operation/operationfactory.js
@@ -16,7 +16,7 @@ describe( 'OperationFactory', () => {
 
 	it( 'should create operation from JSON', () => {
 		const operation = OperationFactory.fromJSON( {
-			__className: 'engine.model.operation.NoOperation',
+			__className: 'NoOperation',
 			baseVersion: 0
 		}, model.doc );
 

--- a/tests/model/operation/renameoperation.js
+++ b/tests/model/operation/renameoperation.js
@@ -108,7 +108,7 @@ describe( 'RenameOperation', () => {
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.RenameOperation',
+				__className: 'RenameOperation',
 				baseVersion: 0,
 				position: op.position.toJSON(),
 				newName: 'newName',

--- a/tests/model/operation/rootattributeoperation.js
+++ b/tests/model/operation/rootattributeoperation.js
@@ -269,9 +269,9 @@ describe( 'RootAttributeOperation', () => {
 
 			const serialized = op.toJSON();
 
-			expect( serialized.__className ).to.equal( 'engine.model.operation.RootAttributeOperation' );
+			expect( serialized.__className ).to.equal( 'RootAttributeOperation' );
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.RootAttributeOperation',
+				__className: 'RootAttributeOperation',
 				baseVersion: 0,
 				key: 'key',
 				newValue: 'newValue',

--- a/tests/model/operation/wrapoperation.js
+++ b/tests/model/operation/wrapoperation.js
@@ -42,7 +42,7 @@ describe( 'WrapOperation', () => {
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.WrapOperation',
+				__className: 'WrapOperation',
 				baseVersion: 0,
 				position: op.position.toJSON(),
 				graveyardPosition: op.graveyardPosition.toJSON(),
@@ -61,7 +61,7 @@ describe( 'WrapOperation', () => {
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
-				__className: 'engine.model.operation.WrapOperation',
+				__className: 'WrapOperation',
 				baseVersion: 0,
 				position: op.position.toJSON(),
 				element: op.element.toJSON(),


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Changed long name returned by `Operation.className` property to the short one. Closes #1513.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
