### PR TITLE
T/1564

### DIFF
--- a/src/view/view.js
+++ b/src/view/view.js
@@ -361,10 +361,9 @@ export default class View {
 		callback( this._writer );
 		this._ongoingChange = false;
 
-		// This lock is used by editing controller to render changes from outer most modelchange() once. As plugins might call
-		// view.change() inside model.change() block - this will ensures that postfixers are called once before rendering.
+		// This lock is used by editing controller to render changes from outer most model.change() once. As plugins might call
+		// view.change() inside model.change() block - this will ensures that postfixers and rendering are called once after all changes.
 		if ( !this._renderingDisabled ) {
-			// Execute all document post-fixers after the change.
 			this._postFixersInProgress = true;
 			this.document._callPostFixers( this._writer );
 			this._postFixersInProgress = false;

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -361,11 +361,14 @@ export default class View {
 		callback( this._writer );
 		this._ongoingChange = false;
 
+		// This lock is used by editing controller to render changes from outer most modelchange() once. As plugins might call
+		// view.change() inside model.change() block - this will ensures that postfixers are called once before rendering.
 		if ( !this._renderingDisabled ) {
 			// Execute all document post-fixers after the change.
 			this._postFixersInProgress = true;
 			this.document._callPostFixers( this._writer );
 			this._postFixersInProgress = false;
+
 			this.fire( 'render' );
 		}
 	}

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -361,12 +361,11 @@ export default class View {
 		callback( this._writer );
 		this._ongoingChange = false;
 
-		// Execute all document post-fixers after the change.
-		this._postFixersInProgress = true;
-		this.document._callPostFixers( this._writer );
-		this._postFixersInProgress = false;
-
 		if ( !this._renderingDisabled ) {
+			// Execute all document post-fixers after the change.
+			this._postFixersInProgress = true;
+			this.document._callPostFixers( this._writer );
+			this._postFixersInProgress = false;
 			this.fire( 'render' );
 		}
 	}

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -431,6 +431,22 @@ describe( 'EditingController', () => {
 				expect( changeListenerSpy.calledOnce ).to.be.true;
 			} );
 
+			it( 'should call view post-fixers once for model.change() block', () => {
+				const postfixerSpy = sinon.spy();
+
+				editing.view.document.registerPostFixer( postfixerSpy );
+
+				model.change( writer => {
+					executeSomeModelChange( writer );
+
+					editing.view.change( writer => {
+						executeSomeViewChange( writer );
+					} );
+				} );
+
+				sinon.assert.calledOnce( postfixerSpy );
+			} );
+
 			function executeSomeModelChange( writer ) {
 				const range = new ModelRange( new ModelPosition( modelRoot, [ 0, 1 ] ), new ModelPosition( modelRoot, [ 2, 2 ] ) );
 				writer.addMarker( 'marker1', { range, usingOperation: true } );

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -396,6 +396,35 @@ describe( 'view', () => {
 		} );
 	} );
 
+	describe( 'editing controller integration', () => {
+		it( 'should call post-fixers once if rendering model changes (_disableRendering integration)', () => {
+			const postFixerSpy = sinon.spy( () => false );
+			const changeSpy = sinon.spy();
+			const eventSpy = sinon.spy();
+
+			viewDocument.registerPostFixer( postFixerSpy );
+
+			view.on( 'render', eventSpy );
+
+			// This is set in editing controller on `model#_beforeChanges` event
+			view._renderingDisabled = true;
+
+			view.change( changeSpy );
+			view.change( changeSpy );
+			view.change( changeSpy );
+
+			// This is set in editing controller on `model#_afterChanges` event
+			view._renderingDisabled = false;
+			view.render();
+
+			sinon.assert.calledOnce( postFixerSpy );
+			sinon.assert.calledThrice( changeSpy );
+			sinon.assert.calledOnce( eventSpy );
+
+			sinon.assert.callOrder( changeSpy, postFixerSpy, eventSpy );
+		} );
+	} );
+
 	describe( 'view and DOM integration', () => {
 		it( 'should remove content of the DOM', () => {
 			const domDiv = createElement( document, 'div', { id: 'editor' }, [

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -396,35 +396,6 @@ describe( 'view', () => {
 		} );
 	} );
 
-	describe( 'editing controller integration', () => {
-		it( 'should call post-fixers once if rendering model changes (_disableRendering integration)', () => {
-			const postFixerSpy = sinon.spy( () => false );
-			const changeSpy = sinon.spy();
-			const eventSpy = sinon.spy();
-
-			viewDocument.registerPostFixer( postFixerSpy );
-
-			view.on( 'render', eventSpy );
-
-			// This is set in editing controller on `model#_beforeChanges` event
-			view._renderingDisabled = true;
-
-			view.change( changeSpy );
-			view.change( changeSpy );
-			view.change( changeSpy );
-
-			// This is set in editing controller on `model#_afterChanges` event
-			view._renderingDisabled = false;
-			view.render();
-
-			sinon.assert.calledOnce( postFixerSpy );
-			sinon.assert.calledThrice( changeSpy );
-			sinon.assert.calledOnce( eventSpy );
-
-			sinon.assert.callOrder( changeSpy, postFixerSpy, eventSpy );
-		} );
-	} );
-
 	describe( 'view and DOM integration', () => {
 		it( 'should remove content of the DOM', () => {
 			const domDiv = createElement( document, 'div', { id: 'editor' }, [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: View post-fixer should be called once while rendering model changes. Closes #1564.

BREAKING CHANGE: View post-fixers are now called once while rendering model changes.

---

### Additional information

* Required fix for bugs related to time of post-fixers are called after model changes.
