### PR TITLE
Do not run `AttributeToAttribute` downcast conversion on `TextProxy` nodes

### DIFF
--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -419,6 +419,9 @@ export default class Conversion {
 	/**
 	 * Sets up converters between the model and the view that convert a model attribute to a view attribute (and vice versa).
 	 * For example, `<image src='foo.jpg'></image>` is converted to `<img src='foo.jpg'></img>` (the same attribute key and value).
+	 * This type of converters is intended to be used with {@link module:engine/model/element~Element model element} nodes.
+	 * To convert text attributes {@link module:engine/conversion/conversion~Conversion#attributeToElement `attributeToElement converter`}
+	 * should be set up.
 	 *
 	 *		// A simple conversion from the `source` model attribute to the `src` view attribute (and vice versa).
 	 *		conversion.attributeToAttribute( { model: 'source', view: 'src' } );

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -10,6 +10,7 @@ import ModelElement from '../model/element';
 import ViewAttributeElement from '../view/attributeelement';
 import DocumentSelection from '../model/documentselection';
 
+import log from '@ckeditor/ckeditor5-utils/src/log';
 import { cloneDeep } from 'lodash-es';
 
 /**
@@ -685,9 +686,44 @@ export function changeAttribute( attributeCreator ) {
 		const viewElement = conversionApi.mapper.toViewElement( data.item );
 		const viewWriter = conversionApi.writer;
 
-		// If model item cannot be mapped to view element, it means item is not an `Element` instance (it is a `TextProxy`).
-		// Only elements can have attributes in a view so do not proceed for anything else (see #1587).
+		// If model item cannot be mapped to a view element, it means item is not an `Element` instance but a `TextProxy` node.
+		// Only elements can have attributes in a view so do not proceed for anything else (#1587).
 		if ( !viewElement ) {
+			/**
+			 * This error occurs when a {@link module:engine/model/textproxy~TextProxy text node} is to be downcasted
+			 * by {@link module:engine/conversion/conversion~Conversion#attributeToAttribute `Attribute to Attribute converter`}.
+			 * In most cases it is caused by converters misconfiguration when only "generic" converter is defined:
+			 *
+			 *		editor.conversion.for( 'downcast' ).add( downcastAttributeToAttribute( {
+			 *			model: 'attribute-name',
+			 *			view: 'attribute-name'
+			 *		} ) );
+			 *
+			 * and given attribute is used on text node, for example:
+			 *
+			 *		model.change( writer => {
+			 *			writer.insertText( 'Foo', { 'attribute-name': 'bar' }, parent, 0 );
+			 *		} );
+			 *
+			 * In such cases, to convert the same attribute for both {@link module:engine/model/element~Element}
+			 * and {@link module:engine/model/textproxy~TextProxy `Text`} nodes, text specific
+			 * {@link module:engine/conversion/conversion~Conversion#attributeToElement `Attribute to Element converter`}
+			 * with higher {@link module:utils/priorities~PriorityString priority} must also be defined:
+			 *
+			 *		conversion.for( 'downcast' ).add( downcastAttributeToElement( {
+			 *			model: {
+			 *				key: 'attribute-name',
+			 *				name: '$text'
+			 *			},
+			 *			view: ( value, writer ) => {
+			 *				return writer.createAttributeElement( 'span', { 'attribute-name': value } );
+			 *			}
+			 *		} ), { priority: 'high' } );
+			 *
+			 * @error conversion-attribute-to-attribute-on-text
+			 */
+			log.warn( 'conversion-attribute-to-attribute-on-text: Trying to convert text node with attribute to attribute converter.' );
+
 			return;
 		}
 

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -685,6 +685,12 @@ export function changeAttribute( attributeCreator ) {
 		const viewElement = conversionApi.mapper.toViewElement( data.item );
 		const viewWriter = conversionApi.writer;
 
+		// If model item cannot be mapped to view element, it means item is not an `Element` instance (it is a `TextProxy`).
+		// Only elements can have attributes in a view so do not proceed for anything else (see #1587).
+		if ( !viewElement ) {
+			return;
+		}
+
 		// First remove the old attribute if there was one.
 		if ( data.attributeOldValue !== null && oldAttribute ) {
 			if ( oldAttribute.key == 'class' ) {

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -717,8 +717,9 @@ export function changeAttribute( attributeCreator ) {
 			 *			},
 			 *			view: ( value, writer ) => {
 			 *				return writer.createAttributeElement( 'span', { 'attribute-name': value } );
-			 *			}
-			 *		} ), { priority: 'high' } );
+			 *			},
+			 *			converterPriority: 'high'
+			 *		} ) );
 			 *
 			 * @error conversion-attribute-to-attribute-on-text
 			 */

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -690,7 +690,7 @@ export function changeAttribute( attributeCreator ) {
 		// Only elements can have attributes in a view so do not proceed for anything else (#1587).
 		if ( !viewElement ) {
 			/**
-			 * This error occurs when a {@link module:engine/model/textproxy~TextProxy text node} is to be downcasted
+			 * This error occurs when a {@link module:engine/model/textproxy~TextProxy text node's} attribute is to be downcasted
 			 * by {@link module:engine/conversion/conversion~Conversion#attributeToAttribute `Attribute to Attribute converter`}.
 			 * In most cases it is caused by converters misconfiguration when only "generic" converter is defined:
 			 *
@@ -723,7 +723,8 @@ export function changeAttribute( attributeCreator ) {
 			 *
 			 * @error conversion-attribute-to-attribute-on-text
 			 */
-			log.warn( 'conversion-attribute-to-attribute-on-text: Trying to convert text node with attribute to attribute converter.' );
+			log.warn( 'conversion-attribute-to-attribute-on-text: ' +
+				'Trying to convert text node\'s attribute with attribute-to-attribute converter.' );
 
 			return;
 		}

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -17,6 +17,9 @@ import ViewContainerElement from '../../src/view/containerelement';
 import ViewUIElement from '../../src/view/uielement';
 import ViewText from '../../src/view/text';
 
+import log from '@ckeditor/ckeditor5-utils/src/log';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+
 import {
 	downcastElementToElement, downcastAttributeToElement, downcastAttributeToAttribute, downcastMarkerToElement, downcastMarkerToHighlight,
 	insertElement, insertUIElement, changeAttribute, wrap, removeUIElement,
@@ -264,6 +267,8 @@ describe( 'downcast-helpers', () => {
 	} );
 
 	describe( 'downcastAttributeToAttribute', () => {
+		testUtils.createSinonSandbox();
+
 		beforeEach( () => {
 			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'image', view: 'img' } ) );
 		} );
@@ -463,6 +468,8 @@ describe( 'downcast-helpers', () => {
 
 		// #1587
 		it( 'config.view and config.model as strings in generic conversion (elements only)', () => {
+			const logSpy = testUtils.sinon.spy( log, 'warn' );
+
 			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
 
 			conversion.for( 'downcast' ).add( downcastAttributeToAttribute( { model: 'test', view: 'test' } ) );
@@ -473,6 +480,7 @@ describe( 'downcast-helpers', () => {
 			} );
 
 			expectResult( '<p test="1"></p><p test="2"></p>' );
+			expect( logSpy.callCount ).to.equal( 0 );
 
 			model.change( writer => {
 				writer.removeAttribute( 'test', modelRoot.getChild( 1 ) );
@@ -483,6 +491,8 @@ describe( 'downcast-helpers', () => {
 
 		// #1587
 		it( 'config.view and config.model as strings in generic conversion (elements + text)', () => {
+			const logSpy = testUtils.sinon.spy( log, 'warn' );
+
 			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
 
 			conversion.for( 'downcast' ).add( downcastAttributeToAttribute( { model: 'test', view: 'test' } ) );
@@ -496,6 +506,8 @@ describe( 'downcast-helpers', () => {
 			} );
 
 			expectResult( '<p>Foo</p><p test="1">Bar</p>' );
+			expect( logSpy.callCount ).to.equal( 2 );
+			expect( logSpy.alwaysCalledWithMatch( 'conversion-attribute-to-attribute-on-text' ) ).to.true;
 
 			model.change( writer => {
 				writer.removeAttribute( 'test', modelRoot.getChild( 1 ) );

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -460,6 +460,49 @@ describe( 'downcast-helpers', () => {
 
 			expectResult( '<img class="styled-pull-out"></img>' );
 		} );
+
+		// #1587
+		it( 'config.view and config.model as strings in generic conversion (elements only)', () => {
+			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
+
+			conversion.for( 'downcast' ).add( downcastAttributeToAttribute( { model: 'test', view: 'test' } ) );
+
+			model.change( writer => {
+				writer.insertElement( 'paragraph', { test: '1' }, modelRoot, 0 );
+				writer.insertElement( 'paragraph', { test: '2' }, modelRoot, 1 );
+			} );
+
+			expectResult( '<p test="1"></p><p test="2"></p>' );
+
+			model.change( writer => {
+				writer.removeAttribute( 'test', modelRoot.getChild( 1 ) );
+			} );
+
+			expectResult( '<p test="1"></p><p></p>' );
+		} );
+
+		// #1587
+		it( 'config.view and config.model as strings in generic conversion (elements + text)', () => {
+			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
+
+			conversion.for( 'downcast' ).add( downcastAttributeToAttribute( { model: 'test', view: 'test' } ) );
+
+			model.change( writer => {
+				writer.insertElement( 'paragraph', modelRoot, 0 );
+				writer.insertElement( 'paragraph', { test: '1' }, modelRoot, 1 );
+
+				writer.insertText( 'Foo', { test: '2' }, modelRoot.getChild( 0 ), 0 );
+				writer.insertText( 'Bar', { test: '3' }, modelRoot.getChild( 1 ), 0 );
+			} );
+
+			expectResult( '<p>Foo</p><p test="1">Bar</p>' );
+
+			model.change( writer => {
+				writer.removeAttribute( 'test', modelRoot.getChild( 1 ) );
+			} );
+
+			expectResult( '<p>Foo</p><p>Bar</p>' );
+		} );
 	} );
 
 	describe( 'downcastMarkerToElement', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Do not run `AttributeToAttribute` downcast conversion on `TextProxy` nodes. Closes #1587.

---

### Additional information

I wanted to elaborate a little on this fix, because it looks like "_Here we got a `null` exception, lets add an `if`, easy-peasy, done_". But it is a little more complex:

The cause of this issue is described in https://github.com/ckeditor/ckeditor5-engine/issues/1587#issuecomment-441062367 - in short attribute to attribute downcast conversion is run for model `TextProxy` which is downcasted to a view `Text` node which cannot have attributes directly (but converter assumes it can).

The reasonable approach will be to downcast (via attribute to attribute converters) only model elements which can have attributes. However, in the model, `TextProxy` is the element which allows attributes. So checking model element for attributes acceptance doesn't make sense. Also model doesn't have a direct knowledge to what view element the model element will be downcasted to (that is the responsibility of converters). So basically to check if element can be processed by attribute to attribute conversion, view element should be checked. And this is what exactly happens here. Since [`conversionApi.mapper.toViewElement( data.item )`](https://github.com/ckeditor/ckeditor5-engine/pull/1595/files#diff-81862f954090bd9f5e3d83507ed19287R685) is the first place where to be converted model element is mapped to view, it is also a proper place to check if element directly accepts attributes. In the view all `Element` nodes can have attributes and other types cannot (so basically `Text` and `TextProxy`). So any node different than `Element` should not be converted and since `conversionApi.mapper.toViewElement()` method works only on `Element` nodes, it returns `null` for other elements.
