### PR TITLE
Prevent rendering when one is in the `change` block.

### DIFF
--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -73,6 +73,15 @@ export default class EditingController {
 		// Whenever model document is changed, convert those changes to the view (using model.Document#differ).
 		// Do it on 'low' priority, so changes are converted after other listeners did their job.
 		// Also convert model selection.
+		this.listenTo( this.model, '_beforeChanges', () => {
+			this.view.disabledRendering = true;
+		}, { priority: 'highest' } );
+
+		this.listenTo( this.model, '_afterChanges', () => {
+			this.view.disabledRendering = false;
+			this.view.render();
+		}, { priority: 'lowest' } );
+
 		this.listenTo( doc, 'change', () => {
 			this.view.change( writer => {
 				this.downcastDispatcher.convertChanges( doc.differ, writer );

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -70,9 +70,10 @@ export default class EditingController {
 		const selection = doc.selection;
 		const markers = this.model.markers;
 
-		// Various plugins listen on model changes (on selection change, post fixers, etc.) and change the view as a
-		// result of the model change, what causes rendering in the middle of conversion, sometimes before the selection
-		// is converted. This is why we want to disable rendering as long as one is in the `model.change` block.
+		// When plugins listen on model changes (on selection change, post fixers, etc) and change the view as a result of
+		// model's change, they might trigger view rendering before the conversion is completed (e.g. before the selection
+		// is converted). We disable rendering for the length of the outermost model change() block to prevent that.
+		//
 		// See  https://github.com/ckeditor/ckeditor5-engine/issues/1528
 		this.listenTo( this.model, '_beforeChanges', () => {
 			this.view._disabledRendering = true;

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -70,7 +70,7 @@ export default class EditingController {
 		const selection = doc.selection;
 		const markers = this.model.markers;
 
-		// Various plugins listen on model changes (on selection change, post fixers, etc.) and changes the view as a
+		// Various plugins listen on model changes (on selection change, post fixers, etc.) and change the view as a
 		// result of the model change, what causes rendering in the middle of conversion, sometimes before the selection
 		// is converted. This is why we want to disable rendering as long as one is in the `model.change` block.
 		// See  https://github.com/ckeditor/ckeditor5-engine/issues/1528

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -76,11 +76,11 @@ export default class EditingController {
 		//
 		// See  https://github.com/ckeditor/ckeditor5-engine/issues/1528
 		this.listenTo( this.model, '_beforeChanges', () => {
-			this.view._disabledRendering = true;
+			this.view._renderingDisabled = true;
 		}, { priority: 'highest' } );
 
 		this.listenTo( this.model, '_afterChanges', () => {
-			this.view._disabledRendering = false;
+			this.view._renderingDisabled = false;
 			this.view.render();
 		}, { priority: 'lowest' } );
 

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -405,7 +405,7 @@ export default class Model {
 	 */
 
 	/**
-	 * Fired when enter the first {@link module:engine/model/model~Model#enqueueChange} or
+	 * Fired when entering the first {@link module:engine/model/model~Model#enqueueChange} or
 	 * {@link module:engine/model/model~Model#change} block of the pending changes.
 	 *
 	 * @protected
@@ -413,7 +413,7 @@ export default class Model {
 	 */
 
 	/**
-	 * Fired when leave the last {@link module:engine/model/model~Model#enqueueChange} or
+	 * Fired when leaving the last {@link module:engine/model/model~Model#enqueueChange} or
 	 * {@link module:engine/model/model~Model#change} block of the pending changes.
 	 *
 	 * @protected

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -370,7 +370,7 @@ export default class Model {
 	_runPendingChanges() {
 		const ret = [];
 
-		this.fire( '_beforeChanges', this._currentWriter );
+		this.fire( '_beforeChanges' );
 
 		while ( this._pendingChanges.length ) {
 			// Create a new writer using batch instance created for this chain of changes.
@@ -388,7 +388,7 @@ export default class Model {
 			this._currentWriter = null;
 		}
 
-		this.fire( '_afterChanges', this._currentWriter );
+		this.fire( '_afterChanges' );
 
 		return ret;
 	}
@@ -402,6 +402,22 @@ export default class Model {
 	 * @protected
 	 * @event _change
 	 * @param {module:engine/model/writer~Writer} writer `Writer` instance that has been used in the change block.
+	 */
+
+	/**
+	 * Fired when enter the first {@link module:engine/model/model~Model#enqueueChange} or
+	 * {@link module:engine/model/model~Model#change} block of the pending changes.
+	 *
+	 * @protected
+	 * @event _beforeChanges
+	 */
+
+	/**
+	 * Fired when leave the last {@link module:engine/model/model~Model#enqueueChange} or
+	 * {@link module:engine/model/model~Model#change} block of the pending changes.
+	 *
+	 * @protected
+	 * @event _afterChanges
 	 */
 
 	/**

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -492,16 +492,16 @@ export default class Model {
 	 */
 
 	/**
-	 * Fired when entering the first {@link module:engine/model/model~Model#enqueueChange} or
-	 * {@link module:engine/model/model~Model#change} block of the pending changes.
+	 * Fired when entering the outermost {@link module:engine/model/model~Model#enqueueChange} or
+	 * {@link module:engine/model/model~Model#change} block.
 	 *
 	 * @protected
 	 * @event _beforeChanges
 	 */
 
 	/**
-	 * Fired when leaving the last {@link module:engine/model/model~Model#enqueueChange} or
-	 * {@link module:engine/model/model~Model#change} block of the pending changes.
+	 * Fired when leaving the outermost {@link module:engine/model/model~Model#enqueueChange} or
+	 * {@link module:engine/model/model~Model#change} block.
 	 *
 	 * @protected
 	 * @event _afterChanges

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -370,6 +370,8 @@ export default class Model {
 	_runPendingChanges() {
 		const ret = [];
 
+		this.fire( '_beforeChanges', this._currentWriter );
+
 		while ( this._pendingChanges.length ) {
 			// Create a new writer using batch instance created for this chain of changes.
 			const currentBatch = this._pendingChanges[ 0 ].batch;
@@ -385,6 +387,8 @@ export default class Model {
 			this._pendingChanges.shift();
 			this._currentWriter = null;
 		}
+
+		this.fire( '_afterChanges', this._currentWriter );
 
 		return ret;
 	}

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -127,6 +127,14 @@ export default class View {
 		this._postFixersInProgress = false;
 
 		/**
+		 * Internal flag to temporary disable rendering. See usage in the editing controller.
+		 *
+		 * @protected
+		 * @member {Boolean} module:engine/view/view~View#_disabledRendering
+		 */
+		this._disabledRendering = false;
+
+		/**
 		 * DowncastWriter instance used in {@link #change change method) callbacks.
 		 *
 		 * @private
@@ -358,7 +366,7 @@ export default class View {
 		this.document._callPostFixers( this._writer );
 		this._postFixersInProgress = false;
 
-		if ( !this.disabledRendering ) {
+		if ( !this._disabledRendering ) {
 			this.fire( 'render' );
 		}
 	}

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -358,8 +358,7 @@ export default class View {
 		this.document._callPostFixers( this._writer );
 		this._postFixersInProgress = false;
 
-
-		if( !this.disabledRendering ) {
+		if ( !this.disabledRendering ) {
 			this.fire( 'render' );
 		}
 	}

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -358,7 +358,10 @@ export default class View {
 		this.document._callPostFixers( this._writer );
 		this._postFixersInProgress = false;
 
-		this.fire( 'render' );
+
+		if( !this.disabledRendering ) {
+			this.fire( 'render' );
+		}
 	}
 
 	/**

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -130,9 +130,9 @@ export default class View {
 		 * Internal flag to temporary disable rendering. See usage in the editing controller.
 		 *
 		 * @protected
-		 * @member {Boolean} module:engine/view/view~View#_disabledRendering
+		 * @member {Boolean} module:engine/view/view~View#_renderingDisabled
 		 */
-		this._disabledRendering = false;
+		this._renderingDisabled = false;
 
 		/**
 		 * DowncastWriter instance used in {@link #change change method) callbacks.
@@ -366,7 +366,7 @@ export default class View {
 		this.document._callPostFixers( this._writer );
 		this._postFixersInProgress = false;
 
-		if ( !this._disabledRendering ) {
+		if ( !this._renderingDisabled ) {
 			this.fire( 'render' );
 		}
 	}

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -340,7 +340,7 @@ describe( 'EditingController', () => {
 				.to.equal( '<p></p><p>f<span>oo</span></p><p>bar</p>' );
 		} );
 
-		describe( 'rendering preventing in the change block', () => {
+		describe( 'preventing rendering while in the model.change() block', () => {
 			let renderSpy;
 
 			beforeEach( () => {
@@ -349,7 +349,7 @@ describe( 'EditingController', () => {
 				editing.view.on( 'render', renderSpy );
 			} );
 
-			it( 'should not call render in the change block', () => {
+			it( 'should not call render in the model.change() block', () => {
 				model.change( writer => {
 					executeSomeModelChange( writer );
 
@@ -359,7 +359,7 @@ describe( 'EditingController', () => {
 				expect( renderSpy.called ).to.be.true;
 			} );
 
-			it( 'should not call render in the change block even if view change was called', () => {
+			it( 'should not call render in the model.change() block even if view.change() was called', () => {
 				model.change( writer => {
 					executeSomeModelChange( writer );
 

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -351,7 +351,7 @@ describe( 'EditingController', () => {
 
 			it( 'should not call render in the change block', () => {
 				model.change( writer => {
-					executeSomeModelAction( writer );
+					executeSomeModelChange( writer );
 
 					expect( renderSpy.called ).to.be.false;
 				} );
@@ -361,9 +361,9 @@ describe( 'EditingController', () => {
 
 			it( 'should not call render in the change block even if view change was called', () => {
 				model.change( writer => {
-					executeSomeModelAction( writer );
+					executeSomeModelChange( writer );
 
-					editing.view.change( writer => executeSomeViewAction( writer ) );
+					editing.view.change( writer => executeSomeViewChange( writer ) );
 
 					expect( renderSpy.called ).to.be.false;
 				} );
@@ -371,14 +371,14 @@ describe( 'EditingController', () => {
 				expect( renderSpy.called ).to.be.true;
 			} );
 
-			it( 'should not call render in the list of pending changes', () => {
+			it( 'should not call render in enqueued changes', () => {
 				model.enqueueChange( writer => {
-					executeSomeModelAction( writer );
+					executeSomeModelChange( writer );
 
 					expect( renderSpy.called ).to.be.false;
 
 					model.enqueueChange( writer => {
-						executeSomeOtherModelAction( writer );
+						executeSomeOtherModelChange( writer );
 
 						expect( renderSpy.called ).to.be.false;
 					} );
@@ -393,7 +393,7 @@ describe( 'EditingController', () => {
 				const postfixerSpy = sinon.spy();
 
 				model.document.registerPostFixer( () => {
-					model.change( writer => executeSomeOtherModelAction( writer ) );
+					model.change( writer => executeSomeOtherModelChange( writer ) );
 
 					expect( renderSpy.called ).to.be.false;
 
@@ -401,7 +401,7 @@ describe( 'EditingController', () => {
 				} );
 
 				model.change( writer => {
-					executeSomeModelAction( writer );
+					executeSomeModelChange( writer );
 
 					expect( renderSpy.called ).to.be.false;
 				} );
@@ -414,7 +414,7 @@ describe( 'EditingController', () => {
 				const changeListenerSpy = sinon.spy();
 
 				model.document.on( 'change', () => {
-					editing.view.change( writer => executeSomeViewAction( writer ) );
+					editing.view.change( writer => executeSomeViewChange( writer ) );
 
 					expect( renderSpy.called ).to.be.false;
 
@@ -422,7 +422,7 @@ describe( 'EditingController', () => {
 				} );
 
 				model.change( writer => {
-					executeSomeModelAction( writer );
+					executeSomeModelChange( writer );
 
 					expect( renderSpy.called ).to.be.false;
 				} );
@@ -431,17 +431,17 @@ describe( 'EditingController', () => {
 				expect( changeListenerSpy.calledOnce ).to.be.true;
 			} );
 
-			function executeSomeModelAction( writer ) {
+			function executeSomeModelChange( writer ) {
 				const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 				writer.addMarker( 'marker1', { range, usingOperation: true } );
 			}
 
-			function executeSomeOtherModelAction( writer ) {
+			function executeSomeOtherModelChange( writer ) {
 				const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 				writer.addMarker( 'marker2', { range, usingOperation: true } );
 			}
 
-			function executeSomeViewAction( writer ) {
+			function executeSomeViewChange( writer ) {
 				writer.addClass( 'foo', editing.view.document.getRoot() );
 			}
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Prevent rendering when one is in the `change` block. Closes #1528.