### PR TITLE
Renamed view 'Writer' to 'DowncastWriter'

### DIFF
--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -21,7 +21,7 @@ import { convertText, convertToModelFragment } from '../conversion/upcast-conver
 
 import ViewDocumentFragment from '../view/documentfragment';
 import ViewDocument from '../view/document';
-import ViewWriter from '../view/writer';
+import ViewDowncastWriter from '../view/downcastwriter';
 
 import ModelRange from '../model/range';
 
@@ -153,9 +153,9 @@ export default class DataController {
 
 		const viewDocumentFragment = new ViewDocumentFragment();
 
-		// Create separate ViewWriter just for data conversion purposes.
+		// Create separate ViewDowncastWriter just for data conversion purposes.
 		// We have no view controller and rendering do DOM in DataController so view.change() block is not used here.
-		const viewWriter = new ViewWriter( new ViewDocument() );
+		const viewWriter = new ViewDowncastWriter( new ViewDocument() );
 		this.mapper.bindElements( modelElementOrFragment, viewDocumentFragment );
 
 		this.downcastDispatcher.convertInsert( modelRange, viewWriter );

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -364,7 +364,7 @@ function _normalizeToElementConfig( view, viewElementType ) {
 // Creates a view element instance from the provided {@link module:engine/view/elementdefinition~ElementDefinition} and class.
 //
 // @param {module:engine/view/elementdefinition~ElementDefinition} viewElementDefinition
-// @param {module:engine/view/writer~Writer} viewWriter
+// @param {module:engine/view/downcastwriter~DowncastWriter} viewWriter
 // @param {'container'|'attribute'|'ui'} viewElementType
 // @returns {module:engine/view/element~Element}
 function _createViewElementFromDefinition( viewElementDefinition, viewWriter, viewElementType ) {

--- a/src/conversion/downcastdispatcher.js
+++ b/src/conversion/downcastdispatcher.js
@@ -74,7 +74,7 @@ import { extend } from 'lodash-es';
  * converted the change should also stop the event (for efficiency purposes).
  *
  * When providing custom listeners for `DowncastDispatcher` remember to use provided
- * {@link module:engine/view/writer~Writer view writer} to apply changes to the view document.
+ * {@link module:engine/view/downcastwriter~DowncastWriter view downcast writer} to apply changes to the view document.
  *
  * Example of a custom converter for `DowncastDispatcher`:
  *
@@ -120,7 +120,7 @@ export default class DowncastDispatcher {
 	 * Takes {@link module:engine/model/differ~Differ model differ} object with buffered changes and fires conversion basing on it.
 	 *
 	 * @param {module:engine/model/differ~Differ} differ Differ object with buffered changes.
-	 * @param {module:engine/view/writer~Writer} writer View writer that should be used to modify view document.
+	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer View writer that should be used to modify view document.
 	 */
 	convertChanges( differ, writer ) {
 		// Before the view is updated, remove markers which have changed.
@@ -155,7 +155,7 @@ export default class DowncastDispatcher {
 	 * @fires insert
 	 * @fires attribute
 	 * @param {module:engine/model/range~Range} range Inserted range.
-	 * @param {module:engine/view/writer~Writer} writer View writer that should be used to modify view document.
+	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer View writer that should be used to modify view document.
 	 */
 	convertInsert( range, writer ) {
 		this.conversionApi.writer = writer;
@@ -195,7 +195,7 @@ export default class DowncastDispatcher {
 	 * @param {module:engine/model/position~Position} position Position from which node was removed.
 	 * @param {Number} length Offset size of removed node.
 	 * @param {String} name Name of removed node.
-	 * @param {module:engine/view/writer~Writer} writer View writer that should be used to modify view document.
+	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer View writer that should be used to modify view document.
 	 */
 	convertRemove( position, length, name, writer ) {
 		this.conversionApi.writer = writer;
@@ -215,7 +215,7 @@ export default class DowncastDispatcher {
 	 * @param {String} key Key of the attribute that has changed.
 	 * @param {*} oldValue Attribute value before the change or `null` if the attribute has not been set before.
 	 * @param {*} newValue New attribute value or `null` if the attribute has been removed.
-	 * @param {module:engine/view/writer~Writer} writer View writer that should be used to modify view document.
+	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer View writer that should be used to modify view document.
 	 */
 	convertAttribute( range, key, oldValue, newValue, writer ) {
 		this.conversionApi.writer = writer;
@@ -251,7 +251,7 @@ export default class DowncastDispatcher {
 	 * @fires attribute
 	 * @param {module:engine/model/selection~Selection} selection Selection to convert.
 	 * @param {Array.<module:engine/model/markercollection~Marker>} markers Array of markers containing model markers.
-	 * @param {module:engine/view/writer~Writer} writer View writer that should be used to modify view document.
+	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer View writer that should be used to modify view document.
 	 */
 	convertSelection( selection, markers, writer ) {
 		const markersAtSelection = Array.from( markers.getMarkersAtPosition( selection.getFirstPosition() ) );
@@ -308,7 +308,7 @@ export default class DowncastDispatcher {
 	 * @fires addMarker
 	 * @param {String} markerName Marker name.
 	 * @param {module:engine/model/range~Range} markerRange Marker range.
-	 * @param {module:engine/view/writer~Writer} writer View writer that should be used to modify view document.
+	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer View writer that should be used to modify view document.
 	 */
 	convertMarkerAdd( markerName, markerRange, writer ) {
 		// Do not convert if range is in graveyard or not in the document (e.g. in DocumentFragment).
@@ -357,7 +357,7 @@ export default class DowncastDispatcher {
 	 * @fires removeMarker
 	 * @param {String} markerName Marker name.
 	 * @param {module:engine/model/range~Range} markerRange Marker range.
-	 * @param {module:engine/view/writer~Writer} writer View writer that should be used to modify view document.
+	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer View writer that should be used to modify view document.
 	 */
 	convertMarkerRemove( markerName, markerRange, writer ) {
 		// Do not convert if range is in graveyard or not in the document (e.g. in DocumentFragment).

--- a/src/view/attributeelement.js
+++ b/src/view/attributeelement.js
@@ -15,7 +15,7 @@ const DEFAULT_PRIORITY = 10;
 
 /**
  * Attributes are elements which define document presentation. They are mostly elements like `<b>` or `<span>`.
- * Attributes can be broken and merged by the {@link module:engine/view/writer~Writer view writer}.
+ * Attributes can be broken and merged by the {@link module:engine/view/downcastwriter~DowncastWriter view downcast writer}.
  *
  * Editing engine does not define fixed HTML DTD. This is why the type of the {@link module:engine/view/element~Element} need to
  * be defined by the feature developer. Creating an element you should use {@link module:engine/view/containerelement~ContainerElement}
@@ -27,7 +27,7 @@ export default class AttributeElement extends Element {
 	/**
 	 * Creates a attribute element.
 	 *
-	 * @see module:engine/view/writer~Writer#createAttributeElement
+	 * @see module:engine/view/downcastwriter~DowncastWriter#createAttributeElement
 	 * @protected
 	 * @see module:engine/view/element~Element
 	 */
@@ -43,7 +43,7 @@ export default class AttributeElement extends Element {
 		this.getFillerOffset = getFillerOffset;
 
 		/**
-		 * Element priority. Decides in what order elements are wrapped by {@link module:engine/view/writer~Writer}.
+		 * Element priority. Decides in what order elements are wrapped by {@link module:engine/view/downcastwriter~DowncastWriter}.
 		 *
 		 * @protected
 		 * @member {Number}
@@ -63,7 +63,7 @@ export default class AttributeElement extends Element {
 		 * Keeps all the attribute elements that have the same {@link module:engine/view/attributeelement~AttributeElement#id ids}
 		 * and still exist in the view tree.
 		 *
-		 * This property is managed by {@link module:engine/view/writer~Writer}.
+		 * This property is managed by {@link module:engine/view/downcastwriter~DowncastWriter}.
 		 *
 		 * @protected
 		 * @member {Set|null}
@@ -72,7 +72,7 @@ export default class AttributeElement extends Element {
 	}
 
 	/**
-	 * Element priority. Decides in what order elements are wrapped by {@link module:engine/view/writer~Writer}.
+	 * Element priority. Decides in what order elements are wrapped by {@link module:engine/view/downcastwriter~DowncastWriter}.
 	 *
 	 * @readonly
 	 * @returns {Number}
@@ -142,10 +142,10 @@ export default class AttributeElement extends Element {
 	 * elements have to have the same {@link module:engine/view/attributeelement~AttributeElement#id} value to be
 	 * considered similar.
 	 *
-	 * Similarity is important for {@link module:engine/view/writer~Writer}. For example:
+	 * Similarity is important for {@link module:engine/view/downcastwriter~DowncastWriter}. For example:
 	 *
 	 * * two following similar elements can be merged together into one, longer element,
-	 * * {@link module:engine/view/writer~Writer#unwrap} checks similarity of passed element and processed element to
+	 * * {@link module:engine/view/downcastwriter~DowncastWriter#unwrap} checks similarity of passed element and processed element to
 	 * decide whether processed element should be unwrapped,
 	 * * etc.
 	 *

--- a/src/view/containerelement.js
+++ b/src/view/containerelement.js
@@ -23,16 +23,15 @@ import Element from './element';
  * DOM properly. {@link module:engine/view/domconverter~DomConverter} will ensure that `ContainerElement` is editable and it is possible
  * to put caret inside it, even if the container is empty.
  *
- * Secondly, {@link module:engine/view/writer~Writer view writer} uses this information.
- * Nodes {@link module:engine/view/writer~Writer#breakAttributes breaking} and {@link module:engine/view/writer~Writer#mergeAttributes
- * merging}
- * is performed only in a bounds of a container nodes.
+ * Secondly, {@link module:engine/view/downcastwriter~DowncastWriter view downcast writer} uses this information.
+ * Nodes {@link module:engine/view/downcastwriter~DowncastWriter#breakAttributes breaking} and
+ * {@link module:engine/view/downcastwriter~DowncastWriter#mergeAttributes merging} is performed only in a bounds of a container nodes.
  *
  * For instance if `<p>` is an container and `<b>` is attribute:
  *
  *		<p><b>fo^o</b></p>
  *
- * {@link module:engine/view/writer~Writer#breakAttributes breakAttributes} will create:
+ * {@link module:engine/view/downcastwriter~DowncastWriter#breakAttributes breakAttributes} will create:
  *
  *		<p><b>fo</b><b>o</b></p>
  *
@@ -49,7 +48,7 @@ export default class ContainerElement extends Element {
 	 * Creates a container element.
 	 *
 	 * @see module:engine/view/element~Element
-	 * @see module:engine/view/writer~Writer#createContainerElement
+	 * @see module:engine/view/downcastwriter~DowncastWriter#createContainerElement
 	 * @protected
 	 */
 	constructor( name, attrs, children ) {

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -112,8 +112,8 @@ export default class Document {
 	 * to elements based on the view structure or selection. However, is you need DOM elements to be already updated, use
 	 * {@link module:engine/view/view~View#event:render render event}.
 	 *
-	 * As a parameter, a post-fixer callback receives a {@link module:engine/view/writer~Writer writer} instance connected with the
-	 * executed changes block.
+	 * As a parameter, a post-fixer callback receives a {@link module:engine/view/downcastwriter~DowncastWriter downcast writer}
+	 * instance connected with the executed changes block.
 	 *
 	 * @param {Function} postFixer
 	 */
@@ -125,7 +125,7 @@ export default class Document {
 	 * Performs post-fixer loops. Executes post-fixer callbacks as long as none of them has done any changes to the model.
 	 *
 	 * @protected
-	 * @param {module:engine/view/writer~Writer} writer
+	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer
 	 */
 	_callPostFixers( writer ) {
 		let wasFixed = false;

--- a/src/view/downcastwriter.js
+++ b/src/view/downcastwriter.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module module:engine/view/writer
+ * @module module:engine/view/downcastwriter
  */
 
 import Position from './position';
@@ -25,7 +25,7 @@ import { isPlainObject } from 'lodash-es';
  * {@link module:engine/view/document~Document view document}. It is not recommended to use it directly. To get an instance
  * of view writer associated with the document use {@link module:engine/view/view~View#change view.change()) method.
  */
-export default class Writer {
+export default class DowncastWriter {
 	constructor( document ) {
 		/**
 		 * @readonly
@@ -88,7 +88,7 @@ export default class Writer {
 	 * 		// Removes all ranges.
 	 *		writer.setSelection( null );
 	 *
-	 * `Writer#setSelection()` allow passing additional options (`backward`, `fake` and `label`) as the last argument.
+	 * `DowncastWriter#setSelection()` allow passing additional options (`backward`, `fake` and `label`) as the last argument.
 	 *
 	 *		// Sets selection as backward.
 	 *		writer.setSelection( range, { backward: true } );
@@ -369,8 +369,8 @@ export default class Writer {
 	 *
 	 * **Note:** {@link module:engine/view/documentfragment~DocumentFragment DocumentFragment} is treated like a container.
 	 *
-	 * **Note:** Difference between {@link module:engine/view/writer~Writer#breakAttributes breakAttributes} and
-	 * {@link module:engine/view/writer~Writer#breakContainer breakContainer} is that `breakAttributes` breaks all
+	 * **Note:** Difference between {@link module:engine/view/downcastwriter~DowncastWriter#breakAttributes breakAttributes} and
+	 * {@link module:engine/view/downcastwriter~DowncastWriter#breakContainer breakContainer} is that `breakAttributes` breaks all
 	 * {@link module:engine/view/attributeelement~AttributeElement attribute elements} that are ancestors of given `position`,
 	 * up to the first encountered {@link module:engine/view/containerelement~ContainerElement container element}.
 	 * `breakContainer` assumes that given `position` is directly in container element and breaks that container element.
@@ -389,7 +389,7 @@ export default class Writer {
 	 *
 	 * @see module:engine/view/attributeelement~AttributeElement
 	 * @see module:engine/view/containerelement~ContainerElement
-	 * @see module:engine/view/writer~Writer#breakContainer
+	 * @see module:engine/view/downcastwriter~DowncastWriter#breakContainer
 	 * @param {module:engine/view/position~Position|module:engine/view/range~Range} positionOrRange Position where
 	 * to break attribute elements.
 	 * @returns {module:engine/view/position~Position|module:engine/view/range~Range} New position or range, after breaking the attribute
@@ -413,15 +413,15 @@ export default class Writer {
 	 *        <p>^foobar</p> -> ^<p>foobar</p>
 	 *        <p>foobar^</p> -> <p>foobar</p>^
 	 *
-	 * **Note:** Difference between {@link module:engine/view/writer~Writer#breakAttributes breakAttributes} and
-	 * {@link module:engine/view/writer~Writer#breakContainer breakContainer} is that `breakAttributes` breaks all
+	 * **Note:** Difference between {@link module:engine/view/downcastwriter~DowncastWriter#breakAttributes breakAttributes} and
+	 * {@link module:engine/view/downcastwriter~DowncastWriter#breakContainer breakContainer} is that `breakAttributes` breaks all
 	 * {@link module:engine/view/attributeelement~AttributeElement attribute elements} that are ancestors of given `position`,
 	 * up to the first encountered {@link module:engine/view/containerelement~ContainerElement container element}.
 	 * `breakContainer` assumes that given `position` is directly in container element and breaks that container element.
 	 *
 	 * @see module:engine/view/attributeelement~AttributeElement
 	 * @see module:engine/view/containerelement~ContainerElement
-	 * @see module:engine/view/writer~Writer#breakAttributes
+	 * @see module:engine/view/downcastwriter~DowncastWriter#breakAttributes
 	 * @param {module:engine/view/position~Position} position Position where to break element.
 	 * @returns {module:engine/view/position~Position} Position between broken elements. If element has not been broken,
 	 * the returned position is placed either before it or after it.
@@ -480,14 +480,14 @@ export default class Writer {
 	 *        <p><b>[]</b></p> -> <p>[]</p>
 	 *        <p><b>foo</b><i>[]</i><b>bar</b></p> -> <p><b>foo{}bar</b></p>
 	 *
-	 * **Note:** Difference between {@link module:engine/view/writer~Writer#mergeAttributes mergeAttributes} and
-	 * {@link module:engine/view/writer~Writer#mergeContainers mergeContainers} is that `mergeAttributes` merges two
+	 * **Note:** Difference between {@link module:engine/view/downcastwriter~DowncastWriter#mergeAttributes mergeAttributes} and
+	 * {@link module:engine/view/downcastwriter~DowncastWriter#mergeContainers mergeContainers} is that `mergeAttributes` merges two
 	 * {@link module:engine/view/attributeelement~AttributeElement attribute elements} or {@link module:engine/view/text~Text text nodes}
 	 * while `mergeContainer` merges two {@link module:engine/view/containerelement~ContainerElement container elements}.
 	 *
 	 * @see module:engine/view/attributeelement~AttributeElement
 	 * @see module:engine/view/containerelement~ContainerElement
-	 * @see module:engine/view/writer~Writer#mergeContainers
+	 * @see module:engine/view/downcastwriter~DowncastWriter#mergeContainers
 	 * @param {module:engine/view/position~Position} position Merge position.
 	 * @returns {module:engine/view/position~Position} Position after merge.
 	 */
@@ -547,14 +547,14 @@ export default class Writer {
 	 *        <p>foo</p>^<p>bar</p> -> <p>foo^bar</p>
 	 *        <div>foo</div>^<p>bar</p> -> <div>foo^bar</div>
 	 *
-	 * **Note:** Difference between {@link module:engine/view/writer~Writer#mergeAttributes mergeAttributes} and
-	 * {@link module:engine/view/writer~Writer#mergeContainers mergeContainers} is that `mergeAttributes` merges two
+	 * **Note:** Difference between {@link module:engine/view/downcastwriter~DowncastWriter#mergeAttributes mergeAttributes} and
+	 * {@link module:engine/view/downcastwriter~DowncastWriter#mergeContainers mergeContainers} is that `mergeAttributes` merges two
 	 * {@link module:engine/view/attributeelement~AttributeElement attribute elements} or {@link module:engine/view/text~Text text nodes}
 	 * while `mergeContainer` merges two {@link module:engine/view/containerelement~ContainerElement container elements}.
 	 *
 	 * @see module:engine/view/attributeelement~AttributeElement
 	 * @see module:engine/view/containerelement~ContainerElement
-	 * @see module:engine/view/writer~Writer#mergeAttributes
+	 * @see module:engine/view/downcastwriter~DowncastWriter#mergeAttributes
 	 * @param {module:engine/view/position~Position} position Merge position.
 	 * @returns {module:engine/view/position~Position} Position after merge.
 	 */
@@ -1304,7 +1304,7 @@ export default class Writer {
 	}
 
 	/**
-	 * Helper function used by other `Writer` methods. Breaks attribute elements at the boundaries of given range.
+	 * Helper function used by other `DowncastWriter` methods. Breaks attribute elements at the boundaries of given range.
 	 *
 	 * @private
 	 * @param {module:engine/view/range~Range} range Range which `start` and `end` positions will be used to break attributes.
@@ -1336,7 +1336,7 @@ export default class Writer {
 	}
 
 	/**
-	 * Helper function used by other `Writer` methods. Breaks attribute elements at given position.
+	 * Helper function used by other `DowncastWriter` methods. Breaks attribute elements at given position.
 	 *
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `view-writer-cannot-break-empty-element` when break position
 	 * is placed inside {@link module:engine/view/emptyelement~EmptyElement EmptyElement}.

--- a/src/view/downcastwriter.js
+++ b/src/view/downcastwriter.js
@@ -21,9 +21,11 @@ import EditableElement from './editableelement';
 import { isPlainObject } from 'lodash-es';
 
 /**
- * View writer class. Provides set of methods used to properly manipulate nodes attached to
+ * View downcast writer class. Provides set of methods used to properly manipulate nodes attached to
  * {@link module:engine/view/document~Document view document}. It is not recommended to use it directly. To get an instance
  * of view writer associated with the document use {@link module:engine/view/view~View#change view.change()) method.
+ * The `DowncastWriter` is designed to work with semantic view which is the view downcasted from model. For working with
+ * ordinary view (e.g. parsed from string) {@link module:engine/view/upcastwriter~UpcastWriter upcast writer} should be used.
  */
 export default class DowncastWriter {
 	constructor( document ) {

--- a/src/view/editableelement.js
+++ b/src/view/editableelement.js
@@ -27,7 +27,7 @@ export default class EditableElement extends ContainerElement {
 	/**
 	 * Creates an editable element.
 	 *
-	 * @see module:engine/view/writer~Writer#createEditableElement
+	 * @see module:engine/view/downcastwriter~DowncastWriter#createEditableElement
 	 * @protected
 	 */
 	constructor( name, attrs, children ) {

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -22,15 +22,15 @@ import { isPlainObject } from 'lodash-es';
  * This is why the type of the {@link module:engine/view/element~Element} need to
  * be defined by the feature developer. When creating an element you should use one of the following methods:
  *
- * * {@link module:engine/view/writer~Writer#createContainerElement `writer.createContainerElement()`} in order to create
+ * * {@link module:engine/view/downcastwriter~DowncastWriter#createContainerElement `writer.createContainerElement()`} in order to create
  * a {@link module:engine/view/containerelement~ContainerElement},
- * * {@link module:engine/view/writer~Writer#createAttributeElement `writer.createAttributeElement()`} in order to create
+ * * {@link module:engine/view/downcastwriter~DowncastWriter#createAttributeElement `writer.createAttributeElement()`} in order to create
  * a {@link module:engine/view/attributeelement~AttributeElement},
- * * {@link module:engine/view/writer~Writer#createEmptyElement `writer.createEmptyElement()`} in order to create
+ * * {@link module:engine/view/downcastwriter~DowncastWriter#createEmptyElement `writer.createEmptyElement()`} in order to create
  * a {@link module:engine/view/emptyelement~EmptyElement}.
- * * {@link module:engine/view/writer~Writer#createUIElement `writer.createUIElement()`} in order to create
+ * * {@link module:engine/view/downcastwriter~DowncastWriter#createUIElement `writer.createUIElement()`} in order to create
  * a {@link module:engine/view/uielement~UIElement}.
- * * {@link module:engine/view/writer~Writer#createEditableElement `writer.createEditableElement()`} in order to create
+ * * {@link module:engine/view/downcastwriter~DowncastWriter#createEditableElement `writer.createEditableElement()`} in order to create
  * a {@link module:engine/view/editableelement~EditableElement}.
  *
  * Note that for view elements which are not created from the model, like elements from mutations, paste or
@@ -50,11 +50,11 @@ export default class Element extends Node {
 	 *		new Element( 'div', mapOfAttributes ); // map
 	 *
 	 * **Note:** Constructor of this class shouldn't be used directly in the code. Use the
-	 * {@link module:engine/view/writer~Writer#createAttributeElement} for inline element,
-	 * {@link module:engine/view/writer~Writer#createContainerElement} for block element,
-	 * {@link module:engine/view/writer~Writer#createEditableElement} for editable element,
-	 * {@link module:engine/view/writer~Writer#createEmptyElement} for empty element or
-	 * {@link module:engine/view/writer~Writer#createUIElement} for UI element instead.
+	 * {@link module:engine/view/downcastwriter~DowncastWriter#createAttributeElement} for inline element,
+	 * {@link module:engine/view/downcastwriter~DowncastWriter#createContainerElement} for block element,
+	 * {@link module:engine/view/downcastwriter~DowncastWriter#createEditableElement} for editable element,
+	 * {@link module:engine/view/downcastwriter~DowncastWriter#createEmptyElement} for empty element or
+	 * {@link module:engine/view/downcastwriter~DowncastWriter#createUIElement} for UI element instead.
 	 *
 	 * @protected
 	 * @param {String} name Node name.
@@ -527,7 +527,7 @@ export default class Element extends Node {
 	 * {@link module:engine/view/element~Element#_insertChild Insert} a child node or a list of child nodes at the end of this node
 	 * and sets the parent of these nodes to this element.
 	 *
-	 * @see module:engine/view/writer~Writer#insert
+	 * @see module:engine/view/downcastwriter~DowncastWriter#insert
 	 * @protected
 	 * @param {module:engine/view/item~Item|Iterable.<module:engine/view/item~Item>} items Items to be inserted.
 	 * @fires module:engine/view/node~Node#change
@@ -541,7 +541,7 @@ export default class Element extends Node {
 	 * Inserts a child node or a list of child nodes on the given index and sets the parent of these nodes to
 	 * this element.
 	 *
-	 * @see module:engine/view/writer~Writer#insert
+	 * @see module:engine/view/downcastwriter~DowncastWriter#insert
 	 * @protected
 	 * @param {Number} index Position where nodes should be inserted.
 	 * @param {module:engine/view/item~Item|Iterable.<module:engine/view/item~Item>} items Items to be inserted.
@@ -573,7 +573,7 @@ export default class Element extends Node {
 	/**
 	 * Removes number of child nodes starting at the given index and set the parent of these nodes to `null`.
 	 *
-	 * @see module:engine/view/writer~Writer#remove
+	 * @see module:engine/view/downcastwriter~DowncastWriter#remove
 	 * @param {Number} index Number of the first node to remove.
 	 * @param {Number} [howMany=1] Number of nodes to remove.
 	 * @fires module:engine/view/node~Node#change
@@ -592,7 +592,7 @@ export default class Element extends Node {
 	/**
 	 * Adds or overwrite attribute with a specified key and value.
 	 *
-	 * @see module:engine/view/writer~Writer#setAttribute
+	 * @see module:engine/view/downcastwriter~DowncastWriter#setAttribute
 	 * @protected
 	 * @param {String} key Attribute key.
 	 * @param {String} value Attribute value.
@@ -615,7 +615,7 @@ export default class Element extends Node {
 	/**
 	 * Removes attribute from the element.
 	 *
-	 * @see module:engine/view/writer~Writer#removeAttribute
+	 * @see module:engine/view/downcastwriter~DowncastWriter#removeAttribute
 	 * @protected
 	 * @param {String} key Attribute key.
 	 * @returns {Boolean} Returns true if an attribute existed and has been removed.
@@ -656,7 +656,7 @@ export default class Element extends Node {
 	 *		element._addClass( 'foo' ); // Adds 'foo' class.
 	 *		element._addClass( [ 'foo', 'bar' ] ); // Adds 'foo' and 'bar' classes.
 	 *
-	 * @see module:engine/view/writer~Writer#addClass
+	 * @see module:engine/view/downcastwriter~DowncastWriter#addClass
 	 * @protected
 	 * @param {Array.<String>|String} className
 	 * @fires module:engine/view/node~Node#change
@@ -674,7 +674,7 @@ export default class Element extends Node {
 	 *		element._removeClass( 'foo' );  // Removes 'foo' class.
 	 *		element._removeClass( [ 'foo', 'bar' ] ); // Removes both 'foo' and 'bar' classes.
 	 *
-	 * @see module:engine/view/writer~Writer#removeClass
+	 * @see module:engine/view/downcastwriter~DowncastWriter#removeClass
 	 * @param {Array.<String>|String} className
 	 * @fires module:engine/view/node~Node#change
 	 */
@@ -694,7 +694,7 @@ export default class Element extends Node {
 	 *			position: 'fixed'
 	 *		} );
 	 *
-	 * @see module:engine/view/writer~Writer#setStyle
+	 * @see module:engine/view/downcastwriter~DowncastWriter#setStyle
 	 * @protected
 	 * @param {String|Object} property Property name or object with key - value pairs.
 	 * @param {String} [value] Value to set. This parameter is ignored if object is provided as the first parameter.
@@ -720,7 +720,7 @@ export default class Element extends Node {
 	 *		element._removeStyle( 'color' );  // Removes 'color' style.
 	 *		element._removeStyle( [ 'color', 'border-top' ] ); // Removes both 'color' and 'border-top' styles.
 	 *
-	 * @see module:engine/view/writer~Writer#removeStyle
+	 * @see module:engine/view/downcastwriter~DowncastWriter#removeStyle
 	 * @protected
 	 * @param {Array.<String>|String} property
 	 * @fires module:engine/view/node~Node#change
@@ -736,7 +736,7 @@ export default class Element extends Node {
 	 * Sets a custom property. Unlike attributes, custom properties are not rendered to the DOM,
 	 * so they can be used to add special data to elements.
 	 *
-	 * @see module:engine/view/writer~Writer#setCustomProperty
+	 * @see module:engine/view/downcastwriter~DowncastWriter#setCustomProperty
 	 * @protected
 	 * @param {String|Symbol} key
 	 * @param {*} value
@@ -748,7 +748,7 @@ export default class Element extends Node {
 	/**
 	 * Removes the custom property stored under the given key.
 	 *
-	 * @see module:engine/view/writer~Writer#removeCustomProperty
+	 * @see module:engine/view/downcastwriter~DowncastWriter#removeCustomProperty
 	 * @protected
 	 * @param {String|Symbol} key
 	 * @returns {Boolean} Returns true if property was removed.

--- a/src/view/emptyelement.js
+++ b/src/view/emptyelement.js
@@ -21,7 +21,7 @@ export default class EmptyElement extends Element {
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `view-emptyelement-cannot-add` when third parameter is passed,
 	 * to inform that usage of EmptyElement is incorrect (adding child nodes to EmptyElement is forbidden).
 	 *
-	 * @see module:engine/view/writer~Writer#createEmptyElement
+	 * @see module:engine/view/downcastwriter~DowncastWriter#createEmptyElement
 	 * @protected
 	 * @param {String} name Node name.
 	 * @param {Object|Iterable} [attributes] Collection of attributes.

--- a/src/view/placeholder.js
+++ b/src/view/placeholder.js
@@ -66,7 +66,7 @@ export function detachPlaceholder( view, element ) {
 //
 // @private
 // @param {module:engine/view/document~Document} view
-// @param {module:engine/view/writer~Writer} writer
+// @param {module:engine/view/downcastwriter~DowncastWriter} writer
 function updateAllPlaceholders( document, writer ) {
 	const placeholders = documentPlaceholders.get( document );
 	let changed = false;
@@ -83,7 +83,7 @@ function updateAllPlaceholders( document, writer ) {
 // Updates placeholder class of given element.
 //
 // @private
-// @param {module:engine/view/writer~Writer} writer
+// @param {module:engine/view/downcastwriter~DowncastWriter} writer
 // @param {module:engine/view/element~Element} element
 // @param {Object} info
 function updateSinglePlaceholder( writer, element, info ) {

--- a/src/view/text.js
+++ b/src/view/text.js
@@ -19,7 +19,7 @@ export default class Text extends Node {
 	 * Creates a tree view text node.
 	 *
 	 * **Note:** Constructor of this class shouldn't be used directly in the code.
-	 * Use the {@link module:engine/view/writer~Writer#createText} method instead.
+	 * Use the {@link module:engine/view/downcastwriter~DowncastWriter#createText} method instead.
 	 *
 	 * @protected
 	 * @param {String} data Text.

--- a/src/view/uielement.js
+++ b/src/view/uielement.js
@@ -23,7 +23,7 @@ export default class UIElement extends Element {
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `view-uielement-cannot-add` when third parameter is passed,
 	 * to inform that usage of UIElement is incorrect (adding child nodes to UIElement is forbidden).
 	 *
-	 * @see module:engine/view/writer~Writer#createUIElement
+	 * @see module:engine/view/downcastwriter~DowncastWriter#createUIElement
 	 * @protected
 	 * @param {String} name Node name.
 	 * @param {Object|Iterable} [attributes] Collection of attributes.

--- a/src/view/upcastwriter.js
+++ b/src/view/upcastwriter.js
@@ -14,7 +14,7 @@ import { isPlainObject } from 'lodash-es';
  * View upcast writer class. Provides set of methods used to properly manipulate nodes attached to
  * {@link module:engine/view/view~View view instance}. It should be only used to manipulate non-semantic view
  * (view created from HTML string). For view which was downcasted from the {@link module:engine/model/model~Model model}
- * see {@link module:engine/view/writer~Writer writer}.
+ * see {@link module:engine/view/downcastwriter~DowncastWriter writer}.
  */
 export default class UpcastWriter {
 	/**

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -8,7 +8,7 @@
  */
 
 import Document from './document';
-import Writer from './writer';
+import DowncastWriter from './downcastwriter';
 import Renderer from './renderer';
 import DomConverter from './domconverter';
 
@@ -33,7 +33,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  *
  * View controller renders view document to DOM whenever view structure changes. To determine when view can be rendered,
  * all changes need to be done using the {@link module:engine/view/view~View#change} method, using
- * {@link module:engine/view/writer~Writer}:
+ * {@link module:engine/view/downcastwriter~DowncastWriter}:
  *
  *		view.change( writer => {
  *			writer.insert( position, writer.createText( 'foo' ) );
@@ -127,12 +127,12 @@ export default class View {
 		this._postFixersInProgress = false;
 
 		/**
-		 * Writer instance used in {@link #change change method) callbacks.
+		 * DowncastWriter instance used in {@link #change change method) callbacks.
 		 *
 		 * @private
-		 * @member {module:engine/view/writer~Writer} module:engine/view/view~View#_writer
+		 * @member {module:engine/view/downcastwriter~DowncastWriter} module:engine/view/view~View#_writer
 		 */
-		this._writer = new Writer( this.document );
+		this._writer = new DowncastWriter( this.document );
 
 		// Add default observers.
 		this.addObserver( MutationObserver );

--- a/tests/view/attributeelement.js
+++ b/tests/view/attributeelement.js
@@ -109,7 +109,7 @@ describe( 'AttributeElement', () => {
 		} );
 	} );
 
-	// More tests are available in Writer tests.
+	// More tests are available in DowncastWriter tests.
 	describe( 'getElementsWithSameId', () => {
 		it( 'should return a copy of _clonesGroup set', () => {
 			const attributeA = new AttributeElement( 'b' );

--- a/tests/view/downcastwriter/breakattributes.js
+++ b/tests/view/downcastwriter/breakattributes.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import Document from '../../../src/view/document';
 import { stringify, parse } from '../../../src/dev-utils/view';
 import ContainerElement from '../../../src/view/containerelement';
@@ -14,12 +14,12 @@ import Range from '../../../src/view/range';
 import Position from '../../../src/view/position';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'breakAttributes()', () => {
 		let writer;
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		describe( 'break position', () => {

--- a/tests/view/downcastwriter/breakcontainer.js
+++ b/tests/view/downcastwriter/breakcontainer.js
@@ -3,14 +3,14 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import { stringify, parse } from '../../../src/dev-utils/view';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import ContainerElement from '../../../src/view/containerelement';
 import Position from '../../../src/view/position';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'breakContainer()', () => {
 		let writer;
 
@@ -27,7 +27,7 @@ describe( 'Writer', () => {
 		}
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		it( 'break inside element - should break container element at given position', () => {

--- a/tests/view/downcastwriter/clear.js
+++ b/tests/view/downcastwriter/clear.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import Range from '../../../src/view/range';
 import { stringify, parse } from '../../../src/dev-utils/view';
 import ContainerElement from '../../../src/view/containerelement';
@@ -13,7 +13,7 @@ import UIElement from '../../../src/view/uielement';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'clear()', () => {
 		let writer;
 
@@ -31,7 +31,7 @@ describe( 'Writer', () => {
 		}
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		it( 'should throw when range placed in two containers', () => {

--- a/tests/view/downcastwriter/insert.js
+++ b/tests/view/downcastwriter/insert.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import ContainerElement from '../../../src/view/containerelement';
 import Element from '../../../src/view/element';
 import EmptyElement from '../../../src/view/emptyelement';
@@ -14,7 +14,7 @@ import { stringify, parse } from '../../../src/dev-utils/view';
 import AttributeElement from '../../../src/view/attributeelement';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'insert()', () => {
 		let writer;
 
@@ -32,7 +32,7 @@ describe( 'Writer', () => {
 		}
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		it( 'should return collapsed range in insertion position when using empty array', () => {

--- a/tests/view/downcastwriter/mergeattributes.js
+++ b/tests/view/downcastwriter/mergeattributes.js
@@ -3,14 +3,14 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import ContainerElement from '../../../src/view/containerelement';
 import Text from '../../../src/view/text';
 import Position from '../../../src/view/position';
 import { stringify, parse } from '../../../src/dev-utils/view';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'mergeAttributes', () => {
 		let writer;
 
@@ -26,7 +26,7 @@ describe( 'Writer', () => {
 		}
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		it( 'should not merge if inside text node', () => {

--- a/tests/view/downcastwriter/mergecontainers.js
+++ b/tests/view/downcastwriter/mergecontainers.js
@@ -3,12 +3,12 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import { stringify, parse } from '../../../src/dev-utils/view';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'mergeContainers()', () => {
 		let writer;
 
@@ -25,7 +25,7 @@ describe( 'Writer', () => {
 		}
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		it( 'should merge two container elements - position between elements', () => {

--- a/tests/view/downcastwriter/move.js
+++ b/tests/view/downcastwriter/move.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import { stringify, parse } from '../../../src/dev-utils/view';
 import ContainerElement from '../../../src/view/containerelement';
 import AttributeElement from '../../../src/view/attributeelement';
@@ -14,7 +14,7 @@ import Position from '../../../src/view/position';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'move()', () => {
 		let writer;
 
@@ -35,7 +35,7 @@ describe( 'Writer', () => {
 		}
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		it( 'should move single text node', () => {

--- a/tests/view/downcastwriter/remove.js
+++ b/tests/view/downcastwriter/remove.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import ContainerElement from '../../../src/view/containerelement';
 import Range from '../../../src/view/range';
 import DocumentFragment from '../../../src/view/documentfragment';
@@ -14,7 +14,7 @@ import UIElement from '../../../src/view/uielement';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'remove()', () => {
 		let writer;
 
@@ -34,7 +34,7 @@ describe( 'Writer', () => {
 		}
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		it( 'should throw when range placed in two containers', () => {

--- a/tests/view/downcastwriter/rename.js
+++ b/tests/view/downcastwriter/rename.js
@@ -3,16 +3,16 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import { parse } from '../../../src/dev-utils/view';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'rename()', () => {
 		let root, foo, writer;
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		beforeEach( () => {

--- a/tests/view/downcastwriter/unwrap.js
+++ b/tests/view/downcastwriter/unwrap.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import Element from '../../../src/view/element';
 import ContainerElement from '../../../src/view/containerelement';
 import AttributeElement from '../../../src/view/attributeelement';
@@ -16,7 +16,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import { stringify, parse } from '../../../src/dev-utils/view';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'unwrap()', () => {
 		let writer;
 
@@ -33,7 +33,7 @@ describe( 'Writer', () => {
 		}
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		it( 'should do nothing on collapsed ranges', () => {

--- a/tests/view/downcastwriter/wrap.js
+++ b/tests/view/downcastwriter/wrap.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import View from '../../../src/view/view';
 import DocumentFragment from '../../../src/view/documentfragment';
 import Element from '../../../src/view/element';
@@ -19,12 +19,12 @@ import { stringify, parse } from '../../../src/dev-utils/view';
 import createViewRoot from '../_utils/createroot';
 import Document from '../../../src/view/document';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	describe( 'wrap()', () => {
 		let writer;
 
 		before( () => {
-			writer = new Writer( new Document() );
+			writer = new DowncastWriter( new Document() );
 		} );
 
 		describe( 'non-collapsed range', () => {

--- a/tests/view/downcastwriter/writer.js
+++ b/tests/view/downcastwriter/writer.js
@@ -3,21 +3,21 @@
  * For licensing, see LICENSE.md.
  */
 
-import Writer from '../../../src/view/writer';
+import DowncastWriter from '../../../src/view/downcastwriter';
 import Document from '../../../src/view/document';
 import EditableElement from '../../../src/view/editableelement';
 import ViewPosition from '../../../src/view/position';
 import ViewRange from '../../../src/view/range';
 import createViewRoot from '../_utils/createroot';
 
-describe( 'Writer', () => {
+describe( 'DowncastWriter', () => {
 	let writer, attributes, root, doc;
 
 	beforeEach( () => {
 		attributes = { foo: 'bar', baz: 'quz' };
 		doc = new Document();
 		root = createViewRoot( doc );
-		writer = new Writer( doc );
+		writer = new DowncastWriter( doc );
 	} );
 
 	describe( 'setSelection()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Renamed view `Writer` to `DowncastWriter`. Closes #1515.

BREAKING CHANGE: The `engine/view/writer` module was renamed to `engine/view/downcastwriter`. See #1515.

---

### Additional information

Some small adjustments were needed in few other packages, see:

* https://github.com/ckeditor/ckeditor5-clipboard/pull/53
* https://github.com/ckeditor/ckeditor5-image/pull/231
* https://github.com/ckeditor/ckeditor5-link/pull/200
* https://github.com/ckeditor/ckeditor5-list/pull/109
* https://github.com/ckeditor/ckeditor5-table/pull/102
* https://github.com/ckeditor/ckeditor5-widget/pull/51
