### PR TITLE
Sanitize InsertOperation#position#stickiness

### DIFF
--- a/src/model/operation/insertoperation.js
+++ b/src/model/operation/insertoperation.js
@@ -40,6 +40,7 @@ export default class InsertOperation extends Operation {
 		 * @member {module:engine/model/position~Position} module:engine/model/operation/insertoperation~InsertOperation#position
 		 */
 		this.position = Position.createFromPosition( position );
+		this.position.stickiness = 'toNone';
 
 		/**
 		 * List of nodes to insert.

--- a/src/model/operation/moveoperation.js
+++ b/src/model/operation/moveoperation.js
@@ -41,6 +41,7 @@ export default class MoveOperation extends Operation {
 		 * @member {module:engine/model/position~Position} module:engine/model/operation/moveoperation~MoveOperation#sourcePosition
 		 */
 		this.sourcePosition = Position.createFromPosition( sourcePosition );
+		// `'toNext'` because `sourcePosition` is a bit like a start of the moved range.
 		this.sourcePosition.stickiness = 'toNext';
 
 		/**

--- a/src/model/operation/wrapoperation.js
+++ b/src/model/operation/wrapoperation.js
@@ -43,6 +43,7 @@ export default class WrapOperation extends Operation {
 		 * @member {module:engine/model/position~Position} module:engine/model/operation/wrapoperation~WrapOperation#position
 		 */
 		this.position = Position.createFromPosition( position );
+		// `'toNext'` because `position` is a bit like a start of the wrapped range.
 		this.position.stickiness = 'toNext';
 
 		/**

--- a/tests/model/operation/insertoperation.js
+++ b/tests/model/operation/insertoperation.js
@@ -31,6 +31,19 @@ describe( 'InsertOperation', () => {
 		expect( op.type ).to.equal( 'insert' );
 	} );
 
+	it( 'should have proper position stickiness', () => {
+		const pos = new Position( root, [ 0 ] );
+		pos.stickiness = 'toNext';
+
+		const op = new InsertOperation(
+			new Position( root, [ 0 ] ),
+			new Text( 'x' ),
+			doc.version
+		);
+
+		expect( op.position.stickiness ).to.equal( 'toNone' );
+	} );
+
 	it( 'should insert text node', () => {
 		model.applyOperation(
 			new InsertOperation(


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Sanitize `InsertOperation#position#stickiness`. Closes #1531.