### PR TITLE
t/1439: Firefox should visually move the caret to the new line after a soft break

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* globals Node */
+
 /**
  * @module engine/view/renderer
  */
@@ -20,6 +22,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
 import isNode from '@ckeditor/ckeditor5-utils/src/dom/isnode';
 import fastDiff from '@ckeditor/ckeditor5-utils/src/fastdiff';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 /**
  * Renderer is responsible for updating the DOM structure and the DOM selection based on
@@ -752,6 +755,31 @@ export default class Renderer {
 
 		domSelection.collapse( anchor.parent, anchor.offset );
 		domSelection.extend( focus.parent, focus.offset );
+
+		// The following is a Firefox–specific hack (https://github.com/ckeditor/ckeditor5-engine/issues/1439).
+		// When the native DOM selection is at the end of the block and preceded by <br /> e.g.
+		//
+		//		<p>foo<br/>[]</p>
+		//
+		// which happens a lot when using the soft line break, the browser fails to (visually) move the
+		// caret to the new line. A quick fix is as simple as force–refreshing the selection with the same range.
+		if ( env.isGecko ) {
+			const parent = focus.parent;
+
+			// This fix works only when the focus point is at the very end of an element.
+			// There is no point in running it in cases unrelated to the browser bug.
+			if ( parent.nodeType != Node.ELEMENT_NODE || focus.offset != parent.childNodes.length - 1 ) {
+				return;
+			}
+
+			const childAtOffset = parent.childNodes[ focus.offset ];
+
+			// To stay on the safe side, the fix being as specific as possible, it targets only the
+			// selection which is at the very end of the element and preceded by <br />.
+			if ( childAtOffset && childAtOffset.tagName == 'BR' ) {
+				domSelection.addRange( domSelection.getRangeAt( 0 ) );
+			}
+		}
 	}
 
 	/**

--- a/tests/manual/tickets/1439/1.html
+++ b/tests/manual/tickets/1439/1.html
@@ -1,0 +1,1 @@
+<div id="editor"></div>

--- a/tests/manual/tickets/1439/1.js
+++ b/tests/manual/tickets/1439/1.js
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ ArticlePluginSet ],
+		toolbar: {
+			items: [
+				'heading',
+				'bold',
+				'italic',
+				'link',
+				'bulletedList',
+				'numberedList',
+				'blockQuote',
+				'undo',
+				'redo'
+			]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/tests/manual/tickets/1439/1.md
+++ b/tests/manual/tickets/1439/1.md
@@ -1,0 +1,11 @@
+## Firefox should visually move the caret to the new line after a soft break [#1439](https://github.com/ckeditor/ckeditor5-engine/issues/1439)
+
+
+1. Open Firefox,
+2. In an empty editor type "foo",
+3. Press <kbd>Shift</kbd>+<kbd>Enter</kbd>.
+
+**Expected**
+
+1. The soft break should be created,
+2. The caret should be **in the new line and blinking**.

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1716,7 +1716,7 @@ describe( 'Renderer', () => {
 		} );
 
 		// #1439
-		it( 'should force–refresh the selection in FF after a soft break to nudge the caret (non-gecko)', () => {
+		it( 'should not force–refresh the selection in non–Gecko browsers after a soft break', () => {
 			const domSelection = domRoot.ownerDocument.defaultView.getSelection();
 
 			testUtils.sinon.stub( env, 'isGecko' ).get( () => false );
@@ -1738,7 +1738,7 @@ describe( 'Renderer', () => {
 		} );
 
 		// #1439
-		it( 'should force–refresh the selection in FF after a soft break to nudge the caret (gecko)', () => {
+		it( 'should force–refresh the selection in Gecko browsers after a soft break to nudge the caret', () => {
 			const domSelection = domRoot.ownerDocument.defaultView.getSelection();
 
 			testUtils.sinon.stub( env, 'isGecko' ).get( () => true );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Firefox should visually move the caret to the new line after a soft break. Closes #1439.

---

### Additional information

* [CI](https://github.com/ckeditor/ckeditor5/compare/t/ckeditor5-engine/1439?expand=1)
* Requires https://github.com/ckeditor/ckeditor5-utils/pull/254

In a F2F talk with @scofalik we decided to keep browser quirks in the engine rather in features (like `ShiftEnterCommand`).

The entire fix is just `domSelection.addRange( domSelection.getRangeAt( 0 ) );` BTW ;-)