### PR TITLE
Upcast element to attribute defaults to 'low' priority instead of 'normal'

### DIFF
--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -410,7 +410,7 @@ export default class Conversion {
 				upcastElementToAttribute( {
 					view,
 					model,
-					priority: definition.priority
+					converterPriority: definition.priority
 				} )
 			);
 		}

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -151,7 +151,7 @@ export function upcastElementToAttribute( config ) {
 	const eventName = elementName ? 'element:' + elementName : 'element';
 
 	return dispatcher => {
-		dispatcher.on( eventName, converter, { priority: config.converterPriority || 'normal' } );
+		dispatcher.on( eventName, converter, { priority: config.converterPriority || 'low' } );
 	};
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Upcast element to attribute defaults to `low` priority instead of `normal`. Closes ckeditor/ckeditor5#1399.

---

### Additional information

See https://github.com/ckeditor/ckeditor5/issues/1399 and https://github.com/ckeditor/ckeditor5/issues/1399#issuecomment-446567893.

I'm not sure, should it be marked as breaking change?

As for testing I have run unit tests from all packages and did some manual testing. However, @Mgsy could also take a quick look. This PR changes the order of conversions (so elements first and then its attributes) so any operation which involves both converting element and its attributes its affected.

Btw. The failing CI tests are just selection tests failing on Edge (#1607).
