### PR TITLE
MoveOperation x SplitOperation transformation for a case when graveyard element is moved

### DIFF
--- a/src/model/differ.js
+++ b/src/model/differ.js
@@ -423,7 +423,7 @@ export default class Differ {
 			// If change happens at the same position...
 			if ( a.position.isEqual( b.position ) ) {
 				// Keep chronological order of operations.
-				return a.changeCount < b.changeCount ? -1 : 1;
+				return a.changeCount - b.changeCount;
 			}
 
 			// If positions differ, position "on the left" should be earlier in the result.

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -517,13 +517,16 @@ export default class Range {
 	 */
 	_getTransformedBySplitOperation( operation ) {
 		const start = this.start._getTransformedBySplitOperation( operation );
-
-		let end;
+		let end = this.end._getTransformedBySplitOperation( operation );
 
 		if ( this.end.isEqual( operation.insertionPosition ) ) {
 			end = this.end.getShiftedBy( 1 );
-		} else {
-			end = this.end._getTransformedBySplitOperation( operation );
+		}
+
+		// Below may happen when range contains graveyard element used by split operation.
+		if ( start.root != end.root ) {
+			// End position was next to the moved graveyard element and was moved with it. Fix it.
+			end = this.end.getShiftedBy( -1 );
 		}
 
 		return new Range( start, end );

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -525,7 +525,8 @@ export default class Range {
 
 		// Below may happen when range contains graveyard element used by split operation.
 		if ( start.root != end.root ) {
-			// End position was next to the moved graveyard element and was moved with it. Fix it.
+			// End position was next to the moved graveyard element and was moved with it.
+			// Fix it by using old `end` which has proper `root`.
 			end = this.end.getShiftedBy( -1 );
 		}
 

--- a/tests/model/operation/transform/merge.js
+++ b/tests/model/operation/transform/merge.js
@@ -174,9 +174,7 @@ describe( 'transform', () => {
 				kate.undo();
 				syncClients();
 
-				expectClients(
-					'<paragraph>Foo</paragraph>'
-				);
+				expectClients( '<paragraph>Foo</paragraph>' );
 			} );
 		} );
 
@@ -221,6 +219,40 @@ describe( 'transform', () => {
 				syncClients();
 
 				expectClients( '<paragraph>FooBar</paragraph>' );
+			} );
+
+			it( 'remove merged element then undo #3', () => {
+				john.setData( '[<paragraph>A</paragraph><paragraph>B</paragraph>]<paragraph>C</paragraph>' );
+				kate.setData( '<paragraph>A</paragraph>[]<paragraph>B</paragraph><paragraph>C</paragraph>' );
+
+				kate.merge();
+				john.remove();
+
+				syncClients();
+				expectClients( '<paragraph>C</paragraph>' );
+
+				john.undo();
+				kate.undo();
+
+				syncClients();
+				expectClients( '<paragraph>A</paragraph><paragraph>B</paragraph><paragraph>C</paragraph>' );
+			} );
+
+			it( 'remove merged element then undo #4', () => {
+				john.setData( '<paragraph>A</paragraph>[<paragraph>B</paragraph><paragraph>C</paragraph>]' );
+				kate.setData( '<paragraph>A</paragraph>[]<paragraph>B</paragraph><paragraph>C</paragraph>' );
+
+				kate.merge();
+				john.remove();
+
+				syncClients();
+				expectClients( '<paragraph>A</paragraph>' );
+
+				john.undo();
+				kate.undo();
+
+				syncClients();
+				expectClients( '<paragraph>A</paragraph><paragraph>B</paragraph><paragraph>C</paragraph>' );
 			} );
 		} );
 
@@ -407,6 +439,24 @@ describe( 'transform', () => {
 						'<paragraph>C</paragraph>' +
 					'</listItem>'
 				);
+			} );
+		} );
+
+		describe( 'by split', () => {
+			it( 'merge element which got split (the element is in blockquote) and undo', () => {
+				john.setData( '<paragraph>Foo</paragraph><blockQuote><paragraph>[]Bar</paragraph></blockQuote>' );
+				kate.setData( '<paragraph>Foo</paragraph><blockQuote><paragraph>B[]ar</paragraph></blockQuote>' );
+
+				john._processExecute( 'delete' );
+				kate.split();
+
+				syncClients();
+				expectClients( '<paragraph>FooB</paragraph><paragraph>ar</paragraph>' );
+
+				john.undo();
+
+				syncClients();
+				expectClients( '<paragraph>Foo</paragraph><blockQuote><paragraph>B</paragraph><paragraph>ar</paragraph></blockQuote>' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `MoveOperation` x `SplitOperation` transformation for a case when graveyard element is moved. Closes #1580.

---

### Additional information

While working on that bug I found an additional unhandled case in `MoveOperation` x `MergeOperation` transformation. We already handled a situation when an element to merge was removed. However, we didn't handle the situation when the removed element was one of multiple removed elements. I also added fixes for that case.