### PR TITLE
Better handling for MoveOperation x SplitOperation transformation special case

### DIFF
--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -449,6 +449,8 @@ class ContextFactory {
 							this._setRelation( opA, opB, 'insertAtSource' );
 						} else if ( opA.targetPosition.isEqual( opB.deletionPosition ) ) {
 							this._setRelation( opA, opB, 'insertBetween' );
+						} else if ( opA.targetPosition.isAfter( opB.sourcePosition ) ) {
+							this._setRelation( opA, opB, 'moveTargetAfter' );
 						}
 
 						break;
@@ -1568,7 +1570,7 @@ setTransformation( MoveOperation, SplitOperation, ( a, b, context ) => {
 	// Do not transform if target position is same as split insertion position and this split comes from undo.
 	// This should be done on relations but it is too much work for now as it would require relations working in collaboration.
 	// We need to make a decision how we will resolve such conflict and this is less harmful way.
-	if ( !a.targetPosition.isEqual( b.insertionPosition ) || !b.graveyardPosition ) {
+	if ( !a.targetPosition.isEqual( b.insertionPosition ) || !b.graveyardPosition || context.abRelation == 'moveTargetAfter' ) {
 		newTargetPosition = a.targetPosition._getTransformedBySplitOperation( b );
 	}
 

--- a/tests/model/operation/transform/undo.js
+++ b/tests/model/operation/transform/undo.js
@@ -238,7 +238,7 @@ describe( 'transform', () => {
 		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
 	} );
 
-	it.skip( 'delete split paragraphs', () => {
+	it( 'delete split paragraphs', () => {
 		john.setData( '<paragraph>Foo</paragraph><paragraph>B[]ar</paragraph>' );
 
 		john.split();
@@ -320,5 +320,28 @@ describe( 'transform', () => {
 
 		john.undo();
 		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+	} );
+
+	// https://github.com/ckeditor/ckeditor5/issues/1288
+	it( 'remove two groups of blocks then undo, undo', () => {
+		john.setData(
+			'<paragraph>X</paragraph><paragraph>A</paragraph><paragraph>B[</paragraph><paragraph>C</paragraph><paragraph>D]</paragraph>'
+		);
+
+		john.delete();
+		john.setSelection( [ 0, 1 ], [ 2, 1 ] );
+		john.delete();
+
+		expectClients( '<paragraph>X</paragraph>' );
+
+		john.undo();
+
+		expectClients( '<paragraph>X</paragraph><paragraph>A</paragraph><paragraph>B</paragraph>' );
+
+		john.undo();
+
+		expectClients(
+			'<paragraph>X</paragraph><paragraph>A</paragraph><paragraph>B</paragraph><paragraph>C</paragraph><paragraph>D</paragraph>'
+		);
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Better handling for `MoveOperation` x `SplitOperation` transformation special case. Closes https://github.com/ckeditor/ckeditor5/issues/1288.