### PR TITLE
MarkerOperation x MarkerOperation transformation when one operation removes marker

### DIFF
--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -1126,7 +1126,7 @@ setTransformation( MarkerOperation, InsertOperation, ( a, b ) => {
 setTransformation( MarkerOperation, MarkerOperation, ( a, b, context ) => {
 	if ( a.name == b.name ) {
 		if ( context.aIsStrong ) {
-			a.oldRange = Range.createFromRange( b.newRange );
+			a.oldRange = b.newRange ? Range.createFromRange( b.newRange ) : null;
 		} else {
 			return [ new NoOperation( 0 ) ];
 		}

--- a/tests/model/operation/transform/marker.js
+++ b/tests/model/operation/transform/marker.js
@@ -82,6 +82,26 @@ describe( 'transform', () => {
 				);
 			} );
 
+			it( 'change marker vs remove marker', () => {
+				john.setData( '<paragraph>F[o]o</paragraph>' );
+				kate.setData( '<paragraph>[]Foo</paragraph>' );
+
+				john.setMarker( 'm1' );
+
+				syncClients();
+
+				john.setSelection( [ 0, 0 ], [ 0, 1 ] );
+				john.setMarker( 'm1' );
+				kate.removeMarker( 'm1' );
+
+				syncClients();
+				expectClients(
+					'<paragraph>' +
+						'<m1:start></m1:start>F<m1:end></m1:end>oo' +
+					'</paragraph>'
+				);
+			} );
+
 			it( 'then wrap and split', () => {
 				john.setData( '<paragraph>[Foo] Bar</paragraph>' );
 				kate.setData( '<paragraph>Fo[o Bar]</paragraph>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `MarkerOperation` x `MarkerOperation` transformation when one operation removes marker. Closes #1529.