### PR TITLE
Added merge x merge transformation case handling when merges source position is same but target different

### DIFF
--- a/tests/model/operation/transform/merge.js
+++ b/tests/model/operation/transform/merge.js
@@ -116,6 +116,18 @@ describe( 'transform', () => {
 
 				expectClients( '<paragraph>For</paragraph>' );
 			} );
+
+			it( 'merged elements and some text', () => {
+				john.setData( '<paragraph>Foo</paragraph><paragraph></paragraph>[]<paragraph>Bar</paragraph>' );
+				kate.setData( '<paragraph>F[oo</paragraph><paragraph></paragraph><paragraph>Ba]r</paragraph>' );
+
+				john.merge();
+				kate.delete();
+
+				syncClients();
+
+				expectClients( '<paragraph>Fr</paragraph>' );
+			} );
 		} );
 
 		describe( 'by wrap', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added merge x merge transformation case handling when merges source position is the same but the target is different. Closes #1557.