### PR TITLE
Range#_getTransformedBySplitOperation will expand the range if insertionPosition is equal to the range end

### DIFF
--- a/src/model/range.js
+++ b/src/model/range.js
@@ -517,7 +517,14 @@ export default class Range {
 	 */
 	_getTransformedBySplitOperation( operation ) {
 		const start = this.start._getTransformedBySplitOperation( operation );
-		const end = this.end._getTransformedBySplitOperation( operation );
+
+		let end;
+
+		if ( this.end.isEqual( operation.insertionPosition ) ) {
+			end = this.end.getShiftedBy( 1 );
+		} else {
+			end = this.end._getTransformedBySplitOperation( operation );
+		}
 
 		return new Range( start, end );
 	}

--- a/tests/model/operation/transform/undo.js
+++ b/tests/model/operation/transform/undo.js
@@ -275,4 +275,50 @@ describe( 'transform', () => {
 		john.redo();
 		expectClients( '<paragraph>Foo</paragraph>' );
 	} );
+
+	it( 'undo pasting', () => {
+		john.setData( '<paragraph>Foo[]Bar</paragraph>' );
+
+		// Below simulates pasting.
+		john.editor.model.change( () => {
+			john.split();
+			john.setSelection( [ 1 ] );
+
+			john.insert( '<paragraph>1</paragraph>' );
+			john.setSelection( [ 1 ] );
+			john.merge();
+
+			john.setSelection( [ 1 ] );
+			john.insert( '<paragraph>2</paragraph>' );
+			john.setSelection( [ 2 ] );
+			john.merge();
+		} );
+
+		expectClients( '<paragraph>Foo1</paragraph><paragraph>2Bar</paragraph>' );
+
+		john.undo();
+
+		expectClients( '<paragraph>FooBar</paragraph>' );
+	} );
+
+	it( 'selection attribute setting: split, bold, merge, undo, undo, undo', () => {
+		// This test is ported from undo to keep 100% CC in engine.
+		john.setData( '<paragraph>Foo[]</paragraph><paragraph>Bar</paragraph>' );
+
+		john.split();
+		john.setSelection( [ 1, 0 ] );
+		john._processExecute( 'bold' );
+		john._processExecute( 'forwardDelete' );
+
+		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+
+		john.undo();
+		expectClients( '<paragraph>Foo</paragraph><paragraph selection:bold="true"></paragraph><paragraph>Bar</paragraph>' );
+
+		john.undo();
+		expectClients( '<paragraph>Foo</paragraph><paragraph></paragraph><paragraph>Bar</paragraph>' );
+
+		john.undo();
+		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+	} );
 } );

--- a/tests/model/operation/transform/utils.js
+++ b/tests/model/operation/transform/utils.js
@@ -1,6 +1,7 @@
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
 
 import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
@@ -30,7 +31,8 @@ export class Client {
 			// Typing is needed for delete command.
 			// UndoEditing is needed for undo command.
 			// Block plugins are needed for proper data serializing.
-			plugins: [ Typing, Paragraph, ListEditing, UndoEditing, BlockQuoteEditing, HeadingEditing ]
+			// BoldEditing is needed for bold command.
+			plugins: [ Typing, Paragraph, ListEditing, UndoEditing, BlockQuoteEditing, HeadingEditing, BoldEditing ]
 		} ).then( editor => {
 			this.editor = editor;
 			this.document = editor.model.document;

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -1038,6 +1038,17 @@ describe( 'Range', () => {
 				expect( transformed[ 0 ].start.path ).to.deep.equal( [ 1, 3 ] );
 				expect( transformed[ 0 ].end.path ).to.deep.equal( [ 1, 3 ] );
 			} );
+
+			it( 'split element which is the last element in the range', () => {
+				range = new Range( new Position( root, [ 1 ] ), new Position( root, [ 3 ] ) );
+
+				const op = new SplitOperation( new Position( root, [ 2, 0 ] ), 6, gyPos, 1 );
+				const transformed = range.getTransformedByOperation( op );
+
+				expect( transformed.length ).to.equal( 1 );
+				expect( transformed[ 0 ].start.path ).to.deep.equal( [ 1 ] );
+				expect( transformed[ 0 ].end.path ).to.deep.equal( [ 4 ] );
+			} );
 		} );
 
 		describe( 'by MergeOperation', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: `Range#_getTransformedBySplitOperation` will expand the range if `insertionPosition` is equal to the range end. Modified transformations to align with that change. Closes https://github.com/ckeditor/ckeditor5/issues/1278.