### PR TITLE
ContainerElement#getFillerOffset can be re-used in other places

### DIFF
--- a/src/view/containerelement.js
+++ b/src/view/containerelement.js
@@ -62,10 +62,12 @@ export default class ContainerElement extends Element {
 	}
 }
 
-// Returns block {@link module:engine/view/filler filler} offset or `null` if block filler is not needed.
-//
-// @returns {Number|null} Block filler offset or `null` if block filler is not needed.
-function getFillerOffset() {
+/**
+ * Returns block {@link module:engine/view/filler filler} offset or `null` if block filler is not needed.
+ *
+ * @returns {Number|null} Block filler offset or `null` if block filler is not needed.
+ */
+export function getFillerOffset() {
 	const children = [ ...this.getChildren() ];
 	const lastChild = children[ this.childCount - 1 ];
 

--- a/tests/view/containerelement.js
+++ b/tests/view/containerelement.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import ContainerElement from '../../src/view/containerelement';
+import { default as ContainerElement, getFillerOffset } from '../../src/view/containerelement';
 import Element from '../../src/view/element';
 import { parse } from '../../src/dev-utils/view';
 
@@ -94,5 +94,11 @@ describe( 'ContainerElement', () => {
 					.to.equals( null );
 			} );
 		} );
+	} );
+} );
+
+describe( 'getFillerOffset()', () => {
+	it( 'should be a function that can be used in other places', () => {
+		expect( getFillerOffset ).is.a( 'function' );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `ContainerElement#getFillerOffset` can be now re-used in other places in the code. See ckeditor/ckeditor5-list#117.
