### PR TITLE
baseVersion was moved to be the last argument in MarkerOperation constructor

### DIFF
--- a/src/model/operation/markeroperation.js
+++ b/src/model/operation/markeroperation.js
@@ -19,12 +19,12 @@ export default class MarkerOperation extends Operation {
 	 * @param {module:engine/model/range~Range} oldRange Marker range before the change.
 	 * @param {module:engine/model/range~Range} newRange Marker range after the change.
 	 * @param {module:engine/model/markercollection~MarkerCollection} markers Marker collection on which change should be executed.
-	 * @param {Number|null} baseVersion Document {@link module:engine/model/document~Document#version} on which operation
 	 * @param {Boolean} affectsData Specifies whether the marker operation affects the data produced by the data pipeline
 	 * (is persisted in the editor's data).
+	 * @param {Number|null} baseVersion Document {@link module:engine/model/document~Document#version} on which operation
 	 * can be applied or `null` if the operation operates on detached (non-document) tree.
 	 */
-	constructor( name, oldRange, newRange, markers, baseVersion, affectsData ) {
+	constructor( name, oldRange, newRange, markers, affectsData, baseVersion ) {
 		super( baseVersion );
 
 		/**
@@ -82,7 +82,7 @@ export default class MarkerOperation extends Operation {
 	 * @returns {module:engine/model/operation/markeroperation~MarkerOperation} Clone of this operation.
 	 */
 	clone() {
-		return new MarkerOperation( this.name, this.oldRange, this.newRange, this._markers, this.baseVersion, this.affectsData );
+		return new MarkerOperation( this.name, this.oldRange, this.newRange, this._markers, this.affectsData, this.baseVersion );
 	}
 
 	/**
@@ -91,7 +91,7 @@ export default class MarkerOperation extends Operation {
 	 * @returns {module:engine/model/operation/markeroperation~MarkerOperation}
 	 */
 	getReversed() {
-		return new MarkerOperation( this.name, this.newRange, this.oldRange, this._markers, this.baseVersion + 1, this.affectsData );
+		return new MarkerOperation( this.name, this.newRange, this.oldRange, this._markers, this.affectsData, this.baseVersion + 1 );
 	}
 
 	/**
@@ -142,8 +142,8 @@ export default class MarkerOperation extends Operation {
 			json.oldRange ? Range.fromJSON( json.oldRange, document ) : null,
 			json.newRange ? Range.fromJSON( json.newRange, document ) : null,
 			document.model.markers,
-			json.baseVersion,
-			json.affectsData
+			json.affectsData,
+			json.baseVersion
 		);
 	}
 }

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -1327,7 +1327,7 @@ function applyMarkerOperation( writer, name, oldRange, newRange, affectsData ) {
 	const model = writer.model;
 	const doc = model.document;
 
-	const operation = new MarkerOperation( name, oldRange, newRange, model.markers, doc.version, affectsData );
+	const operation = new MarkerOperation( name, oldRange, newRange, model.markers, affectsData, doc.version );
 
 	writer.batch.addOperation( operation );
 	model.applyOperation( operation );

--- a/tests/dev-utils/enableenginedebug.js
+++ b/tests/dev-utils/enableenginedebug.js
@@ -294,7 +294,7 @@ describe( 'debug tools', () => {
 			} );
 
 			it( 'MarkerOperation', () => {
-				const op = new MarkerOperation( 'marker', null, ModelRange.createIn( modelRoot ), modelDoc.markers, 0 );
+				const op = new MarkerOperation( 'marker', null, ModelRange.createIn( modelRoot ), modelDoc.markers, false, 0 );
 
 				expect( op.toString() ).to.equal( 'MarkerOperation( 0 ): "marker": null -> main [ 0 ] - [ 6 ]' );
 

--- a/tests/model/operation/markeroperation.js
+++ b/tests/model/operation/markeroperation.js
@@ -24,7 +24,7 @@ describe( 'MarkerOperation', () => {
 	} );
 
 	it( 'should have property type equal to "marker"', () => {
-		const op = new MarkerOperation( 'name', null, range, model.markers, 0, true );
+		const op = new MarkerOperation( 'name', null, range, model.markers, true, 0 );
 		expect( op.type ).to.equal( 'marker' );
 	} );
 
@@ -32,7 +32,7 @@ describe( 'MarkerOperation', () => {
 		sinon.spy( model.markers, '_set' );
 
 		model.applyOperation(
-			new MarkerOperation( 'name', null, range, model.markers, doc.version, true )
+			new MarkerOperation( 'name', null, range, model.markers, true, doc.version )
 		);
 
 		expect( doc.version ).to.equal( 1 );
@@ -42,7 +42,7 @@ describe( 'MarkerOperation', () => {
 
 	it( 'should update marker in document marker collection', () => {
 		model.applyOperation(
-			new MarkerOperation( 'name', null, range, model.markers, doc.version, true )
+			new MarkerOperation( 'name', null, range, model.markers, true, doc.version )
 		);
 
 		const range2 = Range.createFromParentsAndOffsets( root, 0, root, 3 );
@@ -50,7 +50,7 @@ describe( 'MarkerOperation', () => {
 		sinon.spy( model.markers, '_set' );
 
 		model.applyOperation(
-			new MarkerOperation( 'name', range, range2, model.markers, doc.version, true )
+			new MarkerOperation( 'name', range, range2, model.markers, true, doc.version )
 		);
 
 		expect( doc.version ).to.equal( 2 );
@@ -60,13 +60,13 @@ describe( 'MarkerOperation', () => {
 
 	it( 'should remove marker from document marker collection', () => {
 		model.applyOperation(
-			new MarkerOperation( 'name', null, range, model.markers, doc.version, true )
+			new MarkerOperation( 'name', null, range, model.markers, true, doc.version )
 		);
 
 		sinon.spy( model.markers, '_remove' );
 
 		model.applyOperation(
-			new MarkerOperation( 'name', range, null, model.markers, doc.version, true )
+			new MarkerOperation( 'name', range, null, model.markers, true, doc.version )
 		);
 
 		expect( doc.version ).to.equal( 2 );
@@ -78,7 +78,7 @@ describe( 'MarkerOperation', () => {
 		sinon.spy( model.markers, 'fire' );
 
 		model.applyOperation(
-			new MarkerOperation( 'name', null, null, model.markers, doc.version, true )
+			new MarkerOperation( 'name', null, null, model.markers, true, doc.version )
 		);
 
 		expect( model.markers.fire.notCalled ).to.be.true;
@@ -92,7 +92,7 @@ describe( 'MarkerOperation', () => {
 		sinon.spy( model.markers, 'fire' );
 
 		model.applyOperation(
-			new MarkerOperation( 'name', range, range, model.markers, doc.version, false )
+			new MarkerOperation( 'name', range, range, model.markers, false, doc.version )
 		);
 
 		expect( model.markers.fire.notCalled ).to.be.true;
@@ -101,10 +101,10 @@ describe( 'MarkerOperation', () => {
 	it( 'should return MarkerOperation with swapped ranges as reverse operation', () => {
 		const range2 = Range.createFromParentsAndOffsets( root, 0, root, 3 );
 
-		const op1 = new MarkerOperation( 'name', null, range, model.markers, doc.version, true );
+		const op1 = new MarkerOperation( 'name', null, range, model.markers, true, doc.version );
 		const reversed1 = op1.getReversed();
 
-		const op2 = new MarkerOperation( 'name', range, range2, model.markers, doc.version, true );
+		const op2 = new MarkerOperation( 'name', range, range2, model.markers, true, doc.version );
 		const reversed2 = op2.getReversed();
 
 		expect( reversed1 ).to.be.an.instanceof( MarkerOperation );
@@ -124,7 +124,7 @@ describe( 'MarkerOperation', () => {
 	} );
 
 	it( 'should create a MarkerOperation with the same parameters when cloned', () => {
-		const op = new MarkerOperation( 'name', null, range, model.markers, 0, true );
+		const op = new MarkerOperation( 'name', null, range, model.markers, true, 0 );
 		const clone = op.clone();
 
 		expect( clone ).to.be.an.instanceof( MarkerOperation );
@@ -133,7 +133,7 @@ describe( 'MarkerOperation', () => {
 
 	describe( 'toJSON', () => {
 		it( 'should create proper serialized object', () => {
-			const op = new MarkerOperation( 'name', null, range, model.markers, doc.version, true );
+			const op = new MarkerOperation( 'name', null, range, model.markers, true, doc.version );
 			const serialized = op.toJSON();
 
 			expect( serialized ).to.deep.equal( {
@@ -149,7 +149,7 @@ describe( 'MarkerOperation', () => {
 
 	describe( 'fromJSON', () => {
 		it( 'should create proper MarkerOperation from json object #1', () => {
-			const op = new MarkerOperation( 'name', null, range, model.markers, doc.version, true );
+			const op = new MarkerOperation( 'name', null, range, model.markers, true, doc.version );
 
 			const serialized = op.toJSON();
 			const deserialized = MarkerOperation.fromJSON( serialized, doc );
@@ -159,7 +159,7 @@ describe( 'MarkerOperation', () => {
 
 		it( 'should create proper MarkerOperation from json object #2', () => {
 			// Gotta love 100% CC.
-			const op = new MarkerOperation( 'name', range, null, model.markers, doc.version, true );
+			const op = new MarkerOperation( 'name', range, null, model.markers, true, doc.version );
 
 			const serialized = op.toJSON();
 			const deserialized = MarkerOperation.fromJSON( serialized, doc );

--- a/tests/model/operation/transform.js
+++ b/tests/model/operation/transform.js
@@ -465,7 +465,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no position update', () => {
 				const newRange = new Range( new Position( root, [ 0, 2, 0 ] ), new Position( root, [ 0, 2, 4 ] ) );
-				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, 0 );
+				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, false, 0 );
 
 				const transOp = transform( op, transformBy );
 
@@ -896,7 +896,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no position update', () => {
 				const newRange = new Range( new Position( root, [ 0, 2, 0 ] ), new Position( root, [ 0, 2, 8 ] ) );
-				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, 0 );
+				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, false, 0 );
 
 				const transOp = transform( op, transformBy );
 
@@ -1994,7 +1994,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no position update', () => {
 				const newRange = new Range( new Position( root, [ 2, 2, 3 ] ), new Position( root, [ 2, 2, 8 ] ) );
-				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, 0 );
+				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, false, 0 );
 
 				const transOp = transform( op, transformBy );
 
@@ -2131,7 +2131,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no position update', () => {
 				const newRange = new Range( new Position( root, [ 0, 2, 0 ] ), new Position( root, [ 0, 2, 8 ] ) );
-				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, 0 );
+				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, false, 0 );
 
 				const transOp = transform( op, transformBy );
 
@@ -2254,7 +2254,7 @@ describe( 'transform', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'no operation update', () => {
 				const newRange = new Range( new Position( root, [ 0, 2, 0 ] ), new Position( root, [ 0, 2, 8 ] ) );
-				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, 0 );
+				const transformBy = new MarkerOperation( 'name', null, newRange, model.markers, false, 0 );
 
 				const transOp = transform( op, transformBy );
 
@@ -2422,7 +2422,7 @@ describe( 'transform', () => {
 		beforeEach( () => {
 			oldRange = Range.createFromParentsAndOffsets( root, 1, root, 4 );
 			newRange = Range.createFromParentsAndOffsets( root, 10, root, 12 );
-			op = new MarkerOperation( 'name', oldRange, newRange, model.markers, 0 );
+			op = new MarkerOperation( 'name', oldRange, newRange, model.markers, false, 0 );
 
 			expected = {
 				name: 'name',
@@ -2571,7 +2571,7 @@ describe( 'transform', () => {
 
 		describe( 'by MarkerOperation', () => {
 			it( 'different marker name: no operation update', () => {
-				const transformBy = new MarkerOperation( 'otherName', oldRange, newRange, model.markers, 0 );
+				const transformBy = new MarkerOperation( 'otherName', oldRange, newRange, model.markers, false, 0 );
 
 				const transOp = transform( op, transformBy );
 
@@ -2581,7 +2581,7 @@ describe( 'transform', () => {
 
 			it( 'same marker name and is important: convert to NoOperation', () => {
 				const anotherRange = Range.createFromParentsAndOffsets( root, 2, root, 2 );
-				const transformBy = new MarkerOperation( 'name', oldRange, anotherRange, model.markers, 0 );
+				const transformBy = new MarkerOperation( 'name', oldRange, anotherRange, model.markers, false, 0 );
 
 				const transOp = transform( op, transformBy );
 
@@ -2593,7 +2593,7 @@ describe( 'transform', () => {
 
 			it( 'same marker name and is less important: update oldRange parameter', () => {
 				const anotherRange = Range.createFromParentsAndOffsets( root, 2, root, 2 );
-				const transformBy = new MarkerOperation( 'name', oldRange, anotherRange, model.markers, 0 );
+				const transformBy = new MarkerOperation( 'name', oldRange, anotherRange, model.markers, false, 0 );
 
 				const transOp = transform( op, transformBy, strongContext );
 

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -672,7 +672,7 @@ describe( 'Position', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'nothing should change', () => {
 				const op = new MarkerOperation(
-					'marker', null, Range.createFromParentsAndOffsets( root, 1, root, 6 ), model.markers, 1, true
+					'marker', null, Range.createFromParentsAndOffsets( root, 1, root, 6 ), model.markers, true, 1
 				);
 				const transformed = pos.getTransformedByOperation( op );
 

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -850,7 +850,7 @@ describe( 'Range', () => {
 		describe( 'by MarkerOperation', () => {
 			it( 'nothing should change', () => {
 				const op = new MarkerOperation(
-					'marker', null, Range.createFromParentsAndOffsets( root, 1, root, 6 ), model.markers, 1, true
+					'marker', null, Range.createFromParentsAndOffsets( root, 1, root, 6 ), model.markers, true, 1
 				);
 
 				const transformed = range.getTransformedByOperation( op );

--- a/tests/tickets/1323.js
+++ b/tests/tickets/1323.js
@@ -34,10 +34,10 @@ describe( 'Bug ckeditor5-engine@1323', () => {
 
 			model.change( () => {
 				// Add marker.
-				model.applyOperation( new MarkerOperation( 'name', null, range, model.markers, 0 ) );
+				model.applyOperation( new MarkerOperation( 'name', null, range, model.markers, false, 0 ) );
 
 				// Remove marker.
-				model.applyOperation( new MarkerOperation( 'name', range, null, model.markers, 1 ) );
+				model.applyOperation( new MarkerOperation( 'name', range, null, model.markers, false, 1 ) );
 
 				sinon.assert.notCalled( spy );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Changed: `baseVersion` was moved to be the last argument in `MarkerOperation` constructor. Closes #1510.

---

### Additional information

Bases on https://github.com/ckeditor/ckeditor5-engine/pull/1525
