### PR TITLE
T/1556: Expose conversion utilities

### DIFF
--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -87,7 +87,8 @@ export default class Conversion {
 	 * module:engine/conversion/upcastdispatcher~UpcastDispatcher|Array.<module:engine/conversion/downcastdispatcher~DowncastDispatcher|
 	 * module:engine/conversion/upcastdispatcher~UpcastDispatcher>} options.dispatcher Dispatcher or array of dispatchers to register
 	 * under the given name.
-	 * @param {module:engine/conversion/downcast-converters~DowncastHelpers} helpers
+	 * @param {module:engine/conversion/downcast-converters~DowncastHelpers|
+	 * module:engine/conversion/upcast-converters~UpcastHelpers} helpers
 	 */
 	register( options ) {
 		if ( this._dispatchersGroups.has( options.name ) ) {
@@ -151,7 +152,8 @@ export default class Conversion {
 	 *		conversion.for( 'downcast' ).add( conversion.customConverter( 'insert:paragraph', myConverter ) );
 	 *
 	 * @param {String} groupName The name of dispatchers group to add the converters to.
-	 * @returns {module:engine/conversion/conversion~ConversionHelpers|module:engine/conversion/downcast-converters~DowncastHelpers}
+	 * @returns {module:engine/conversion/conversion~ConversionHelpers|module:engine/conversion/downcast-converters~DowncastHelpers|
+	 * module:engine/conversion/upcast-converters~UpcastHelpers}
 	 * An object with the `.add()` method, providing a way to add converters.
 	 */
 	for( groupName ) {
@@ -599,7 +601,7 @@ export default class Conversion {
  * @property {String} name Group name
  * @property {Array.<module:engine/conversion/downcastdispatcher~DowncastDispatcher|
  * module:engine/conversion/upcastdispatcher~UpcastDispatcher>} dispatchers
- * @property {module:engine/conversion/downcast-converters~DowncastHelpers} helpers
+ * @property {module:engine/conversion/downcast-converters~DowncastHelpers|module:engine/conversion/upcast-converters~UpcastHelpers} helpers
  */
 
 /**

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -97,13 +97,16 @@ export default class Conversion {
 		this._dispatchersGroups.set( options.name, group );
 	}
 
+	/* eslint-disable max-len */
 	/**
 	 * Provides chainable API to assign converters to dispatchers registered under a given group name. Converters are added
-	 * by calling the `.add()` method of an object returned by this function.
+	 * by calling the {@link module:engine/conversion/conversion~ConversionHelpers#add `.add()`} method of an
+	 * {@link module:engine/conversion/conversion~ConversionHelpers conversion helpers} returned by this function.
 	 *
-	 *		conversion.for( 'downcast' )
+	 *		editor.conversion.for( 'downcast' )
 	 *			.add( conversionHelperA )
-	 *			.add( conversionHelperB );
+	 *			.add( conversionHelperB )
+	 *			.elementToElement( config );
 	 *
 	 * In this example `conversionHelperA` and `conversionHelperB` will be called for all dispatchers from the `'model'` group.
 	 *
@@ -115,15 +118,17 @@ export default class Conversion {
 	 *
 	 * For downcast (model-to-view conversion), these are:
 	 *
-	 * * {@link module:engine/conversion/downcast-converters~_downcastElementToElement Downcast element-to-element converter},
-	 * * {@link module:engine/conversion/downcast-converters~_downcastAttributeToElement Downcast attribute-to-element converter},
-	 * * {@link module:engine/conversion/downcast-converters~_downcastAttributeToAttribute Downcast attribute-to-attribute converter}.
+	 * * {@link module:engine/conversion/downcast-converters~DowncastHelpers#elementToElement Downcast element-to-element converter},
+	 * * {@link module:engine/conversion/downcast-converters~DowncastHelpers#attributeToElement Downcast attribute-to-element converter},
+	 * * {@link module:engine/conversion/downcast-converters~DowncastHelpers#attributeToAttribute Downcast attribute-to-attribute converter}.
+	 * * {@link module:engine/conversion/downcast-converters~DowncastHelpers#markerToElement Downcast marker-to-element converter}.
+	 * * {@link module:engine/conversion/downcast-converters~DowncastHelpers#markerToHighlight Downcast marker-to-highlight converter}.
 	 *
 	 * For upcast (view-to-model conversion), these are:
 	 *
-	 * * {@link module:engine/conversion/upcast-converters~_upcastElementToElement Upcast element-to-element converter},
-	 * * {@link module:engine/conversion/upcast-converters~_upcastElementToAttribute Upcast attribute-to-element converter},
-	 * * {@link module:engine/conversion/upcast-converters~_upcastAttributeToAttribute Upcast attribute-to-attribute converter}.
+	 * * {@link module:engine/conversion/upcast-converters~UpcastHelpers#elementToElement Upcast element-to-element converter},
+	 * * {@link module:engine/conversion/upcast-converters~UpcastHelpers#elementToAttribute Upcast attribute-to-element converter},
+	 * * {@link module:engine/conversion/upcast-converters~UpcastHelpers#attributeToAttribute Upcast attribute-to-attribute converter}.
 	 *
 	 * An example of using conversion helpers to convert the `paragraph` model element to the `p` view element (and back):
 	 *
@@ -131,19 +136,15 @@ export default class Conversion {
 	 *		const config = { model: 'paragraph', view: 'p' };
 	 *
 	 *		// Add converters to proper dispatchers using conversion helpers.
-	 *		conversion.for( 'downcast' ).elementToElement( config ) );
-	 *		conversion.for( 'upcast' ).elementToElement( config ) );
-	 *
-	 * An example of providing a custom conversion helper that uses a custom converter function:
-	 *
-	 *		// Adding a custom `myConverter` converter for 'paragraph' element insertion, with the default priority ('normal').
-	 *		conversion.for( 'downcast' ).add( conversion.customConverter( 'insert:paragraph', myConverter ) );
+	 *		editor.conversion.for( 'downcast' ).elementToElement( config ) );
+	 *		editor.conversion.for( 'upcast' ).elementToElement( config ) );
 	 *
 	 * @param {String} groupName The name of dispatchers group to add the converters to.
 	 * @returns {module:engine/conversion/conversion~ConversionHelpers|module:engine/conversion/downcast-converters~DowncastHelpers|
 	 * module:engine/conversion/upcast-converters~UpcastHelpers}
 	 * An object with the `.add()` method, providing a way to add converters.
 	 */
+	/* eslint-enable max-len */
 	for( groupName ) {
 		const { dispatchers, helpers } = this._getDispatchersGroup( groupName );
 

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -96,7 +96,12 @@ export default class Conversion {
 			throw new CKEditorError( 'conversion-register-group-exists: Trying to register a group name that was already registered.' );
 		}
 
-		this._dispatchersGroups.set( groupName, dispatchers );
+		const group = {
+			name: groupName,
+			dispatchers
+		};
+
+		this._dispatchersGroups.set( groupName, group );
 	}
 
 	/**
@@ -553,9 +558,7 @@ export default class Conversion {
 	 * module:engine/conversion/upcastdispatcher~UpcastDispatcher>}
 	 */
 	_getDispatchers( groupName ) {
-		const dispatchers = this._dispatchersGroups.get( groupName );
-
-		if ( !dispatchers ) {
+		if ( !this._dispatchersGroups.has( groupName ) ) {
 			/**
 			 * Trying to add a converter to an unknown dispatchers group.
 			 *
@@ -563,6 +566,8 @@ export default class Conversion {
 			 */
 			throw new CKEditorError( 'conversion-for-unknown-group: Trying to add a converter to an unknown dispatchers group.' );
 		}
+
+		const { dispatchers } = this._dispatchersGroups.get( groupName );
 
 		return dispatchers;
 	}

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -100,7 +100,8 @@ export default class Conversion {
 
 		const group = {
 			name: options.name,
-			dispatchers: Array.isArray( options.dispatcher ) ? options.dispatcher : [ options.dispatcher ]
+			dispatchers: Array.isArray( options.dispatcher ) ? options.dispatcher : [ options.dispatcher ],
+			helpers: options.helpers
 		};
 
 		this._dispatchersGroups.set( options.name, group );

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -9,12 +9,6 @@
 
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
-import {
-	upcastElementToElement,
-	upcastElementToAttribute,
-	upcastAttributeToAttribute
-} from './upcast-converters';
-
 /**
  * A utility class that helps add converters to upcast and downcast dispatchers.
  *
@@ -34,12 +28,12 @@ import {
  * method:
  *
  *		// Add a converter to editing downcast and data downcast.
- *		editor.conversion.for( 'downcast' ).for( 'downcast' ).elementToElement( config ) );
+ *		editor.conversion.for( 'downcast' ).elementToElement( config ) );
  *
  *		// Add a converter to the data pipepline only:
- *		editor.conversion.for( 'dataDowncast' ).for( 'downcast' ).elementToElement( dataConversionConfig ) );
+ *		editor.conversion.for( 'dataDowncast' ).elementToElement( dataConversionConfig ) );
  *		// And a slightly different one for the editing pipeline:
- *		editor.conversion.for( 'editingDowncast' ).for( 'downcast' ).elementToElement( editingConversionConfig ) );
+ *		editor.conversion.for( 'editingDowncast' ).elementToElement( editingConversionConfig ) );
  *
  * The functions used in `add()` calls are one-way converters (i.e. you need to remember yourself to add
  * a converter in the other direction, if your feature requires that). They are also called "conversion helpers".
@@ -127,9 +121,9 @@ export default class Conversion {
 	 *
 	 * For upcast (view-to-model conversion), these are:
 	 *
-	 * * {@link module:engine/conversion/upcast-converters~upcastElementToElement Upcast element-to-element converter},
-	 * * {@link module:engine/conversion/upcast-converters~upcastElementToAttribute Upcast attribute-to-element converter},
-	 * * {@link module:engine/conversion/upcast-converters~upcastAttributeToAttribute Upcast attribute-to-attribute converter}.
+	 * * {@link module:engine/conversion/upcast-converters~_upcastElementToElement Upcast element-to-element converter},
+	 * * {@link module:engine/conversion/upcast-converters~_upcastElementToAttribute Upcast attribute-to-element converter},
+	 * * {@link module:engine/conversion/upcast-converters~_upcastAttributeToAttribute Upcast attribute-to-attribute converter}.
 	 *
 	 * An example of using conversion helpers to convert the `paragraph` model element to the `p` view element (and back):
 	 *
@@ -137,8 +131,8 @@ export default class Conversion {
 	 *		const config = { model: 'paragraph', view: 'p' };
 	 *
 	 *		// Add converters to proper dispatchers using conversion helpers.
-	 *		conversion.for( 'downcast' ).for( 'downcast' ).elementToElement( config ) );
-	 *		conversion.for( 'upcast' ).add( upcastElementToElement( config ) );
+	 *		conversion.for( 'downcast' ).elementToElement( config ) );
+	 *		conversion.for( 'upcast' ).elementToElement( config ) );
 	 *
 	 * An example of providing a custom conversion helper that uses a custom converter function:
 	 *
@@ -241,13 +235,12 @@ export default class Conversion {
 
 		// Set up upcast converter.
 		for ( const { model, view } of _getAllUpcastDefinitions( definition ) ) {
-			this.for( 'upcast' ).add(
-				upcastElementToElement( {
+			this.for( 'upcast' )
+				.elementToElement( {
 					model,
 					view,
 					converterPriority: definition.converterPriority
-				} )
-			);
+				} );
 		}
 	}
 
@@ -414,13 +407,12 @@ export default class Conversion {
 
 		// Set up upcast converter.
 		for ( const { model, view } of _getAllUpcastDefinitions( definition ) ) {
-			this.for( 'upcast' ).add(
-				upcastElementToAttribute( {
+			this.for( 'upcast' )
+				.elementToAttribute( {
 					view,
 					model,
 					converterPriority: definition.priority
-				} )
-			);
+				} );
 		}
 	}
 
@@ -540,12 +532,11 @@ export default class Conversion {
 
 		// Set up upcast converter.
 		for ( const { model, view } of _getAllUpcastDefinitions( definition ) ) {
-			this.for( 'upcast' ).add(
-				upcastAttributeToAttribute( {
+			this.for( 'upcast' )
+				.attributeToAttribute( {
 					view,
 					model
-				} )
-			);
+				} );
 		}
 	}
 

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -81,13 +81,15 @@ export default class Conversion {
 	 * If a given group name is used for the second time, the
 	 * {@link module:utils/ckeditorerror~CKEditorError `conversion-register-group-exists` error} is thrown.
 	 *
-	 * @param {String} groupName The name for dispatchers group.
-	 * @param {Array.<module:engine/conversion/downcastdispatcher~DowncastDispatcher|
-	 * module:engine/conversion/upcastdispatcher~UpcastDispatcher>} dispatchers Dispatchers to register
+	 * @param {Object} options
+	 * @param {String} options.name The name for dispatchers group.
+	 * @param {module:engine/conversion/downcastdispatcher~DowncastDispatcher|
+	 * module:engine/conversion/upcastdispatcher~UpcastDispatcher|Array.<module:engine/conversion/downcastdispatcher~DowncastDispatcher|
+	 * module:engine/conversion/upcastdispatcher~UpcastDispatcher>} options.dispatcher Dispatcher or array of dispatchers to register
 	 * under the given name.
 	 */
-	register( groupName, dispatchers ) {
-		if ( this._dispatchersGroups.has( groupName ) ) {
+	register( options ) {
+		if ( this._dispatchersGroups.has( options.name ) ) {
 			/**
 			 * Trying to register a group name that was already registered.
 			 *
@@ -97,11 +99,11 @@ export default class Conversion {
 		}
 
 		const group = {
-			name: groupName,
-			dispatchers
+			name: options.name,
+			dispatchers: Array.isArray( options.dispatcher ) ? options.dispatcher : [ options.dispatcher ]
 		};
 
-		this._dispatchersGroups.set( groupName, group );
+		this._dispatchersGroups.set( options.name, group );
 	}
 
 	/**

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -104,9 +104,9 @@ export default class Conversion {
 	 * {@link module:engine/conversion/conversion~ConversionHelpers conversion helpers} returned by this function.
 	 *
 	 *		editor.conversion.for( 'downcast' )
-	 *			.add( conversionHelperA )
-	 *			.add( conversionHelperB )
-	 *			.elementToElement( config );
+	 *			.add( conversionHelperA ) // Adds a custom converter A.
+	 *			.add( conversionHelperB ) // Adds a custom converter B.
+	 *			.elementToElement( config ); // Adds a custom element-to-element downcast converter.
 	 *
 	 * In this example `conversionHelperA` and `conversionHelperB` will be called for all dispatchers from the `'model'` group.
 	 *
@@ -129,6 +129,7 @@ export default class Conversion {
 	 * * {@link module:engine/conversion/upcast-converters~UpcastHelpers#elementToElement Upcast element-to-element converter},
 	 * * {@link module:engine/conversion/upcast-converters~UpcastHelpers#elementToAttribute Upcast attribute-to-element converter},
 	 * * {@link module:engine/conversion/upcast-converters~UpcastHelpers#attributeToAttribute Upcast attribute-to-attribute converter}.
+	 * * {@link module:engine/conversion/upcast-converters~UpcastHelpers#elementToMarker Upcast element-to-marker converter}.
 	 *
 	 * An example of using conversion helpers to convert the `paragraph` model element to the `p` view element (and back):
 	 *
@@ -142,7 +143,6 @@ export default class Conversion {
 	 * @param {String} groupName The name of dispatchers group to add the converters to.
 	 * @returns {module:engine/conversion/conversion~ConversionHelpers|module:engine/conversion/downcast-converters~DowncastHelpers|
 	 * module:engine/conversion/upcast-converters~UpcastHelpers}
-	 * An object with the `.add()` method, providing a way to add converters.
 	 */
 	/* eslint-enable max-len */
 	for( groupName ) {
@@ -593,7 +593,7 @@ export default class Conversion {
 /**
  * Base class for conversion utilises.
  *
- * @interface ConversionHelpers
+ * @interface module:engine/conversion/conversion~ConversionHelpers
  */
 
 /**
@@ -603,7 +603,8 @@ export default class Conversion {
  *
  * @method module:engine/conversion/conversion~ConversionHelpers#add
  * @param {Function} conversionHelper The function to be called on event.
- * @returns {module:engine/conversion/conversion~Conversion}
+ * @returns {module:engine/conversion/conversion~ConversionHelpers|module:engine/conversion/downcast-converters~DowncastHelpers|
+ * module:engine/conversion/upcast-converters~UpcastHelpers}
  */
 
 // Helper function for the `Conversion` `.add()` method.

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -87,6 +87,7 @@ export default class Conversion {
 	 * module:engine/conversion/upcastdispatcher~UpcastDispatcher|Array.<module:engine/conversion/downcastdispatcher~DowncastDispatcher|
 	 * module:engine/conversion/upcastdispatcher~UpcastDispatcher>} options.dispatcher Dispatcher or array of dispatchers to register
 	 * under the given name.
+	 * @param {module:engine/conversion/downcast-converters~DowncastHelpers} helpers
 	 */
 	register( options ) {
 		if ( this._dispatchersGroups.has( options.name ) ) {
@@ -150,7 +151,7 @@ export default class Conversion {
 	 *		conversion.for( 'downcast' ).add( conversion.customConverter( 'insert:paragraph', myConverter ) );
 	 *
 	 * @param {String} groupName The name of dispatchers group to add the converters to.
-	 * @returns {module:engine/conversion/downcast-converters~DowncastHelpers}
+	 * @returns {module:engine/conversion/conversion~ConversionHelpers|module:engine/conversion/downcast-converters~DowncastHelpers}
 	 * An object with the `.add()` method, providing a way to add converters.
 	 */
 	for( groupName ) {

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -149,18 +149,21 @@ export default class Conversion {
 	 *		conversion.for( 'downcast' ).add( conversion.customConverter( 'insert:paragraph', myConverter ) );
 	 *
 	 * @param {String} groupName The name of dispatchers group to add the converters to.
-	 * @returns {Object} An object with the `.add()` method, providing a way to add converters.
+	 * @returns {module:engine/conversion/downcast-converters~DowncastHelpers}
+	 * An object with the `.add()` method, providing a way to add converters.
 	 */
 	for( groupName ) {
-		const dispatchers = this._getDispatchers( groupName );
+		const { dispatchers, helpers } = this._getDispatchersGroup( groupName );
 
-		return {
+		const baseRetVal = {
 			add( conversionHelper ) {
 				_addToDispatchers( dispatchers, conversionHelper );
 
 				return this;
 			}
 		};
+
+		return Object.assign( {}, baseRetVal, helpers );
 	}
 
 	/**
@@ -549,17 +552,16 @@ export default class Conversion {
 	}
 
 	/**
-	 * Returns dispatchers registered under a given group name.
+	 * Returns dispatchers group registered under a given group name.
 	 *
 	 * If the given group name has not been registered, the
 	 * {@link module:utils/ckeditorerror~CKEditorError `conversion-for-unknown-group` error} is thrown.
 	 *
 	 * @private
 	 * @param {String} groupName
-	 * @returns {Array.<module:engine/conversion/downcastdispatcher~DowncastDispatcher|
-	 * module:engine/conversion/upcastdispatcher~UpcastDispatcher>}
+	 * @returns {module:engine/conversion/conversion~DispatchersGroup}
 	 */
-	_getDispatchers( groupName ) {
+	_getDispatchersGroup( groupName ) {
 		if ( !this._dispatchersGroups.has( groupName ) ) {
 			/**
 			 * Trying to add a converter to an unknown dispatchers group.
@@ -569,9 +571,7 @@ export default class Conversion {
 			throw new CKEditorError( 'conversion-for-unknown-group: Trying to add a converter to an unknown dispatchers group.' );
 		}
 
-		const { dispatchers } = this._dispatchersGroups.get( groupName );
-
-		return dispatchers;
+		return this._dispatchersGroups.get( groupName );
 	}
 }
 
@@ -590,6 +590,30 @@ export default class Conversion {
  * is an object that assigns these values (`upcastAlso` object keys) to {@link module:engine/view/matcher~MatcherPattern}s
  * (`upcastAlso` object values).
  * @property {module:utils/priorities~PriorityString} [converterPriority] The converter priority.
+ */
+
+/**
+ * @typedef {Object} module:engine/conversion/conversion~DispatchersGroup
+ * @property {String} name Group name
+ * @property {Array.<module:engine/conversion/downcastdispatcher~DowncastDispatcher|
+ * module:engine/conversion/upcastdispatcher~UpcastDispatcher>} dispatchers
+ * @property {module:engine/conversion/downcast-converters~DowncastHelpers} helpers
+ */
+
+/**
+ * Base class for conversion utilises.
+ *
+ * @interface ConversionHelpers
+ */
+
+/**
+ * Registers a conversion helper.
+ *
+ * **Note**: See full usage example in the `{@link module:engine/conversion/conversion~Conversion#for conversion.for()}` method description
+ *
+ * @method module:engine/conversion/conversion~ConversionHelpers#add
+ * @param {Function} conversionHelper The function to be called on event.
+ * @returns {module:engine/conversion/conversion~Conversion}
  */
 
 // Helper function for the `Conversion` `.add()` method.

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -10,12 +10,6 @@
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 import {
-	downcastElementToElement,
-	downcastAttributeToElement,
-	downcastAttributeToAttribute
-} from './downcast-converters';
-
-import {
 	upcastElementToElement,
 	upcastElementToAttribute,
 	upcastAttributeToAttribute
@@ -40,12 +34,12 @@ import {
  * method:
  *
  *		// Add a converter to editing downcast and data downcast.
- *		editor.conversion.for( 'downcast' ).add( downcastElementToElement( config ) );
+ *		editor.conversion.for( 'downcast' ).for( 'downcast' ).elementToElement( config ) );
  *
  *		// Add a converter to the data pipepline only:
- *		editor.conversion.for( 'dataDowncast' ).add( downcastElementToElement( dataConversionConfig ) );
+ *		editor.conversion.for( 'dataDowncast' ).for( 'downcast' ).elementToElement( dataConversionConfig ) );
  *		// And a slightly different one for the editing pipeline:
- *		editor.conversion.for( 'editingDowncast' ).add( downcastElementToElement( editingConversionConfig ) );
+ *		editor.conversion.for( 'editingDowncast' ).for( 'downcast' ).elementToElement( editingConversionConfig ) );
  *
  * The functions used in `add()` calls are one-way converters (i.e. you need to remember yourself to add
  * a converter in the other direction, if your feature requires that). They are also called "conversion helpers".
@@ -127,9 +121,9 @@ export default class Conversion {
 	 *
 	 * For downcast (model-to-view conversion), these are:
 	 *
-	 * * {@link module:engine/conversion/downcast-converters~downcastElementToElement Downcast element-to-element converter},
-	 * * {@link module:engine/conversion/downcast-converters~downcastAttributeToElement Downcast attribute-to-element converter},
-	 * * {@link module:engine/conversion/downcast-converters~downcastAttributeToAttribute Downcast attribute-to-attribute converter}.
+	 * * {@link module:engine/conversion/downcast-converters~_downcastElementToElement Downcast element-to-element converter},
+	 * * {@link module:engine/conversion/downcast-converters~_downcastAttributeToElement Downcast attribute-to-element converter},
+	 * * {@link module:engine/conversion/downcast-converters~_downcastAttributeToAttribute Downcast attribute-to-attribute converter}.
 	 *
 	 * For upcast (view-to-model conversion), these are:
 	 *
@@ -143,7 +137,7 @@ export default class Conversion {
 	 *		const config = { model: 'paragraph', view: 'p' };
 	 *
 	 *		// Add converters to proper dispatchers using conversion helpers.
-	 *		conversion.for( 'downcast' ).add( downcastElementToElement( config ) );
+	 *		conversion.for( 'downcast' ).for( 'downcast' ).elementToElement( config ) );
 	 *		conversion.for( 'upcast' ).add( upcastElementToElement( config ) );
 	 *
 	 * An example of providing a custom conversion helper that uses a custom converter function:
@@ -243,7 +237,7 @@ export default class Conversion {
 	 */
 	elementToElement( definition ) {
 		// Set up downcast converter.
-		this.for( 'downcast' ).add( downcastElementToElement( definition ) );
+		this.for( 'downcast' ).elementToElement( definition );
 
 		// Set up upcast converter.
 		for ( const { model, view } of _getAllUpcastDefinitions( definition ) ) {
@@ -416,7 +410,7 @@ export default class Conversion {
 	 */
 	attributeToElement( definition ) {
 		// Set up downcast converter.
-		this.for( 'downcast' ).add( downcastAttributeToElement( definition ) );
+		this.for( 'downcast' ).attributeToElement( definition );
 
 		// Set up upcast converter.
 		for ( const { model, view } of _getAllUpcastDefinitions( definition ) ) {
@@ -542,7 +536,7 @@ export default class Conversion {
 	 */
 	attributeToAttribute( definition ) {
 		// Set up downcast converter.
-		this.for( 'downcast' ).add( downcastAttributeToAttribute( definition ) );
+		this.for( 'downcast' ).attributeToAttribute( definition );
 
 		// Set up upcast converter.
 		for ( const { model, view } of _getAllUpcastDefinitions( definition ) ) {

--- a/src/conversion/conversion.js
+++ b/src/conversion/conversion.js
@@ -32,6 +32,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  *
  *		// Add a converter to the data pipepline only:
  *		editor.conversion.for( 'dataDowncast' ).elementToElement( dataConversionConfig ) );
+ *
  *		// And a slightly different one for the editing pipeline:
  *		editor.conversion.for( 'editingDowncast' ).elementToElement( editingConversionConfig ) );
  *

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -1278,5 +1278,56 @@ export const helpers = {
 	 */
 	attributeToAttribute( config ) {
 		return this.add( downcastAttributeToAttribute( config ) );
+	},
+
+	/**
+	 * Model marker to view element conversion helper.
+	 *
+	 * This conversion results in creating a view element on the boundaries of the converted marker. If the converted marker
+	 * is collapsed, only one element is created. For example, model marker set like this: `<paragraph>F[oo b]ar</paragraph>`
+	 * becomes `<p>F<span data-marker="search"></span>oo b<span data-marker="search"></span>ar</p>` in the view.
+	 *
+	 *		conversion.for( 'downcast' ).markerToElement( { model: 'search', view: 'marker-search' } );
+	 *
+	 *		conversion.for( 'downcast' ).markerToElement( { model: 'search', view: 'search-result', converterPriority: 'high' } );
+	 *
+	 *		conversion.for( 'downcast' ).markerToElement( {
+	 *			model: 'search',
+	 *			view: {
+	 *				name: 'span',
+	 *				attributes: {
+	 *					'data-marker': 'search'
+	 *				}
+	 *			}
+	 *		} );
+	 *
+	 *		conversion.for( 'downcast' ).markerToElement( {
+	 *			model: 'search',
+	 *			view: ( markerData, viewWriter ) => {
+	 *			return viewWriter.createUIElement( 'span', { 'data-marker': 'search', 'data-start': markerData.isOpening } );
+	 *			}
+	 *		} );
+	 *
+	 * If a function is passed as the `config.view` parameter, it will be used to generate both boundary elements. The function
+	 * receives the `data` object as a parameter and should return an instance of the
+	 * {@link module:engine/view/uielement~UIElement view UI element}. The `data` and `conversionApi` objects are passed from
+	 * {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:addMarker}. Additionally,
+	 * the `data.isOpening` parameter is passed, which is set to `true` for the marker start boundary element, and `false` to
+	 * the marker end boundary element.
+	 *
+	 * This kind of conversion is useful for saving data into the database, so it should be used in the data conversion pipeline.
+	 *
+	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add a converter to the conversion process.
+	 *
+	 * @method #markerToElement
+	 * @param {Object} config Conversion configuration.
+	 * @param {String} config.model The name of the model marker (or model marker group) to convert.
+	 * @param {module:engine/view/elementdefinition~ElementDefinition|Function} config.view A view element definition or a function
+	 * that takes the model marker data as a parameter and returns a view UI element.
+	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
+	 * @returns {Function} Conversion helper.
+	 */
+	markerToElement( config ) {
+		return this.add( downcastMarkerToElement( config ) );
 	}
 };

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -962,7 +962,7 @@ export function createViewElementFromHighlightDescriptor( descriptor ) {
  * @interface module:engine/conversion/downcast-converters~DowncastHelpers
  * @extends module:engine/conversion/conversion~ConversionHelpers
  */
-export const helpers = {
+export const downcastHelpers = {
 	/**
 	 * Model element to view element conversion helper.
 	 *

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -1204,10 +1204,10 @@ export const helpers = {
 	 *			}
 	 *		} );
 	 *
-	 * @method #attributeToElement
 	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
 	 * to the conversion process.
-	 * @method #attributeToAttribute
+	 *
+	 * @method #attributeToElement
 	 * @param {Object} config Conversion configuration.
 	 * @param {String|Object} config.model The key of the attribute to convert from or a `{ key, values }` object. `values` is an array
 	 * of `String`s with possible values if the model attribute is an enumerable.

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -22,27 +22,13 @@ import { cloneDeep } from 'lodash-es';
 /**
  * Model element to view element conversion helper.
  *
- * This conversion results in creating a view element. For example, model `<paragraph>Foo</paragraph>` becomes `<p>Foo</p>` in the view.
+ *		editor.conversion.for( 'downcast' )
+ *			.add( _downcastElementToElement( {
+ *				model: 'paragraph',
+ *				view: 'p'
+ *			} ) );
  *
- *		_downcastElementToElement( { model: 'paragraph', view: 'p' } );
- *
- *		_downcastElementToElement( { model: 'paragraph', view: 'div', converterPriority: 'high' } );
- *
- *		_downcastElementToElement( {
- *			model: 'fancyParagraph',
- *			view: {
- *				name: 'p',
- *				classes: 'fancy'
- *			}
- *		} );
- *
- *		_downcastElementToElement( {
- *			model: 'heading',
- *			view: ( modelElement, viewWriter ) => viewWriter.createContainerElement( 'h' + modelElement.getAttribute( 'level' ) )
- *		} );
- *
- * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
- * to the conversion process.
+ * The method is publicly available as {@link ~DowncastHelpers#elementToElement `.elementToElement()` downcast helper}.
  *
  * @protected
  * @param {Object} config Conversion configuration.
@@ -65,61 +51,13 @@ export function _downcastElementToElement( config ) {
 /**
  * Model attribute to view element conversion helper.
  *
- * This conversion results in wrapping view nodes with a view attribute element. For example, a model text node with
- * `"Foo"` as data and the `bold` attribute becomes `<strong>Foo</strong>` in the view.
+ *		editor.conversion.for( 'downcast' )
+ *			.add( _downcastAttributeToElement( {
+ *				model: 'bold',
+ *				view: 'strong'
+ *			} ) );
  *
- *		_downcastAttributeToElement( { model: 'bold', view: 'strong' } );
- *
- *		_downcastAttributeToElement( { model: 'bold', view: 'b', converterPriority: 'high' } );
- *
- *		_downcastAttributeToElement( {
- *			model: 'invert',
- *			view: {
- *				name: 'span',
- *				classes: [ 'font-light', 'bg-dark' ]
- *			}
- *		} );
- *
- *		_downcastAttributeToElement( {
- *			model: {
- *				key: 'fontSize',
- *				values: [ 'big', 'small' ]
- *			},
- *			view: {
- *				big: {
- *					name: 'span',
- *					styles: {
- *						'font-size': '1.2em'
- *					}
- *				},
- *				small: {
- *					name: 'span',
- *					styles: {
- *						'font-size': '0.8em'
- *					}
- *				}
- *			}
- *		} );
- *
- *		_downcastAttributeToElement( {
- *			model: 'bold',
- *				view: ( modelAttributeValue, viewWriter ) => {
- *				return viewWriter.createAttributeElement( 'span', { style: 'font-weight:' + modelAttributeValue } );
- *			}
- *		} );
- *
- *		_downcastAttributeToElement( {
- *			model: {
- *				key: 'color',
- *				name: '$text'
- *			},
- *			view: ( modelAttributeValue, viewWriter ) => {
- *				return viewWriter.createAttributeElement( 'span', { style: 'color:' + modelAttributeValue } );
- *			}
- *		} );
- *
- * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
- * to the conversion process.
+ * The method is publicly available as {@link ~DowncastHelpers#attributeToElement `.attributeToElement()` downcast helper}.
  *
  * @protected
  * @param {Object} config Conversion configuration.
@@ -160,45 +98,13 @@ export function _downcastAttributeToElement( config ) {
 /**
  * Model attribute to view attribute conversion helper.
  *
- * This conversion results in adding an attribute to a view node, basing on an attribute from a model node. For example,
- * `<image src='foo.jpg'></image>` is converted to `<img src='foo.jpg'></img>`.
+ *		editor.conversion.for( 'downcast' )
+ *			.add( _downcastAttributeToAttribute( {
+ *				model: 'source',
+ *				view: 'src'
+ *			} ) );
  *
- *		_downcastAttributeToAttribute( { model: 'source', view: 'src' } );
- *
- *		_downcastAttributeToAttribute( { model: 'source', view: 'href', converterPriority: 'high' } );
- *
- *		_downcastAttributeToAttribute( {
- *			model: {
- *				name: 'image',
- *				key: 'source'
- *			},
- *			view: 'src'
- *		} );
- *
- *		_downcastAttributeToAttribute( {
- *			model: {
- *				name: 'styled',
- *				values: [ 'dark', 'light' ]
- *			},
- *			view: {
- *				dark: {
- *					key: 'class',
- *					value: [ 'styled', 'styled-dark' ]
- *				},
- *				light: {
- *					key: 'class',
- *					value: [ 'styled', 'styled-light' ]
- *				}
- *			}
- *		} );
- *
- *		_downcastAttributeToAttribute( {
- *			model: 'styled',
- *			view: modelAttributeValue => ( { key: 'class', value: 'styled-' + modelAttributeValue } )
- *		} );
- *
- * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
- * to the conversion process.
+ * The method is publicly available as {@link ~DowncastHelpers#attributeToAttribute `.attributeToAttribute()` downcast helper}.
  *
  * @protected
  * @param {Object} config Conversion configuration.
@@ -240,41 +146,13 @@ export function _downcastAttributeToAttribute( config ) {
 /**
  * Model marker to view element conversion helper.
  *
- * This conversion results in creating a view element on the boundaries of the converted marker. If the converted marker
- * is collapsed, only one element is created. For example, model marker set like this: `<paragraph>F[oo b]ar</paragraph>`
- * becomes `<p>F<span data-marker="search"></span>oo b<span data-marker="search"></span>ar</p>` in the view.
+ *		editor.conversion.for( 'downcast' )
+ *			.add( _downcastMarkerToElement( {
+ *				model: 'search',
+ *				view: 'marker-search'
+ *			} ) );
  *
- *		_downcastMarkerToElement( { model: 'search', view: 'marker-search' } );
- *
- *		_downcastMarkerToElement( { model: 'search', view: 'search-result', converterPriority: 'high' } );
- *
- *		_downcastMarkerToElement( {
- *			model: 'search',
- *			view: {
- *				name: 'span',
- *				attributes: {
- *					'data-marker': 'search'
- *				}
- *			}
- *		} );
- *
- *		_downcastMarkerToElement( {
- *			model: 'search',
- *			view: ( markerData, viewWriter ) => {
- *			return viewWriter.createUIElement( 'span', { 'data-marker': 'search', 'data-start': markerData.isOpening } );
- *			}
- *		} );
- *
- * If a function is passed as the `config.view` parameter, it will be used to generate both boundary elements. The function
- * receives the `data` object as a parameter and should return an instance of the
- * {@link module:engine/view/uielement~UIElement view UI element}. The `data` and `conversionApi` objects are passed from
- * {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:addMarker}. Additionally,
- * the `data.isOpening` parameter is passed, which is set to `true` for the marker start boundary element, and `false` to
- * the marker end boundary element.
- *
- * This kind of conversion is useful for saving data into the database, so it should be used in the data conversion pipeline.
- *
- * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add a converter to the conversion process.
+ * The method is publicly available as {@link ~DowncastHelpers#markerToElement `.markerToElement()` downcast helper}.
  *
  * @protected
  * @param {Object} config Conversion configuration.
@@ -298,44 +176,13 @@ export function _downcastMarkerToElement( config ) {
 /**
  * Model marker to highlight conversion helper.
  *
- * This conversion results in creating a highlight on view nodes. For this kind of conversion,
- * {@link module:engine/conversion/downcast-converters~HighlightDescriptor} should be provided.
+ *		editor.conversion.for( 'downcast' )
+ *			.add( _downcastMarkerToHighlight( {
+ *				model: 'comment',
+ *				view: { classes: 'comment' }
+ *			} ) );
  *
- * For text nodes, a `<span>` {@link module:engine/view/attributeelement~AttributeElement} is created and it wraps all text nodes
- * in the converted marker range. For example, a model marker set like this: `<paragraph>F[oo b]ar</paragraph>` becomes
- * `<p>F<span class="comment">oo b</span>ar</p>` in the view.
- *
- * {@link module:engine/view/containerelement~ContainerElement} may provide a custom way of handling highlight. Most often,
- * the element itself is given classes and attributes described in the highlight descriptor (instead of being wrapped in `<span>`).
- * For example, a model marker set like this: `[<image src="foo.jpg"></image>]` becomes `<img src="foo.jpg" class="comment"></img>`
- * in the view.
- *
- * For container elements, the conversion is two-step. While the converter processes the highlight descriptor and passes it
- * to a container element, it is the container element instance itself that applies values from the highlight descriptor.
- * So, in a sense, the converter takes care of stating what should be applied on what, while the element decides how to apply that.
- *
- *		downcastMarkerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
- *
- *		downcastMarkerToHighlight( { model: 'comment', view: { classes: 'new-comment' }, converterPriority: 'high' } );
- *
- *		downcastMarkerToHighlight( {
- *			model: 'comment',
- *			view: data => {
- *				// Assuming that the marker name is in a form of comment:commentType.
- *				const commentType = data.markerName.split( ':' )[ 1 ];
- *
- *				return {
- *					classes: [ 'comment', 'comment-' + commentType ]
- *				};
- *			}
- *		} );
- *
- * If a function is passed as the `config.view` parameter, it will be used to generate the highlight descriptor. The function
- * receives the `data` object as a parameter and should return a
- * {@link module:engine/conversion/downcast-converters~HighlightDescriptor highlight descriptor}.
- * The `data` object properties are passed from {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:addMarker}.
- *
- * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add a converter to the conversion process.
+ * The method is publicly available as {@link ~DowncastHelpers#markerToElement `.markerToElement()` downcast helper}.
  *
  * @protected
  * @param {Object} config Conversion configuration.
@@ -715,7 +562,7 @@ export function changeAttribute( attributeCreator ) {
 			 * {@link module:engine/conversion/conversion~Conversion#attributeToElement `Attribute to Element converter`}
 			 * with higher {@link module:utils/priorities~PriorityString priority} must also be defined:
 			 *
-			 *		conversion.for( 'downcast' ).attributeToElement( {
+			 *		editor.conversion.for( 'downcast' ).attributeToElement( {
 			 *			model: {
 			 *				key: 'attribute-name',
 			 *				name: '$text'
@@ -1121,9 +968,16 @@ export const helpers = {
 	 *
 	 * This conversion results in creating a view element. For example, model `<paragraph>Foo</paragraph>` becomes `<p>Foo</p>` in the view.
 	 *
-	 *		editor.conversion.for( 'downcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
+	 *		editor.conversion.for( 'downcast' ).elementToElement( {
+	 *			model: 'paragraph',
+	 *			view: 'p'
+	 *		} );
 	 *
-	 *		editor.conversion.for( 'downcast' ).elementToElement( { model: 'paragraph', view: 'div', converterPriority: 'high' } );
+	 *		editor.conversion.for( 'downcast' ).elementToElement( {
+	 *			model: 'paragraph',
+	 *			view: 'div',
+	 *			converterPriority: 'high'
+	 *		} );
 	 *
 	 *		editor.conversion.for( 'downcast' ).elementToElement( {
 	 *			model: 'fancyParagraph',
@@ -1135,7 +989,9 @@ export const helpers = {
 	 *
 	 *		editor.conversion.for( 'downcast' ).elementToElement( {
 	 *			model: 'heading',
-	 *			view: ( modelElement, viewWriter ) => viewWriter.createContainerElement( 'h' + modelElement.getAttribute( 'level' ) )
+	 *			view: ( modelElement, viewWriter ) => {
+	 *				return viewWriter.createContainerElement( 'h' + modelElement.getAttribute( 'level' ) )
+	 *			}
 	 *		} );
 	 *
 	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
@@ -1159,9 +1015,16 @@ export const helpers = {
 	 * This conversion results in wrapping view nodes with a view attribute element. For example, a model text node with
 	 * `"Foo"` as data and the `bold` attribute becomes `<strong>Foo</strong>` in the view.
 	 *
-	 *		editor.conversion.for( 'downcast' ).attributeToElement( { model: 'bold', view: 'strong' } );
+	 *		editor.conversion.for( 'downcast' ).attributeToElement( {
+	 *			model: 'bold',
+	 *			view: 'strong'
+	 *		} );
 	 *
-	 *		editor.conversion.for( 'downcast' ).attributeToElement( { model: 'bold', view: 'b', converterPriority: 'high' } );
+	 *		editor.conversion.for( 'downcast' ).attributeToElement( {
+	 *			model: 'bold',
+	 *			view: 'b',
+	 *			converterPriority: 'high'
+	 *		} );
 	 *
 	 *		editor.conversion.for( 'downcast' ).attributeToElement( {
 	 *			model: 'invert',
@@ -1195,7 +1058,9 @@ export const helpers = {
 	 *		editor.conversion.for( 'downcast' ).attributeToElement( {
 	 *			model: 'bold',
 	 *			view: ( modelAttributeValue, viewWriter ) => {
-	 *				return viewWriter.createAttributeElement( 'span', { style: 'font-weight:' + modelAttributeValue } );
+	 *				return viewWriter.createAttributeElement( 'span', {
+	 *					style: 'font-weight:' + modelAttributeValue
+	 *				} );
 	 *			}
 	 *		} );
 	 *
@@ -1205,7 +1070,9 @@ export const helpers = {
 	 *				name: '$text'
 	 *			},
 	 *			view: ( modelAttributeValue, viewWriter ) => {
-	 *				return viewWriter.createAttributeElement( 'span', { style: 'color:' + modelAttributeValue } );
+	 *				return viewWriter.createAttributeElement( 'span', {
+	 *					style: 'color:' + modelAttributeValue
+	 *				} );
 	 *			}
 	 *		} );
 	 *
@@ -1232,11 +1099,18 @@ export const helpers = {
 	 * This conversion results in adding an attribute to a view node, basing on an attribute from a model node. For example,
 	 * `<image src='foo.jpg'></image>` is converted to `<img src='foo.jpg'></img>`.
 	 *
-	 *		conversion.for( 'downcast' ).attributeToAttribute( { model: 'source', view: 'src' } );
+	 *		editor.conversion.for( 'downcast' ).attributeToAttribute( {
+	 *			model: 'source',
+	 *			view: 'src'
+	 *		} );
 	 *
-	 *		conversion.for( 'downcast' ).attributeToAttribute( { model: 'source', view: 'href', converterPriority: 'high' } );
+	 *		editor.conversion.for( 'downcast' ).attributeToAttribute( {
+	 *			model: 'source',
+	 *			view: 'href',
+	 *			converterPriority: 'high'
+	 *		} );
 	 *
-	 *		conversion.for( 'downcast' ).attributeToAttribute( {
+	 *		editor.conversion.for( 'downcast' ).attributeToAttribute( {
 	 *			model: {
 	 *				name: 'image',
 	 *				key: 'source'
@@ -1244,7 +1118,7 @@ export const helpers = {
 	 *			view: 'src'
 	 *		} );
 	 *
-	 *		conversion.for( 'downcast' ).attributeToAttribute( {
+	 *		editor.conversion.for( 'downcast' ).attributeToAttribute( {
 	 *			model: {
 	 *				name: 'styled',
 	 *				values: [ 'dark', 'light' ]
@@ -1261,7 +1135,7 @@ export const helpers = {
 	 *			}
 	 *		} );
 	 *
-	 *		conversion.for( 'downcast' ).attributeToAttribute( {
+	 *		editor.conversion.for( 'downcast' ).attributeToAttribute( {
 	 *			model: 'styled',
 	 *			view: modelAttributeValue => ( { key: 'class', value: 'styled-' + modelAttributeValue } )
 	 *		} );
@@ -1292,11 +1166,18 @@ export const helpers = {
 	 * is collapsed, only one element is created. For example, model marker set like this: `<paragraph>F[oo b]ar</paragraph>`
 	 * becomes `<p>F<span data-marker="search"></span>oo b<span data-marker="search"></span>ar</p>` in the view.
 	 *
-	 *		conversion.for( 'downcast' ).markerToElement( { model: 'search', view: 'marker-search' } );
+	 *		editor.conversion.for( 'downcast' ).markerToElement( {
+	 *			model: 'search',
+	 *			view: 'marker-search'
+	 *		} );
 	 *
-	 *		conversion.for( 'downcast' ).markerToElement( { model: 'search', view: 'search-result', converterPriority: 'high' } );
+	 *		editor.conversion.for( 'downcast' ).markerToElement( {
+	 *			model: 'search',
+	 *			view: 'search-result',
+	 *			converterPriority: 'high'
+	 *		} );
 	 *
-	 *		conversion.for( 'downcast' ).markerToElement( {
+	 *		editor.conversion.for( 'downcast' ).markerToElement( {
 	 *			model: 'search',
 	 *			view: {
 	 *				name: 'span',
@@ -1306,10 +1187,13 @@ export const helpers = {
 	 *			}
 	 *		} );
 	 *
-	 *		conversion.for( 'downcast' ).markerToElement( {
+	 *		editor.conversion.for( 'downcast' ).markerToElement( {
 	 *			model: 'search',
 	 *			view: ( markerData, viewWriter ) => {
-	 *			return viewWriter.createUIElement( 'span', { 'data-marker': 'search', 'data-start': markerData.isOpening } );
+	 *				return viewWriter.createUIElement( 'span', {
+	 *					'data-marker': 'search',
+	 *					'data-start': markerData.isOpening
+	 *				} );
 	 *			}
 	 *		} );
 	 *
@@ -1322,7 +1206,8 @@ export const helpers = {
 	 *
 	 * This kind of conversion is useful for saving data into the database, so it should be used in the data conversion pipeline.
 	 *
-	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add a converter to the conversion process.
+	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
+	 * to the conversion process.
 	 *
 	 * @method #markerToElement
 	 * @param {Object} config Conversion configuration.
@@ -1355,15 +1240,15 @@ export const helpers = {
 	 * to a container element, it is the container element instance itself that applies values from the highlight descriptor.
 	 * So, in a sense, the converter takes care of stating what should be applied on what, while the element decides how to apply that.
 	 *
-	 *		conversion.for( 'downcast' ).markerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
+	 *		editor.conversion.for( 'downcast' ).markerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
 	 *
-	 *		conversion.for( 'downcast' ).markerToHighlight( {
+	 *		editor.conversion.for( 'downcast' ).markerToHighlight( {
 	 *			model: 'comment',
 	 *			view: { classes: 'new-comment' },
 	 *			converterPriority: 'high'
 	 *		} );
 	 *
-	 *		conversion.for( 'downcast' ).markerToHighlight( {
+	 *		editor.conversion.for( 'downcast' ).markerToHighlight( {
 	 *			model: 'comment',
 	 *			view: data => {
 	 *				// Assuming that the marker name is in a form of comment:commentType.
@@ -1380,7 +1265,8 @@ export const helpers = {
 	 * {@link module:engine/conversion/downcast-converters~HighlightDescriptor highlight descriptor}.
 	 * The `data` object properties are passed from {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:addMarker}.
 	 *
-	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add a converter to the conversion process.
+	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
+	 * to the conversion process.
 	 *
 	 * @method #markerToHighlight
 	 * @param {Object} config Conversion configuration.

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -1145,5 +1145,78 @@ export const helpers = {
 	 */
 	elementToElement( config ) {
 		return this.add( downcastElementToElement( config ) );
+	},
+
+	/**
+	 * Model attribute to view element conversion helper.
+	 *
+	 *
+	 * This conversion results in wrapping view nodes with a view attribute element. For example, a model text node with
+	 * `"Foo"` as data and the `bold` attribute becomes `<strong>Foo</strong>` in the view.
+	 *
+	 *		editor.conversion.for( 'downcast' ).attributeToElement( { model: 'bold', view: 'strong' } );
+	 *
+	 *		editor.conversion.for( 'downcast' ).attributeToElement( { model: 'bold', view: 'b', converterPriority: 'high' } );
+	 *
+	 *		editor.conversion.for( 'downcast' ).attributeToElement( {
+	 *			model: 'invert',
+	 *			view: {
+	 *				name: 'span',
+	 *				classes: [ 'font-light', 'bg-dark' ]
+	 *			}
+	 *		} );
+	 *
+	 *		editor.conversion.for( 'downcast' ).attributeToElement( {
+	 *			model: {
+	 *				key: 'fontSize',
+	 *				values: [ 'big', 'small' ]
+	 *			},
+	 *			view: {
+	 *				big: {
+	 *					name: 'span',
+	 *					styles: {
+	 *						'font-size': '1.2em'
+	 *					}
+	 *				},
+	 *				small: {
+	 *					name: 'span',
+	 *					styles: {
+	 *						'font-size': '0.8em'
+	 *					}
+	 *				}
+	 *			}
+	 *		} );
+	 *
+	 *		editor.conversion.for( 'downcast' ).attributeToElement( {
+	 *			model: 'bold',
+	 *			view: ( modelAttributeValue, viewWriter ) => {
+	 *				return viewWriter.createAttributeElement( 'span', { style: 'font-weight:' + modelAttributeValue } );
+	 *			}
+	 *		} );
+	 *
+	 *		editor.conversion.for( 'downcast' ).attributeToElement( {
+	 *			model: {
+	 *				key: 'color',
+	 *				name: '$text'
+	 *			},
+	 *			view: ( modelAttributeValue, viewWriter ) => {
+	 *				return viewWriter.createAttributeElement( 'span', { style: 'color:' + modelAttributeValue } );
+	 *			}
+	 *		} );
+	 *
+	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
+	 * to the conversion process.
+	 * @method #attributeToAttribute
+	 * @param {Object} config Conversion configuration.
+	 * @param {String|Object} config.model The key of the attribute to convert from or a `{ key, values }` object. `values` is an array
+	 * of `String`s with possible values if the model attribute is an enumerable.
+	 * @param {module:engine/view/elementdefinition~ElementDefinition|Function|Object} config.view A view element definition or a function
+	 * that takes the model attribute value and {@link module:engine/view/downcastwriter~DowncastWriter view downcast writer}
+	 * as parameters and returns a view attribute element. If `config.model.values` is
+	 * given, `config.view` should be an object assigning values from `config.model.values` to view element definitions or functions.
+	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
+	 */
+	attributeToElement( config ) {
+		return this.add( downcastAttributeToElement( config ) );
 	}
 };

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -36,10 +36,10 @@ import { cloneDeep } from 'lodash-es';
  *			}
  *		} );
  *
- * 		downcastElementToElement( {
- * 			model: 'heading',
- * 			view: ( modelElement, viewWriter ) => viewWriter.createContainerElement( 'h' + modelElement.getAttribute( 'level' ) )
- * 		} );
+ *		downcastElementToElement( {
+ *			model: 'heading',
+ *			view: ( modelElement, viewWriter ) => viewWriter.createContainerElement( 'h' + modelElement.getAttribute( 'level' ) )
+ *		} );
  *
  * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
  * to the conversion process.
@@ -100,12 +100,12 @@ export function downcastElementToElement( config ) {
  *			}
  *		} );
  *
- * 		downcastAttributeToElement( {
- * 			model: 'bold',
- * 			view: ( modelAttributeValue, viewWriter ) => {
- * 				return viewWriter.createAttributeElement( 'span', { style: 'font-weight:' + modelAttributeValue } );
- * 			}
- * 		} );
+ *		downcastAttributeToElement( {
+ *			model: 'bold',
+ *				view: ( modelAttributeValue, viewWriter ) => {
+ *				return viewWriter.createAttributeElement( 'span', { style: 'font-weight:' + modelAttributeValue } );
+ *			}
+ *		} );
  *
  *		downcastAttributeToElement( {
  *			model: {
@@ -255,12 +255,12 @@ export function downcastAttributeToAttribute( config ) {
  *			}
  *		} );
  *
- * 		downcastMarkerToElement( {
- * 			model: 'search',
- * 			view: ( markerData, viewWriter ) => {
- *	 			return viewWriter.createUIElement( 'span', { 'data-marker': 'search', 'data-start': markerData.isOpening } );
- * 			}
- * 		} );
+ *		downcastMarkerToElement( {
+ *			model: 'search',
+ *			view: ( markerData, viewWriter ) => {
+ *			return viewWriter.createUIElement( 'span', { 'data-marker': 'search', 'data-start': markerData.isOpening } );
+ *			}
+ *		} );
  *
  * If a function is passed as the `config.view` parameter, it will be used to generate both boundary elements. The function
  * receives the `data` object as a parameter and should return an instance of the
@@ -314,17 +314,17 @@ export function downcastMarkerToElement( config ) {
  *
  *		downcastMarkerToHighlight( { model: 'comment', view: { classes: 'new-comment' }, converterPriority: 'high' } );
  *
- * 		downcastMarkerToHighlight( {
- * 			model: 'comment',
- * 			view: data => {
- * 				// Assuming that the marker name is in a form of comment:commentType.
- *	 			const commentType = data.markerName.split( ':' )[ 1 ];
+ *		downcastMarkerToHighlight( {
+ *			model: 'comment',
+ *			view: data => {
+ *				// Assuming that the marker name is in a form of comment:commentType.
+ *				const commentType = data.markerName.split( ':' )[ 1 ];
  *
- *	 			return {
- *	 				classes: [ 'comment', 'comment-' + commentType ]
- *	 			};
- * 			}
- * 		} );
+ *				return {
+ *					classes: [ 'comment', 'comment-' + commentType ]
+ *				};
+ *			}
+ *		} );
  *
  * If a function is passed as the `config.view` parameter, it will be used to generate the highlight descriptor. The function
  * receives the `data` object as a parameter and should return a
@@ -1107,13 +1107,42 @@ export function createViewElementFromHighlightDescriptor( descriptor ) {
 /**
  * Downcast conversion helper functions.
  *
- * @typedef {Object} DowncastHelpers
+ * @interface module:engine/conversion/downcast-converters~DowncastHelpers
  */
 export const helpers = {
-	elementToElement: downcastElementToElement,
-	attributeToElement: downcastAttributeToElement,
-	attributeToAttribute: downcastAttributeToAttribute,
-	markerToElement: downcastMarkerToElement,
-	markerToHighlight: downcastMarkerToHighlight,
-	createViewElementFromHighlightDescriptor
+	/**
+	 * Model element to view element conversion helper.
+	 *
+	 * This conversion results in creating a view element. For example, model `<paragraph>Foo</paragraph>` becomes `<p>Foo</p>` in the view.
+	 *
+	 *		editor.conversion.for( 'downcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
+	 *
+	 *		editor.conversion.for( 'downcast' ).elementToElement( { model: 'paragraph', view: 'div', converterPriority: 'high' } );
+	 *
+	 *		editor.conversion.for( 'downcast' ).elementToElement( {
+	 *			model: 'fancyParagraph',
+	 *			view: {
+	 *				name: 'p',
+	 *				classes: 'fancy'
+	 *			}
+	 *		} );
+	 *
+	 *		editor.conversion.for( 'downcast' ).elementToElement( {
+	 *			model: 'heading',
+	 *			view: ( modelElement, viewWriter ) => viewWriter.createContainerElement( 'h' + modelElement.getAttribute( 'level' ) )
+	 *		} );
+	 *
+	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
+	 * to the conversion process.
+	 *
+	 * @method #elementToElement
+	 * @param {Object} config Conversion configuration.
+	 * @param {String} config.model The name of the model element to convert.
+	 * @param {module:engine/view/elementdefinition~ElementDefinition|Function} config.view A view element definition or a function
+	 * that takes the model element and {@link module:engine/view/downcastwriter~DowncastWriter view downcast writer}
+	 * as parameters and returns a view container element.
+	 */
+	elementToElement( config ) {
+		return this.add( downcastElementToElement( config ) );
+	}
 };

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -24,11 +24,11 @@ import { cloneDeep } from 'lodash-es';
  *
  * This conversion results in creating a view element. For example, model `<paragraph>Foo</paragraph>` becomes `<p>Foo</p>` in the view.
  *
- *		downcastElementToElement( { model: 'paragraph', view: 'p' } );
+ *		_downcastElementToElement( { model: 'paragraph', view: 'p' } );
  *
- *		downcastElementToElement( { model: 'paragraph', view: 'div', converterPriority: 'high' } );
+ *		_downcastElementToElement( { model: 'paragraph', view: 'div', converterPriority: 'high' } );
  *
- *		downcastElementToElement( {
+ *		_downcastElementToElement( {
  *			model: 'fancyParagraph',
  *			view: {
  *				name: 'p',
@@ -36,7 +36,7 @@ import { cloneDeep } from 'lodash-es';
  *			}
  *		} );
  *
- *		downcastElementToElement( {
+ *		_downcastElementToElement( {
  *			model: 'heading',
  *			view: ( modelElement, viewWriter ) => viewWriter.createContainerElement( 'h' + modelElement.getAttribute( 'level' ) )
  *		} );
@@ -44,6 +44,7 @@ import { cloneDeep } from 'lodash-es';
  * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
  * to the conversion process.
  *
+ * @protected
  * @param {Object} config Conversion configuration.
  * @param {String} config.model The name of the model element to convert.
  * @param {module:engine/view/elementdefinition~ElementDefinition|Function} config.view A view element definition or a function
@@ -51,7 +52,7 @@ import { cloneDeep } from 'lodash-es';
  * as parameters and returns a view container element.
  * @returns {Function} Conversion helper.
  */
-export function downcastElementToElement( config ) {
+export function _downcastElementToElement( config ) {
 	config = cloneDeep( config );
 
 	config.view = _normalizeToElementConfig( config.view, 'container' );
@@ -67,11 +68,11 @@ export function downcastElementToElement( config ) {
  * This conversion results in wrapping view nodes with a view attribute element. For example, a model text node with
  * `"Foo"` as data and the `bold` attribute becomes `<strong>Foo</strong>` in the view.
  *
- *		downcastAttributeToElement( { model: 'bold', view: 'strong' } );
+ *		_downcastAttributeToElement( { model: 'bold', view: 'strong' } );
  *
- *		downcastAttributeToElement( { model: 'bold', view: 'b', converterPriority: 'high' } );
+ *		_downcastAttributeToElement( { model: 'bold', view: 'b', converterPriority: 'high' } );
  *
- *		downcastAttributeToElement( {
+ *		_downcastAttributeToElement( {
  *			model: 'invert',
  *			view: {
  *				name: 'span',
@@ -79,7 +80,7 @@ export function downcastElementToElement( config ) {
  *			}
  *		} );
  *
- *		downcastAttributeToElement( {
+ *		_downcastAttributeToElement( {
  *			model: {
  *				key: 'fontSize',
  *				values: [ 'big', 'small' ]
@@ -100,14 +101,14 @@ export function downcastElementToElement( config ) {
  *			}
  *		} );
  *
- *		downcastAttributeToElement( {
+ *		_downcastAttributeToElement( {
  *			model: 'bold',
  *				view: ( modelAttributeValue, viewWriter ) => {
  *				return viewWriter.createAttributeElement( 'span', { style: 'font-weight:' + modelAttributeValue } );
  *			}
  *		} );
  *
- *		downcastAttributeToElement( {
+ *		_downcastAttributeToElement( {
  *			model: {
  *				key: 'color',
  *				name: '$text'
@@ -120,6 +121,7 @@ export function downcastElementToElement( config ) {
  * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
  * to the conversion process.
  *
+ * @protected
  * @param {Object} config Conversion configuration.
  * @param {String|Object} config.model The key of the attribute to convert from or a `{ key, values }` object. `values` is an array
  * of `String`s with possible values if the model attribute is an enumerable.
@@ -130,7 +132,7 @@ export function downcastElementToElement( config ) {
  * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
  * @returns {Function} Conversion helper.
  */
-export function downcastAttributeToElement( config ) {
+export function _downcastAttributeToElement( config ) {
 	config = cloneDeep( config );
 
 	const modelKey = config.model.key ? config.model.key : config.model;
@@ -161,11 +163,11 @@ export function downcastAttributeToElement( config ) {
  * This conversion results in adding an attribute to a view node, basing on an attribute from a model node. For example,
  * `<image src='foo.jpg'></image>` is converted to `<img src='foo.jpg'></img>`.
  *
- *		downcastAttributeToAttribute( { model: 'source', view: 'src' } );
+ *		_downcastAttributeToAttribute( { model: 'source', view: 'src' } );
  *
- *		downcastAttributeToAttribute( { model: 'source', view: 'href', converterPriority: 'high' } );
+ *		_downcastAttributeToAttribute( { model: 'source', view: 'href', converterPriority: 'high' } );
  *
- *		downcastAttributeToAttribute( {
+ *		_downcastAttributeToAttribute( {
  *			model: {
  *				name: 'image',
  *				key: 'source'
@@ -173,7 +175,7 @@ export function downcastAttributeToElement( config ) {
  *			view: 'src'
  *		} );
  *
- *		downcastAttributeToAttribute( {
+ *		_downcastAttributeToAttribute( {
  *			model: {
  *				name: 'styled',
  *				values: [ 'dark', 'light' ]
@@ -190,7 +192,7 @@ export function downcastAttributeToElement( config ) {
  *			}
  *		} );
  *
- *		downcastAttributeToAttribute( {
+ *		_downcastAttributeToAttribute( {
  *			model: 'styled',
  *			view: modelAttributeValue => ( { key: 'class', value: 'styled-' + modelAttributeValue } )
  *		} );
@@ -198,6 +200,7 @@ export function downcastAttributeToElement( config ) {
  * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
  * to the conversion process.
  *
+ * @protected
  * @param {Object} config Conversion configuration.
  * @param {String|Object} config.model The key of the attribute to convert from or a `{ key, values, [ name ] }` object describing
  * the attribute key, possible values and, optionally, an element name to convert from.
@@ -209,7 +212,7 @@ export function downcastAttributeToElement( config ) {
  * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
  * @returns {Function} Conversion helper.
  */
-export function downcastAttributeToAttribute( config ) {
+export function _downcastAttributeToAttribute( config ) {
 	config = cloneDeep( config );
 
 	const modelKey = config.model.key ? config.model.key : config.model;
@@ -241,11 +244,11 @@ export function downcastAttributeToAttribute( config ) {
  * is collapsed, only one element is created. For example, model marker set like this: `<paragraph>F[oo b]ar</paragraph>`
  * becomes `<p>F<span data-marker="search"></span>oo b<span data-marker="search"></span>ar</p>` in the view.
  *
- *		downcastMarkerToElement( { model: 'search', view: 'marker-search' } );
+ *		_downcastMarkerToElement( { model: 'search', view: 'marker-search' } );
  *
- *		downcastMarkerToElement( { model: 'search', view: 'search-result', converterPriority: 'high' } );
+ *		_downcastMarkerToElement( { model: 'search', view: 'search-result', converterPriority: 'high' } );
  *
- *		downcastMarkerToElement( {
+ *		_downcastMarkerToElement( {
  *			model: 'search',
  *			view: {
  *				name: 'span',
@@ -255,7 +258,7 @@ export function downcastAttributeToAttribute( config ) {
  *			}
  *		} );
  *
- *		downcastMarkerToElement( {
+ *		_downcastMarkerToElement( {
  *			model: 'search',
  *			view: ( markerData, viewWriter ) => {
  *			return viewWriter.createUIElement( 'span', { 'data-marker': 'search', 'data-start': markerData.isOpening } );
@@ -273,6 +276,7 @@ export function downcastAttributeToAttribute( config ) {
  *
  * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add a converter to the conversion process.
  *
+ * @protected
  * @param {Object} config Conversion configuration.
  * @param {String} config.model The name of the model marker (or model marker group) to convert.
  * @param {module:engine/view/elementdefinition~ElementDefinition|Function} config.view A view element definition or a function
@@ -280,7 +284,7 @@ export function downcastAttributeToAttribute( config ) {
  * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
  * @returns {Function} Conversion helper.
  */
-export function downcastMarkerToElement( config ) {
+export function _downcastMarkerToElement( config ) {
 	config = cloneDeep( config );
 
 	config.view = _normalizeToElementConfig( config.view, 'ui' );
@@ -333,6 +337,7 @@ export function downcastMarkerToElement( config ) {
  *
  * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add a converter to the conversion process.
  *
+ * @protected
  * @param {Object} config Conversion configuration.
  * @param {String} config.model The name of the model marker (or model marker group) to convert.
  * @param {module:engine/conversion/downcast-converters~HighlightDescriptor|Function} config.view A highlight descriptor
@@ -340,7 +345,7 @@ export function downcastMarkerToElement( config ) {
  * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
  * @returns {Function} Conversion helper.
  */
-export function downcastMarkerToHighlight( config ) {
+export function _downcastMarkerToHighlight( config ) {
 	return dispatcher => {
 		dispatcher.on( 'addMarker:' + config.model, highlightText( config.view ), { priority: config.converterPriority || 'normal' } );
 		dispatcher.on( 'addMarker:' + config.model, highlightElement( config.view ), { priority: config.converterPriority || 'normal' } );
@@ -694,7 +699,7 @@ export function changeAttribute( attributeCreator ) {
 			 * by {@link module:engine/conversion/conversion~Conversion#attributeToAttribute `Attribute to Attribute converter`}.
 			 * In most cases it is caused by converters misconfiguration when only "generic" converter is defined:
 			 *
-			 *		editor.conversion.for( 'downcast' ).add( downcastAttributeToAttribute( {
+			 *		editor.conversion.for( 'downcast' ).attributeToAttribute( {
 			 *			model: 'attribute-name',
 			 *			view: 'attribute-name'
 			 *		} ) );
@@ -710,7 +715,7 @@ export function changeAttribute( attributeCreator ) {
 			 * {@link module:engine/conversion/conversion~Conversion#attributeToElement `Attribute to Element converter`}
 			 * with higher {@link module:utils/priorities~PriorityString priority} must also be defined:
 			 *
-			 *		conversion.for( 'downcast' ).add( downcastAttributeToElement( {
+			 *		conversion.for( 'downcast' ).attributeToElement( {
 			 *			model: {
 			 *				key: 'attribute-name',
 			 *				name: '$text'
@@ -1144,7 +1149,7 @@ export const helpers = {
 	 * as parameters and returns a view container element.
 	 */
 	elementToElement( config ) {
-		return this.add( downcastElementToElement( config ) );
+		return this.add( _downcastElementToElement( config ) );
 	},
 
 	/**
@@ -1218,7 +1223,7 @@ export const helpers = {
 	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
 	 */
 	attributeToElement( config ) {
-		return this.add( downcastAttributeToElement( config ) );
+		return this.add( _downcastAttributeToElement( config ) );
 	},
 
 	/**
@@ -1277,7 +1282,7 @@ export const helpers = {
 	 * @returns {Function} Conversion helper.
 	 */
 	attributeToAttribute( config ) {
-		return this.add( downcastAttributeToAttribute( config ) );
+		return this.add( _downcastAttributeToAttribute( config ) );
 	},
 
 	/**
@@ -1328,7 +1333,7 @@ export const helpers = {
 	 * @returns {Function} Conversion helper.
 	 */
 	markerToElement( config ) {
-		return this.add( downcastMarkerToElement( config ) );
+		return this.add( _downcastMarkerToElement( config ) );
 	},
 
 	/**
@@ -1386,6 +1391,6 @@ export const helpers = {
 	 * @returns {Function} Conversion helper.
 	 */
 	markerToHighlight( config ) {
-		return this.add( downcastMarkerToHighlight( config ) );
+		return this.add( _downcastMarkerToHighlight( config ) );
 	}
 };

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -1003,6 +1003,7 @@ export const helpers = {
 	 * @param {module:engine/view/elementdefinition~ElementDefinition|Function} config.view A view element definition or a function
 	 * that takes the model element and {@link module:engine/view/downcastwriter~DowncastWriter view downcast writer}
 	 * as parameters and returns a view container element.
+	 * @returns {module:engine/conversion/downcast-converters~DowncastHelpers}
 	 */
 	elementToElement( config ) {
 		return this.add( _downcastElementToElement( config ) );
@@ -1010,7 +1011,6 @@ export const helpers = {
 
 	/**
 	 * Model attribute to view element conversion helper.
-	 *
 	 *
 	 * This conversion results in wrapping view nodes with a view attribute element. For example, a model text node with
 	 * `"Foo"` as data and the `bold` attribute becomes `<strong>Foo</strong>` in the view.
@@ -1088,6 +1088,7 @@ export const helpers = {
 	 * as parameters and returns a view attribute element. If `config.model.values` is
 	 * given, `config.view` should be an object assigning values from `config.model.values` to view element definitions or functions.
 	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
+	 * @returns {module:engine/conversion/downcast-converters~DowncastHelpers}
 	 */
 	attributeToElement( config ) {
 		return this.add( _downcastAttributeToElement( config ) );
@@ -1153,7 +1154,7 @@ export const helpers = {
 	 * If `config.model.values` is set, `config.view` should be an object assigning values from `config.model.values` to
 	 * `{ key, value }` objects or a functions.
 	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
-	 * @returns {Function} Conversion helper.
+	 * @returns {module:engine/conversion/downcast-converters~DowncastHelpers}
 	 */
 	attributeToAttribute( config ) {
 		return this.add( _downcastAttributeToAttribute( config ) );
@@ -1215,7 +1216,7 @@ export const helpers = {
 	 * @param {module:engine/view/elementdefinition~ElementDefinition|Function} config.view A view element definition or a function
 	 * that takes the model marker data as a parameter and returns a view UI element.
 	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
-	 * @returns {Function} Conversion helper.
+	 * @returns {module:engine/conversion/downcast-converters~DowncastHelpers}
 	 */
 	markerToElement( config ) {
 		return this.add( _downcastMarkerToElement( config ) );
@@ -1274,7 +1275,7 @@ export const helpers = {
 	 * @param {module:engine/conversion/downcast-converters~HighlightDescriptor|Function} config.view A highlight descriptor
 	 * that will be used for highlighting or a function that takes the model marker data as a parameter and returns a highlight descriptor.
 	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
-	 * @returns {Function} Conversion helper.
+	 * @returns {module:engine/conversion/downcast-converters~DowncastHelpers}
 	 */
 	markerToHighlight( config ) {
 		return this.add( _downcastMarkerToHighlight( config ) );

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -1108,6 +1108,7 @@ export function createViewElementFromHighlightDescriptor( descriptor ) {
  * Downcast conversion helper functions.
  *
  * @interface module:engine/conversion/downcast-converters~DowncastHelpers
+ * @extends module:engine/conversion/conversion~ConversionHelpers
  */
 export const helpers = {
 	/**

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -1329,5 +1329,63 @@ export const helpers = {
 	 */
 	markerToElement( config ) {
 		return this.add( downcastMarkerToElement( config ) );
+	},
+
+	/**
+	 * Model marker to highlight conversion helper.
+	 *
+	 * This conversion results in creating a highlight on view nodes. For this kind of conversion,
+	 * {@link module:engine/conversion/downcast-converters~HighlightDescriptor} should be provided.
+	 *
+	 * For text nodes, a `<span>` {@link module:engine/view/attributeelement~AttributeElement} is created and it wraps all text nodes
+	 * in the converted marker range. For example, a model marker set like this: `<paragraph>F[oo b]ar</paragraph>` becomes
+	 * `<p>F<span class="comment">oo b</span>ar</p>` in the view.
+	 *
+	 * {@link module:engine/view/containerelement~ContainerElement} may provide a custom way of handling highlight. Most often,
+	 * the element itself is given classes and attributes described in the highlight descriptor (instead of being wrapped in `<span>`).
+	 * For example, a model marker set like this: `[<image src="foo.jpg"></image>]` becomes `<img src="foo.jpg" class="comment"></img>`
+	 * in the view.
+	 *
+	 * For container elements, the conversion is two-step. While the converter processes the highlight descriptor and passes it
+	 * to a container element, it is the container element instance itself that applies values from the highlight descriptor.
+	 * So, in a sense, the converter takes care of stating what should be applied on what, while the element decides how to apply that.
+	 *
+	 *		conversion.for( 'downcast' ).markerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
+	 *
+	 *		conversion.for( 'downcast' ).markerToHighlight( {
+	 *			model: 'comment',
+	 *			view: { classes: 'new-comment' },
+	 *			converterPriority: 'high'
+	 *		} );
+	 *
+	 *		conversion.for( 'downcast' ).markerToHighlight( {
+	 *			model: 'comment',
+	 *			view: data => {
+	 *				// Assuming that the marker name is in a form of comment:commentType.
+	 *				const commentType = data.markerName.split( ':' )[ 1 ];
+	 *
+	 *				return {
+	 *					classes: [ 'comment', 'comment-' + commentType ]
+	 *				};
+	 *			}
+	 *		} );
+	 *
+	 * If a function is passed as the `config.view` parameter, it will be used to generate the highlight descriptor. The function
+	 * receives the `data` object as a parameter and should return a
+	 * {@link module:engine/conversion/downcast-converters~HighlightDescriptor highlight descriptor}.
+	 * The `data` object properties are passed from {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:addMarker}.
+	 *
+	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add a converter to the conversion process.
+	 *
+	 * @method #markerToHighlight
+	 * @param {Object} config Conversion configuration.
+	 * @param {String} config.model The name of the model marker (or model marker group) to convert.
+	 * @param {module:engine/conversion/downcast-converters~HighlightDescriptor|Function} config.view A highlight descriptor
+	 * that will be used for highlighting or a function that takes the model marker data as a parameter and returns a highlight descriptor.
+	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
+	 * @returns {Function} Conversion helper.
+	 */
+	markerToHighlight( config ) {
+		return this.add( downcastMarkerToHighlight( config ) );
 	}
 };

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -1103,3 +1103,17 @@ export function createViewElementFromHighlightDescriptor( descriptor ) {
  * attribute element. If the descriptor is applied to an element, usually these attributes will be set on that element, however,
  * this depends on how the element converts the descriptor.
  */
+
+/**
+ * Downcast conversion helper functions.
+ *
+ * @typedef {Object} DowncastHelpers
+ */
+export const helpers = {
+	elementToElement: downcastElementToElement,
+	attributeToElement: downcastAttributeToElement,
+	attributeToAttribute: downcastAttributeToAttribute,
+	markerToElement: downcastMarkerToElement,
+	markerToHighlight: downcastMarkerToHighlight,
+	createViewElementFromHighlightDescriptor
+};

--- a/src/conversion/downcast-converters.js
+++ b/src/conversion/downcast-converters.js
@@ -1204,6 +1204,7 @@ export const helpers = {
 	 *			}
 	 *		} );
 	 *
+	 * @method #attributeToElement
 	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
 	 * to the conversion process.
 	 * @method #attributeToAttribute
@@ -1218,5 +1219,64 @@ export const helpers = {
 	 */
 	attributeToElement( config ) {
 		return this.add( downcastAttributeToElement( config ) );
+	},
+
+	/**
+	 * Model attribute to view attribute conversion helper.
+	 *
+	 * This conversion results in adding an attribute to a view node, basing on an attribute from a model node. For example,
+	 * `<image src='foo.jpg'></image>` is converted to `<img src='foo.jpg'></img>`.
+	 *
+	 *		conversion.for( 'downcast' ).attributeToAttribute( { model: 'source', view: 'src' } );
+	 *
+	 *		conversion.for( 'downcast' ).attributeToAttribute( { model: 'source', view: 'href', converterPriority: 'high' } );
+	 *
+	 *		conversion.for( 'downcast' ).attributeToAttribute( {
+	 *			model: {
+	 *				name: 'image',
+	 *				key: 'source'
+	 *			},
+	 *			view: 'src'
+	 *		} );
+	 *
+	 *		conversion.for( 'downcast' ).attributeToAttribute( {
+	 *			model: {
+	 *				name: 'styled',
+	 *				values: [ 'dark', 'light' ]
+	 *			},
+	 *			view: {
+	 *				dark: {
+	 *					key: 'class',
+	 *					value: [ 'styled', 'styled-dark' ]
+	 *				},
+	 *				light: {
+	 *					key: 'class',
+	 *					value: [ 'styled', 'styled-light' ]
+	 *				}
+	 *			}
+	 *		} );
+	 *
+	 *		conversion.for( 'downcast' ).attributeToAttribute( {
+	 *			model: 'styled',
+	 *			view: modelAttributeValue => ( { key: 'class', value: 'styled-' + modelAttributeValue } )
+	 *		} );
+	 *
+	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
+	 * to the conversion process.
+	 *
+	 * @method #attributeToAttribute
+	 * @param {Object} config Conversion configuration.
+	 * @param {String|Object} config.model The key of the attribute to convert from or a `{ key, values, [ name ] }` object describing
+	 * the attribute key, possible values and, optionally, an element name to convert from.
+	 * @param {String|Object|Function} config.view A view attribute key, or a `{ key, value }` object or a function that takes
+	 * the model attribute value and returns a `{ key, value }` object. If `key` is `'class'`, `value` can be a `String` or an
+	 * array of `String`s. If `key` is `'style'`, `value` is an object with key-value pairs. In other cases, `value` is a `String`.
+	 * If `config.model.values` is set, `config.view` should be an object assigning values from `config.model.values` to
+	 * `{ key, value }` objects or a functions.
+	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
+	 * @returns {Function} Conversion helper.
+	 */
+	attributeToAttribute( config ) {
+		return this.add( downcastAttributeToAttribute( config ) );
 	}
 };

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -516,7 +516,7 @@ export const helpers = {
 	 * @param {String|module:engine/model/element~Element|Function} config.model Name of the model element, a model element
 	 * instance or a function that takes a view element and returns a model element. The model element will be inserted in the model.
 	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
-	 * @returns {Function} Conversion helper.
+	 * @returns {module:engine/conversion/upcast-converters~UpcastHelpers}
 	 */
 	elementToElement( config ) {
 		return this.add( _upcastElementToElement( config ) );
@@ -602,7 +602,7 @@ export const helpers = {
 	 * the model attribute. `value` property may be set as a function that takes a view element and returns the value.
 	 * If `String` is given, the model attribute value will be set to `true`.
 	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
-	 * @returns {module:engine/conversion/conversion~Conversion} Conversion helper.
+	 * @returns {module:engine/conversion/upcast-converters~UpcastHelpers}
 	 */
 	elementToAttribute( config ) {
 		return this.add( _upcastElementToAttribute( config ) );
@@ -696,7 +696,7 @@ export const helpers = {
 	 * the model attribute. `value` property may be set as a function that takes a view element and returns the value.
 	 * If `String` is given, the model attribute value will be same as view attribute value.
 	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='low'] Converter priority.
-	 * @returns {Function} Conversion helper.
+	 * @returns {module:engine/conversion/upcast-converters~UpcastHelpers}
 	 */
 	attributeToAttribute( config ) {
 		return this.add( _upcastAttributeToAttribute( config ) );
@@ -745,7 +745,7 @@ export const helpers = {
 	 * @param {String|Function} config.model Name of the model marker, or a function that takes a view element and returns
 	 * a model marker name.
 	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
-	 * @returns {Function} Conversion helper.
+	 * @returns {module:engine/conversion/upcast-converters~UpcastHelpers}
 	 */
 	elementToMarker( config ) {
 		return this.add( _upcastElementToMarker( config ) );

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -735,5 +735,86 @@ export const helpers = {
 	 */
 	elementToAttribute( config ) {
 		return this.add( upcastElementToAttribute( config ) );
+	},
+
+	/**
+	 * View attribute to model attribute conversion helper.
+	 *
+	 * This conversion results in setting an attribute on a model node. For example, view `<img src="foo.jpg"></img>` becomes
+	 * `<image source="foo.jpg"></image>` in the model.
+	 *
+	 * This helper is meant to convert view attributes from view elements which got converted to the model, so the view attribute
+	 * is set only on the corresponding model node:
+	 *
+	 *		<div class="dark"><div>foo</div></div>    -->    <div dark="true"><div>foo</div></div>
+	 *
+	 * Above, `class="dark"` attribute is added only to the `<div>` elements that has it. This is in contrary to
+	 * {@link module:engine/conversion/upcast-converters~upcastElementToAttribute} which sets attributes for all the children in the model:
+	 *
+	 *		<strong>Foo</strong>   -->   <strong><p>Foo</p></strong>   -->   <paragraph><$text bold="true">Foo</$text></paragraph>
+	 *
+	 * Above is a sample of HTML code, that goes through autoparagraphing (first step) and then is converted (second step).
+	 * Even though `<strong>` is over `<p>` element, `bold="true"` was added to the text.
+	 *
+	 * Keep in mind that the attribute will be set only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
+	 *
+	 *		conversion.for( 'upcast' ).attributeToAttribute( { view: 'src', model: 'source' } );
+	 *
+	 *		conversion.for( 'upcast' ).attributeToAttribute( { view: { key: 'src' }, model: 'source' } );
+	 *
+	 *		conversion.for( 'upcast' ).attributeToAttribute( { view: { key: 'src' }, model: 'source', converterPriority: 'normal' } );
+	 *
+	 *		conversion.for( 'upcast' ).attributeToAttribute( {
+	 *			view: {
+	 *				key: 'data-style',
+	 *				value: /[\s\S]+/
+	 *			},
+	 *			model: 'styled'
+	 *		} );
+	 *
+	 *		conversion.for( 'upcast' ).attributeToAttribute( {
+	 *			view: {
+	 *				name: 'img',
+	 *				key: 'class',
+	 *				value: 'styled-dark'
+	 *			},
+	 *			model: {
+	 *				key: 'styled',
+	 *				value: 'dark'
+	 *			}
+	 *		} );
+	 *
+	 *		conversion.for( 'upcast' ).attributeToAttribute( {
+	 *			view: {
+	 *				key: 'class',
+	 *				value: /styled-[\S]+/
+	 *			},
+	 *			model: {
+	 *				key: 'styled'
+	 *				value: viewElement => {
+	 *					const regexp = /styled-([\S]+)/;
+	 *					const match = viewElement.getAttribute( 'class' ).match( regexp );
+	 *
+	 *					return match[ 1 ];
+	 *				}
+	 *			}
+	 *		} );
+	 *
+	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+	 *
+	 * @param {Object} config Conversion configuration.
+	 * @param {String|Object} config.view Specifies which view attribute will be converted. If a `String` is passed,
+	 * attributes with given key will be converted. If an `Object` is passed, it must have a required `key` property,
+	 * specifying view attribute key, and may have an optional `value` property, specifying view attribute value and optional `name`
+	 * property specifying a view element name from/on which the attribute should be converted. `value` can be given as a `String`,
+	 * a `RegExp` or a function callback, that takes view attribute value as the only parameter and returns `Boolean`.
+	 * @param {String|Object} config.model Model attribute key or an object with `key` and `value` properties, describing
+	 * the model attribute. `value` property may be set as a function that takes a view element and returns the value.
+	 * If `String` is given, the model attribute value will be same as view attribute value.
+	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='low'] Converter priority.
+	 * @returns {Function} Conversion helper.
+	 */
+	attributeToAttribute( config ) {
+		return this.add( upcastAttributeToAttribute( config ) );
 	}
 };

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -607,3 +607,56 @@ export function convertText() {
 		}
 	};
 }
+
+/**
+ * Upcast conversion helper functions.
+ *
+ * @interface module:engine/conversion/upcast-converters~UpcastHelpers
+ * @extends module:engine/conversion/conversion~ConversionHelpers
+ */
+export const helpers = {
+	/**
+	 * View element to model element conversion helper.
+	 *
+	 * This conversion results in creating a model element. For example,
+	 * view `<p>Foo</p>` becomes `<paragraph>Foo</paragraph>` in the model.
+	 *
+	 * Keep in mind that the element will be inserted only if it is allowed
+	 * by {@link module:engine/model/schema~Schema schema} configuration.
+	 *
+	 *		conversion.for( 'upcast' ).elementToElement( { view: 'p', model: 'paragraph' } );
+	 *
+	 *		conversion.for( 'upcast' ).elementToElement( { view: 'p', model: 'paragraph', converterPriority: 'high' } );
+	 *
+	 *		conversion.for( 'upcast' ).elementToElement( {
+	 *			view: {
+	 *				name: 'p',
+	 *				classes: 'fancy'
+	 *			},
+	 *			model: 'fancyParagraph'
+	 *		} );
+	 *
+	 *		conversion.for( 'upcast' ).elementToElement( {
+	 * 			view: {
+	 *				name: 'p',
+	 *				classes: 'heading'
+	 * 			},
+	 * 			model: ( viewElement, modelWriter ) => {
+	 * 				return modelWriter.createElement( 'heading', { level: viewElement.getAttribute( 'data-level' ) } );
+	 * 			}
+	 * 		} );
+	 *
+	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+	 *
+	 * @method #elementToElement
+	 * @param {Object} config Conversion configuration.
+	 * @param {module:engine/view/matcher~MatcherPattern} config.view Pattern matching all view elements which should be converted.
+	 * @param {String|module:engine/model/element~Element|Function} config.model Name of the model element, a model element
+	 * instance or a function that takes a view element and returns a model element. The model element will be inserted in the model.
+	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
+	 * @returns {Function} Conversion helper.
+	 */
+	elementToElement( config ) {
+		return this.add( upcastElementToElement( config ) );
+	}
+};

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -19,33 +19,13 @@ import { cloneDeep } from 'lodash-es';
 /**
  * View element to model element conversion helper.
  *
- * This conversion results in creating a model element. For example, view `<p>Foo</p>` becomes `<paragraph>Foo</paragraph>` in the model.
+ *		editor.conversion.for( 'upcast' )
+ *			.add( _upcastElementToElement( {
+ *				view: 'p',
+ *				model: 'paragraph'
+ *			} ) );
  *
- * Keep in mind that the element will be inserted only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
- *
- *		_upcastElementToElement( { view: 'p', model: 'paragraph' } );
- *
- *		_upcastElementToElement( { view: 'p', model: 'paragraph', converterPriority: 'high' } );
- *
- *		_upcastElementToElement( {
- *			view: {
- *				name: 'p',
- *				classes: 'fancy'
- *			},
- *			model: 'fancyParagraph'
- *		} );
- *
- *		_upcastElementToElement( {
- * 			view: {
- *				name: 'p',
- *				classes: 'heading'
- * 			},
- * 			model: ( viewElement, modelWriter ) => {
- * 				return modelWriter.createElement( 'heading', { level: viewElement.getAttribute( 'data-level' ) } );
- * 			}
- * 		} );
- *
- * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+ * The method is publicly available as {@link ~UpcastHelpers#elementToElement `.elementToElement()` upcast helper}.
  *
  * @param {Object} config Conversion configuration.
  * @param {module:engine/view/matcher~MatcherPattern} config.view Pattern matching all view elements which should be converted.
@@ -70,67 +50,13 @@ export function _upcastElementToElement( config ) {
 /**
  * View element to model attribute conversion helper.
  *
- * This conversion results in setting an attribute on a model node. For example, view `<strong>Foo</strong>` becomes
- * `Foo` {@link module:engine/model/text~Text model text node} with `bold` attribute set to `true`.
+ *		editor.conversion.for( 'upcast' )
+ *			.add( _upcastElementToAttribute( {
+ *				view: 'strong',
+ *				model: 'bold'
+ *			} ) );
  *
- * This helper is meant to set a model attribute on all the elements that are inside the converted element:
- *
- *		<strong>Foo</strong>   -->   <strong><p>Foo</p></strong>   -->   <paragraph><$text bold="true">Foo</$text></paragraph>
- *
- * Above is a sample of HTML code, that goes through autoparagraphing (first step) and then is converted (second step).
- * Even though `<strong>` is over `<p>` element, `bold="true"` was added to the text. See
- * {@link module:engine/conversion/upcast-converters~upcastAttributeToAttribute} for comparison.
- *
- * Keep in mind that the attribute will be set only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
- *
- *		_upcastElementToAttribute( { view: 'strong', model: 'bold' } );
- *
- *		_upcastElementToAttribute( { view: 'strong', model: 'bold', converterPriority: 'high' } );
- *
- *		_upcastElementToAttribute( {
- *			view: {
- *				name: 'span',
- *				classes: 'bold'
- *			},
- *			model: 'bold'
- *		} );
- *
- *		_upcastElementToAttribute( {
- *			view: {
- *				name: 'span',
- *				classes: [ 'styled', 'styled-dark' ]
- *			},
- *			model: {
- *				key: 'styled',
- *				value: 'dark'
- *			}
- *		} );
- *
- * 		_upcastElementToAttribute( {
- *			view: {
- *				name: 'span',
- *				styles: {
- *					'font-size': /[\s\S]+/
- *				}
- *			},
- *			model: {
- *				key: 'fontSize',
- *				value: viewElement => {
- *					const fontSize = viewElement.getStyle( 'font-size' );
- *					const value = fontSize.substr( 0, fontSize.length - 2 );
- *
- *					if ( value <= 10 ) {
- *						return 'small';
- *					} else if ( value > 12 ) {
- *						return 'big';
- *					}
- *
- *					return null;
- *				}
- *			}
- *		} );
- *
- * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+ * The method is publicly available as {@link ~UpcastHelpers#elementToAttribute `.elementToAttribute()` upcast helper}.
  *
  * @param {Object} config Conversion configuration.
  * @param {module:engine/view/matcher~MatcherPattern} config.view Pattern matching all view elements which should be converted.
@@ -158,67 +84,13 @@ export function _upcastElementToAttribute( config ) {
 /**
  * View attribute to model attribute conversion helper.
  *
- * This conversion results in setting an attribute on a model node. For example, view `<img src="foo.jpg"></img>` becomes
- * `<image source="foo.jpg"></image>` in the model.
+ *		editor.conversion.for( 'upcast' )
+ *			.add( _upcastAttributeToAttribute( {
+ *				view: 'src',
+ *				model: 'source'
+ *			} ) );
  *
- * This helper is meant to convert view attributes from view elements which got converted to the model, so the view attribute
- * is set only on the corresponding model node:
- *
- *		<div class="dark"><div>foo</div></div>    -->    <div dark="true"><div>foo</div></div>
- *
- * Above, `class="dark"` attribute is added only to the `<div>` elements that has it. This is in contrary to
- * {@link module:engine/conversion/upcast-converters~upcastElementToAttribute} which sets attributes for all the children in the model:
- *
- *		<strong>Foo</strong>   -->   <strong><p>Foo</p></strong>   -->   <paragraph><$text bold="true">Foo</$text></paragraph>
- *
- * Above is a sample of HTML code, that goes through autoparagraphing (first step) and then is converted (second step).
- * Even though `<strong>` is over `<p>` element, `bold="true"` was added to the text.
- *
- * Keep in mind that the attribute will be set only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
- *
- *		_upcastAttributeToAttribute( { view: 'src', model: 'source' } );
- *
- *		_upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source' } );
- *
- *		_upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source', converterPriority: 'normal' } );
- *
- *		_upcastAttributeToAttribute( {
- *			view: {
- *				key: 'data-style',
- *				value: /[\s\S]+/
- *			},
- *			model: 'styled'
- *		} );
- *
- *		_upcastAttributeToAttribute( {
- *			view: {
- *				name: 'img',
- *				key: 'class',
- *				value: 'styled-dark'
- *			},
- *			model: {
- *				key: 'styled',
- *				value: 'dark'
- *			}
- *		} );
- *
- *		_upcastAttributeToAttribute( {
- *			view: {
- *				key: 'class',
- *				value: /styled-[\S]+/
- *			},
- *			model: {
- *				key: 'styled'
- *				value: viewElement => {
- *					const regexp = /styled-([\S]+)/;
- *					const match = viewElement.getAttribute( 'class' ).match( regexp );
- *
- *					return match[ 1 ];
- *				}
- *			}
- *		} );
- *
- * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+ * The method is publicly available as {@link ~UpcastHelpers#attributeToAttribute `.attributeToAttribute()` upcast helper}.
  *
  * @param {Object} config Conversion configuration.
  * @param {String|Object} config.view Specifies which view attribute will be converted. If a `String` is passed,
@@ -253,31 +125,13 @@ export function _upcastAttributeToAttribute( config ) {
 /**
  * View element to model marker conversion helper.
  *
- * This conversion results in creating a model marker. For example, if the marker was stored in a view as an element:
- * `<p>Fo<span data-marker="comment" data-comment-id="7"></span>o</p><p>B<span data-marker="comment" data-comment-id="7"></span>ar</p>`,
- * after the conversion is done, the marker will be available in
- * {@link module:engine/model/model~Model#markers model document markers}.
+ *		editor.conversion.for( 'upcast' )
+ *			.add( _upcastElementToMarker( {
+ *				view: 'marker-search',
+ *				model: 'search'
+ *			} ) );
  *
- *		_upcastElementToMarker( { view: 'marker-search', model: 'search' } );
- *
- *		_upcastElementToMarker( { view: 'marker-search', model: 'search', converterPriority: 'high' } );
- *
- *		_upcastElementToMarker( {
- *			view: 'marker-search',
- *			model: viewElement => 'comment:' + viewElement.getAttribute( 'data-comment-id' )
- *		} );
- *
- *		_upcastElementToMarker( {
- *			view: {
- *				name: 'span',
- *				attributes: {
- *					'data-marker': 'search'
- *				}
- *			},
- *			model: 'search'
- *		} );
- *
- * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+ * The method is publicly available as {@link ~UpcastHelpers#elementToMarker `.elementToMarker()` upcast helper}.
  *
  * @param {Object} config Conversion configuration.
  * @param {module:engine/view/matcher~MatcherPattern} config.view Pattern matching all view elements which should be converted.
@@ -624,11 +478,18 @@ export const helpers = {
 	 * Keep in mind that the element will be inserted only if it is allowed
 	 * by {@link module:engine/model/schema~Schema schema} configuration.
 	 *
-	 *		conversion.for( 'upcast' ).elementToElement( { view: 'p', model: 'paragraph' } );
+	 *		editor.conversion.for( 'upcast' ).elementToElement( {
+	 *			view: 'p',
+	 *			model: 'paragraph'
+	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).elementToElement( { view: 'p', model: 'paragraph', converterPriority: 'high' } );
+	 *		editor.conversion.for( 'upcast' ).elementToElement( {
+	 *			view: 'p',
+	 *			model: 'paragraph',
+	 *			converterPriority: 'high'
+	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).elementToElement( {
+	 *		editor.conversion.for( 'upcast' ).elementToElement( {
 	 *			view: {
 	 *				name: 'p',
 	 *				classes: 'fancy'
@@ -636,7 +497,7 @@ export const helpers = {
 	 *			model: 'fancyParagraph'
 	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).elementToElement( {
+	 *		editor.conversion.for( 'upcast' ).elementToElement( {
 	 * 			view: {
 	 *				name: 'p',
 	 *				classes: 'heading'
@@ -646,7 +507,8 @@ export const helpers = {
 	 * 			}
 	 * 		} );
 	 *
-	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
+	 * to the conversion process.
 	 *
 	 * @method #elementToElement
 	 * @param {Object} config Conversion configuration.
@@ -676,11 +538,18 @@ export const helpers = {
 	 *
 	 * Keep in mind that the attribute will be set only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
 	 *
-	 *		conversion.for( 'upcast' ).elementToAttribute( { view: 'strong', model: 'bold' } );
+	 *		editor.conversion.for( 'upcast' ).elementToAttribute( {
+	 *			view: 'strong',
+	 *			model: 'bold'
+	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).elementToAttribute( { view: 'strong', model: 'bold', converterPriority: 'high' } );
+	 *		editor.conversion.for( 'upcast' ).elementToAttribute( {
+	 *			view: 'strong',
+	 *			model: 'bold',
+	 *			converterPriority: 'high'
+	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).elementToAttribute( {
+	 *		editor.conversion.for( 'upcast' ).elementToAttribute( {
 	 *			view: {
 	 *				name: 'span',
 	 *				classes: 'bold'
@@ -688,7 +557,7 @@ export const helpers = {
 	 *			model: 'bold'
 	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).elementToAttribute( {
+	 *		editor.conversion.for( 'upcast' ).elementToAttribute( {
 	 *			view: {
 	 *				name: 'span',
 	 *				classes: [ 'styled', 'styled-dark' ]
@@ -699,7 +568,7 @@ export const helpers = {
 	 *			}
 	 *		} );
 	 *
-	 * 		conversion.for( 'upcast' ).elementToAttribute( {
+	 * 		editor.conversion.for( 'upcast' ).elementToAttribute( {
 	 *			view: {
 	 *				name: 'span',
 	 *				styles: {
@@ -723,8 +592,10 @@ export const helpers = {
 	 *			}
 	 *		} );
 	 *
-	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
+	 * to the conversion process.
 	 *
+	 * @method #elementToAttribute
 	 * @param {Object} config Conversion configuration.
 	 * @param {module:engine/view/matcher~MatcherPattern} config.view Pattern matching all view elements which should be converted.
 	 * @param {String|Object} config.model Model attribute key or an object with `key` and `value` properties, describing
@@ -749,7 +620,8 @@ export const helpers = {
 	 *		<div class="dark"><div>foo</div></div>    -->    <div dark="true"><div>foo</div></div>
 	 *
 	 * Above, `class="dark"` attribute is added only to the `<div>` elements that has it. This is in contrary to
-	 * {@link module:engine/conversion/upcast-converters~upcastElementToAttribute} which sets attributes for all the children in the model:
+	 * {@link module:engine/conversion/upcast-converters~UpcastHelpers#elementToAttribute} which sets attributes for
+	 * all the children in the model:
 	 *
 	 *		<strong>Foo</strong>   -->   <strong><p>Foo</p></strong>   -->   <paragraph><$text bold="true">Foo</$text></paragraph>
 	 *
@@ -758,13 +630,23 @@ export const helpers = {
 	 *
 	 * Keep in mind that the attribute will be set only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
 	 *
-	 *		conversion.for( 'upcast' ).attributeToAttribute( { view: 'src', model: 'source' } );
+	 *		editor.conversion.for( 'upcast' ).attributeToAttribute( {
+	 *			view: 'src',
+	 *			model: 'source'
+	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).attributeToAttribute( { view: { key: 'src' }, model: 'source' } );
+	 *		editor.conversion.for( 'upcast' ).attributeToAttribute( {
+	 *			view: { key: 'src' },
+	 *			model: 'source'
+	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).attributeToAttribute( { view: { key: 'src' }, model: 'source', converterPriority: 'normal' } );
+	 *		editor.conversion.for( 'upcast' ).attributeToAttribute( {
+	 *			view: { key: 'src' },
+	 *			model: 'source',
+	 *			converterPriority: 'normal'
+	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).attributeToAttribute( {
+	 *		editor.conversion.for( 'upcast' ).attributeToAttribute( {
 	 *			view: {
 	 *				key: 'data-style',
 	 *				value: /[\s\S]+/
@@ -772,7 +654,7 @@ export const helpers = {
 	 *			model: 'styled'
 	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).attributeToAttribute( {
+	 *		editor.conversion.for( 'upcast' ).attributeToAttribute( {
 	 *			view: {
 	 *				name: 'img',
 	 *				key: 'class',
@@ -784,7 +666,7 @@ export const helpers = {
 	 *			}
 	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).attributeToAttribute( {
+	 *		editor.conversion.for( 'upcast' ).attributeToAttribute( {
 	 *			view: {
 	 *				key: 'class',
 	 *				value: /styled-[\S]+/
@@ -800,8 +682,10 @@ export const helpers = {
 	 *			}
 	 *		} );
 	 *
-	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
+	 * to the conversion process.
 	 *
+	 * @method #attributeToAttribute
 	 * @param {Object} config Conversion configuration.
 	 * @param {String|Object} config.view Specifies which view attribute will be converted. If a `String` is passed,
 	 * attributes with given key will be converted. If an `Object` is passed, it must have a required `key` property,
@@ -826,16 +710,23 @@ export const helpers = {
 	 * after the conversion is done, the marker will be available in
 	 * {@link module:engine/model/model~Model#markers model document markers}.
 	 *
-	 *		conversion.for( 'upcast' ).elementToMarker( { view: 'marker-search', model: 'search' } );
+	 *		editor.conversion.for( 'upcast' ).elementToMarker( {
+	 *			view: 'marker-search',
+	 *			model: 'search'
+	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).elementToMarker( { view: 'marker-search', model: 'search', converterPriority: 'high' } );
+	 *		editor.conversion.for( 'upcast' ).elementToMarker( {
+	 *			view: 'marker-search',
+	 *			model: 'search',
+	 *			converterPriority: 'high'
+	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).elementToMarker( {
+	 *		editor.conversion.for( 'upcast' ).elementToMarker( {
 	 *			view: 'marker-search',
 	 *			model: viewElement => 'comment:' + viewElement.getAttribute( 'data-comment-id' )
 	 *		} );
 	 *
-	 *		conversion.for( 'upcast' ).elementToMarker( {
+	 *		editor.conversion.for( 'upcast' ).elementToMarker( {
 	 *			view: {
 	 *				name: 'span',
 	 *				attributes: {
@@ -845,8 +736,10 @@ export const helpers = {
 	 *			model: 'search'
 	 *		} );
 	 *
-	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
+	 * to the conversion process.
 	 *
+	 * @method #elementToMarker
 	 * @param {Object} config Conversion configuration.
 	 * @param {module:engine/view/matcher~MatcherPattern} config.view Pattern matching all view elements which should be converted.
 	 * @param {String|Function} config.model Name of the model marker, or a function that takes a view element and returns

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -468,7 +468,7 @@ export function convertText() {
  * @interface module:engine/conversion/upcast-converters~UpcastHelpers
  * @extends module:engine/conversion/conversion~ConversionHelpers
  */
-export const helpers = {
+export const upcastHelpers = {
 	/**
 	 * View element to model element conversion helper.
 	 *

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -826,16 +826,16 @@ export const helpers = {
 	 * after the conversion is done, the marker will be available in
 	 * {@link module:engine/model/model~Model#markers model document markers}.
 	 *
-	 *        conversion.for( 'upcast' ).elementToMarker( { view: 'marker-search', model: 'search' } );
+	 *		conversion.for( 'upcast' ).elementToMarker( { view: 'marker-search', model: 'search' } );
 	 *
-	 *        conversion.for( 'upcast' ).elementToMarker( { view: 'marker-search', model: 'search', converterPriority: 'high' } );
+	 *		conversion.for( 'upcast' ).elementToMarker( { view: 'marker-search', model: 'search', converterPriority: 'high' } );
 	 *
-	 *        conversion.for( 'upcast' ).elementToMarker( {
+	 *		conversion.for( 'upcast' ).elementToMarker( {
 	 *			view: 'marker-search',
 	 *			model: viewElement => 'comment:' + viewElement.getAttribute( 'data-comment-id' )
 	 *		} );
 	 *
-	 *        conversion.for( 'upcast' ).elementToMarker( {
+	 *		conversion.for( 'upcast' ).elementToMarker( {
 	 *			view: {
 	 *				name: 'span',
 	 *				attributes: {

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -816,5 +816,45 @@ export const helpers = {
 	 */
 	attributeToAttribute( config ) {
 		return this.add( upcastAttributeToAttribute( config ) );
+	},
+
+	/**
+	 * View element to model marker conversion helper.
+	 *
+	 * This conversion results in creating a model marker. For example, if the marker was stored in a view as an element:
+	 * `<p>Fo<span data-marker="comment" data-comment-id="7"></span>o</p><p>B<span data-marker="comment" data-comment-id="7"></span>ar</p>`,
+	 * after the conversion is done, the marker will be available in
+	 * {@link module:engine/model/model~Model#markers model document markers}.
+	 *
+	 *        conversion.for( 'upcast' ).elementToMarker( { view: 'marker-search', model: 'search' } );
+	 *
+	 *        conversion.for( 'upcast' ).elementToMarker( { view: 'marker-search', model: 'search', converterPriority: 'high' } );
+	 *
+	 *        conversion.for( 'upcast' ).elementToMarker( {
+	 *			view: 'marker-search',
+	 *			model: viewElement => 'comment:' + viewElement.getAttribute( 'data-comment-id' )
+	 *		} );
+	 *
+	 *        conversion.for( 'upcast' ).elementToMarker( {
+	 *			view: {
+	 *				name: 'span',
+	 *				attributes: {
+	 *					'data-marker': 'search'
+	 *				}
+	 *			},
+	 *			model: 'search'
+	 *		} );
+	 *
+	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+	 *
+	 * @param {Object} config Conversion configuration.
+	 * @param {module:engine/view/matcher~MatcherPattern} config.view Pattern matching all view elements which should be converted.
+	 * @param {String|Function} config.model Name of the model marker, or a function that takes a view element and returns
+	 * a model marker name.
+	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
+	 * @returns {Function} Conversion helper.
+	 */
+	elementToMarker( config ) {
+		return this.add( upcastElementToMarker( config ) );
 	}
 };

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -23,11 +23,11 @@ import { cloneDeep } from 'lodash-es';
  *
  * Keep in mind that the element will be inserted only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
  *
- *		upcastElementToElement( { view: 'p', model: 'paragraph' } );
+ *		_upcastElementToElement( { view: 'p', model: 'paragraph' } );
  *
- *		upcastElementToElement( { view: 'p', model: 'paragraph', converterPriority: 'high' } );
+ *		_upcastElementToElement( { view: 'p', model: 'paragraph', converterPriority: 'high' } );
  *
- *		upcastElementToElement( {
+ *		_upcastElementToElement( {
  *			view: {
  *				name: 'p',
  *				classes: 'fancy'
@@ -35,7 +35,7 @@ import { cloneDeep } from 'lodash-es';
  *			model: 'fancyParagraph'
  *		} );
  *
- *		upcastElementToElement( {
+ *		_upcastElementToElement( {
  * 			view: {
  *				name: 'p',
  *				classes: 'heading'
@@ -54,7 +54,7 @@ import { cloneDeep } from 'lodash-es';
  * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
  * @returns {Function} Conversion helper.
  */
-export function upcastElementToElement( config ) {
+export function _upcastElementToElement( config ) {
 	config = cloneDeep( config );
 
 	const converter = _prepareToElementConverter( config );
@@ -83,11 +83,11 @@ export function upcastElementToElement( config ) {
  *
  * Keep in mind that the attribute will be set only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
  *
- *		upcastElementToAttribute( { view: 'strong', model: 'bold' } );
+ *		_upcastElementToAttribute( { view: 'strong', model: 'bold' } );
  *
- *		upcastElementToAttribute( { view: 'strong', model: 'bold', converterPriority: 'high' } );
+ *		_upcastElementToAttribute( { view: 'strong', model: 'bold', converterPriority: 'high' } );
  *
- *		upcastElementToAttribute( {
+ *		_upcastElementToAttribute( {
  *			view: {
  *				name: 'span',
  *				classes: 'bold'
@@ -95,7 +95,7 @@ export function upcastElementToElement( config ) {
  *			model: 'bold'
  *		} );
  *
- *		upcastElementToAttribute( {
+ *		_upcastElementToAttribute( {
  *			view: {
  *				name: 'span',
  *				classes: [ 'styled', 'styled-dark' ]
@@ -106,7 +106,7 @@ export function upcastElementToElement( config ) {
  *			}
  *		} );
  *
- * 		upcastElementToAttribute( {
+ * 		_upcastElementToAttribute( {
  *			view: {
  *				name: 'span',
  *				styles: {
@@ -140,7 +140,7 @@ export function upcastElementToElement( config ) {
  * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
  * @returns {Function} Conversion helper.
  */
-export function upcastElementToAttribute( config ) {
+export function _upcastElementToAttribute( config ) {
 	config = cloneDeep( config );
 
 	_normalizeModelAttributeConfig( config );
@@ -176,13 +176,13 @@ export function upcastElementToAttribute( config ) {
  *
  * Keep in mind that the attribute will be set only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
  *
- *		upcastAttributeToAttribute( { view: 'src', model: 'source' } );
+ *		_upcastAttributeToAttribute( { view: 'src', model: 'source' } );
  *
- *		upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source' } );
+ *		_upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source' } );
  *
- *		upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source', converterPriority: 'normal' } );
+ *		_upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source', converterPriority: 'normal' } );
  *
- *		upcastAttributeToAttribute( {
+ *		_upcastAttributeToAttribute( {
  *			view: {
  *				key: 'data-style',
  *				value: /[\s\S]+/
@@ -190,7 +190,7 @@ export function upcastElementToAttribute( config ) {
  *			model: 'styled'
  *		} );
  *
- *		upcastAttributeToAttribute( {
+ *		_upcastAttributeToAttribute( {
  *			view: {
  *				name: 'img',
  *				key: 'class',
@@ -202,7 +202,7 @@ export function upcastElementToAttribute( config ) {
  *			}
  *		} );
  *
- *		upcastAttributeToAttribute( {
+ *		_upcastAttributeToAttribute( {
  *			view: {
  *				key: 'class',
  *				value: /styled-[\S]+/
@@ -232,7 +232,7 @@ export function upcastElementToAttribute( config ) {
  * @param {module:utils/priorities~PriorityString} [config.converterPriority='low'] Converter priority.
  * @returns {Function} Conversion helper.
  */
-export function upcastAttributeToAttribute( config ) {
+export function _upcastAttributeToAttribute( config ) {
 	config = cloneDeep( config );
 
 	let viewKey = null;
@@ -258,16 +258,16 @@ export function upcastAttributeToAttribute( config ) {
  * after the conversion is done, the marker will be available in
  * {@link module:engine/model/model~Model#markers model document markers}.
  *
- *		upcastElementToMarker( { view: 'marker-search', model: 'search' } );
+ *		_upcastElementToMarker( { view: 'marker-search', model: 'search' } );
  *
- *		upcastElementToMarker( { view: 'marker-search', model: 'search', converterPriority: 'high' } );
+ *		_upcastElementToMarker( { view: 'marker-search', model: 'search', converterPriority: 'high' } );
  *
- *		upcastElementToMarker( {
+ *		_upcastElementToMarker( {
  *			view: 'marker-search',
  *			model: viewElement => 'comment:' + viewElement.getAttribute( 'data-comment-id' )
  *		} );
  *
- *		upcastElementToMarker( {
+ *		_upcastElementToMarker( {
  *			view: {
  *				name: 'span',
  *				attributes: {
@@ -286,12 +286,12 @@ export function upcastAttributeToAttribute( config ) {
  * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
  * @returns {Function} Conversion helper.
  */
-export function upcastElementToMarker( config ) {
+export function _upcastElementToMarker( config ) {
 	config = cloneDeep( config );
 
 	_normalizeToMarkerConfig( config );
 
-	return upcastElementToElement( config );
+	return _upcastElementToElement( config );
 }
 
 // Helper function for from-view-element conversion. Checks if `config.view` directly specifies converted view element's name
@@ -548,7 +548,7 @@ function _setAttributeOn( modelRange, modelAttribute, shallow, conversionApi ) {
 }
 
 // Helper function for upcasting-to-marker conversion. Takes the config in a format requested by `upcastElementToMarker()`
-// function and converts it to a format that is supported by `upcastElementToElement()` function.
+// function and converts it to a format that is supported by `_upcastElementToElement()` function.
 //
 // @param {Object} config Conversion configuration.
 function _normalizeToMarkerConfig( config ) {
@@ -657,7 +657,7 @@ export const helpers = {
 	 * @returns {Function} Conversion helper.
 	 */
 	elementToElement( config ) {
-		return this.add( upcastElementToElement( config ) );
+		return this.add( _upcastElementToElement( config ) );
 	},
 
 	/**
@@ -734,7 +734,7 @@ export const helpers = {
 	 * @returns {module:engine/conversion/conversion~Conversion} Conversion helper.
 	 */
 	elementToAttribute( config ) {
-		return this.add( upcastElementToAttribute( config ) );
+		return this.add( _upcastElementToAttribute( config ) );
 	},
 
 	/**
@@ -815,7 +815,7 @@ export const helpers = {
 	 * @returns {Function} Conversion helper.
 	 */
 	attributeToAttribute( config ) {
-		return this.add( upcastAttributeToAttribute( config ) );
+		return this.add( _upcastAttributeToAttribute( config ) );
 	},
 
 	/**
@@ -855,6 +855,6 @@ export const helpers = {
 	 * @returns {Function} Conversion helper.
 	 */
 	elementToMarker( config ) {
-		return this.add( upcastElementToMarker( config ) );
+		return this.add( _upcastElementToMarker( config ) );
 	}
 };

--- a/src/conversion/upcast-converters.js
+++ b/src/conversion/upcast-converters.js
@@ -658,5 +658,82 @@ export const helpers = {
 	 */
 	elementToElement( config ) {
 		return this.add( upcastElementToElement( config ) );
+	},
+
+	/**
+	 * View element to model attribute conversion helper.
+	 *
+	 * This conversion results in setting an attribute on a model node. For example, view `<strong>Foo</strong>` becomes
+	 * `Foo` {@link module:engine/model/text~Text model text node} with `bold` attribute set to `true`.
+	 *
+	 * This helper is meant to set a model attribute on all the elements that are inside the converted element:
+	 *
+	 *		<strong>Foo</strong>   -->   <strong><p>Foo</p></strong>   -->   <paragraph><$text bold="true">Foo</$text></paragraph>
+	 *
+	 * Above is a sample of HTML code, that goes through autoparagraphing (first step) and then is converted (second step).
+	 * Even though `<strong>` is over `<p>` element, `bold="true"` was added to the text. See
+	 * {@link module:engine/conversion/upcast-converters~UpcastHelpers#attributeToAttribute} for comparison.
+	 *
+	 * Keep in mind that the attribute will be set only if it is allowed by {@link module:engine/model/schema~Schema schema} configuration.
+	 *
+	 *		conversion.for( 'upcast' ).elementToAttribute( { view: 'strong', model: 'bold' } );
+	 *
+	 *		conversion.for( 'upcast' ).elementToAttribute( { view: 'strong', model: 'bold', converterPriority: 'high' } );
+	 *
+	 *		conversion.for( 'upcast' ).elementToAttribute( {
+	 *			view: {
+	 *				name: 'span',
+	 *				classes: 'bold'
+	 *			},
+	 *			model: 'bold'
+	 *		} );
+	 *
+	 *		conversion.for( 'upcast' ).elementToAttribute( {
+	 *			view: {
+	 *				name: 'span',
+	 *				classes: [ 'styled', 'styled-dark' ]
+	 *			},
+	 *			model: {
+	 *				key: 'styled',
+	 *				value: 'dark'
+	 *			}
+	 *		} );
+	 *
+	 * 		conversion.for( 'upcast' ).elementToAttribute( {
+	 *			view: {
+	 *				name: 'span',
+	 *				styles: {
+	 *					'font-size': /[\s\S]+/
+	 *				}
+	 *			},
+	 *			model: {
+	 *				key: 'fontSize',
+	 *				value: viewElement => {
+	 *					const fontSize = viewElement.getStyle( 'font-size' );
+	 *					const value = fontSize.substr( 0, fontSize.length - 2 );
+	 *
+	 *					if ( value <= 10 ) {
+	 *						return 'small';
+	 *					} else if ( value > 12 ) {
+	 *						return 'big';
+	 *					}
+	 *
+	 *					return null;
+	 *				}
+	 *			}
+	 *		} );
+	 *
+	 * See {@link module:engine/conversion/conversion~Conversion#for} to learn how to add converter to conversion process.
+	 *
+	 * @param {Object} config Conversion configuration.
+	 * @param {module:engine/view/matcher~MatcherPattern} config.view Pattern matching all view elements which should be converted.
+	 * @param {String|Object} config.model Model attribute key or an object with `key` and `value` properties, describing
+	 * the model attribute. `value` property may be set as a function that takes a view element and returns the value.
+	 * If `String` is given, the model attribute value will be set to `true`.
+	 * @param {module:utils/priorities~PriorityString} [config.converterPriority='normal'] Converter priority.
+	 * @returns {module:engine/conversion/conversion~Conversion} Conversion helper.
+	 */
+	elementToAttribute( config ) {
+		return this.add( upcastElementToAttribute( config ) );
 	}
 };

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -24,9 +24,9 @@ import {
 } from '../../src/conversion/upcast-converters';
 
 import {
-	downcastElementToElement,
-	downcastAttributeToElement,
-	downcastMarkerToHighlight
+	_downcastElementToElement,
+	_downcastAttributeToElement,
+	_downcastMarkerToHighlight
 } from '../../src/conversion/downcast-converters';
 
 describe( 'DataController', () => {
@@ -285,7 +285,7 @@ describe( 'DataController', () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 			setData( model, '<paragraph>foo</paragraph>' );
 
-			downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
+			_downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
 
 			expect( data.get() ).to.equal( '<p>foo</p>' );
 		} );
@@ -294,7 +294,7 @@ describe( 'DataController', () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 			setData( model, '<paragraph></paragraph>' );
 
-			downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
+			_downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
 
 			expect( data.get() ).to.equal( '<p>&nbsp;</p>' );
 		} );
@@ -303,7 +303,7 @@ describe( 'DataController', () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 			setData( model, '<paragraph>foo</paragraph><paragraph>bar</paragraph>' );
 
-			downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
+			_downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
 
 			expect( data.get() ).to.equal( '<p>foo</p><p>bar</p>' );
 		} );
@@ -319,7 +319,7 @@ describe( 'DataController', () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 			setData( model, '<paragraph>foo<$text bold="true">bar</$text></paragraph>' );
 
-			downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
+			_downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
 
 			expect( data.get() ).to.equal( '<p>foobar</p>' );
 		} );
@@ -328,8 +328,8 @@ describe( 'DataController', () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 			setData( model, '<paragraph>foo<$text bold="true">bar</$text></paragraph>' );
 
-			downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
-			downcastAttributeToElement( { model: 'bold', view: 'strong' } )( data.downcastDispatcher );
+			_downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
+			_downcastAttributeToElement( { model: 'bold', view: 'strong' } )( data.downcastDispatcher );
 
 			expect( data.get() ).to.equal( '<p>foo<strong>bar</strong></p>' );
 		} );
@@ -341,8 +341,8 @@ describe( 'DataController', () => {
 			setData( model, '<paragraph>foo</paragraph>', { rootName: 'main' } );
 			setData( model, 'Bar', { rootName: 'title' } );
 
-			downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
-			downcastAttributeToElement( { model: 'bold', view: 'strong' } )( data.downcastDispatcher );
+			_downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
+			_downcastAttributeToElement( { model: 'bold', view: 'strong' } )( data.downcastDispatcher );
 
 			expect( data.get() ).to.equal( '<p>foo</p>' );
 			expect( data.get( 'main' ) ).to.equal( '<p>foo</p>' );
@@ -358,7 +358,7 @@ describe( 'DataController', () => {
 			schema.extend( '$block', { allowIn: 'div' } );
 			schema.extend( 'div', { allowIn: '$root' } );
 
-			downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
+			_downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
 		} );
 
 		it( 'should stringify a content of an element', () => {
@@ -382,7 +382,7 @@ describe( 'DataController', () => {
 			schema.extend( '$block', { allowIn: 'div' } );
 			schema.extend( 'div', { allowIn: '$root' } );
 
-			downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
+			_downcastElementToElement( { model: 'paragraph', view: 'p' } )( data.downcastDispatcher );
 		} );
 
 		it( 'should convert a content of an element', () => {
@@ -403,7 +403,7 @@ describe( 'DataController', () => {
 			const modelElement = parseModel( '<div><paragraph>foobar</paragraph></div>', schema );
 			const modelRoot = model.document.getRoot();
 
-			downcastMarkerToHighlight( { model: 'marker:a', view: { classes: 'a' } } )( data.downcastDispatcher );
+			_downcastMarkerToHighlight( { model: 'marker:a', view: { classes: 'a' } } )( data.downcastDispatcher );
 
 			model.change( writer => {
 				writer.insert( modelElement, modelRoot, 0 );
@@ -421,8 +421,8 @@ describe( 'DataController', () => {
 			const modelElement = parseModel( '<div><paragraph>foo</paragraph><paragraph>bar</paragraph></div>', schema );
 			const modelRoot = model.document.getRoot();
 
-			downcastMarkerToHighlight( { model: 'marker:a', view: { classes: 'a' } } )( data.downcastDispatcher );
-			downcastMarkerToHighlight( { model: 'marker:b', view: { classes: 'b' } } )( data.downcastDispatcher );
+			_downcastMarkerToHighlight( { model: 'marker:a', view: { classes: 'a' } } )( data.downcastDispatcher );
+			_downcastMarkerToHighlight( { model: 'marker:b', view: { classes: 'b' } } )( data.downcastDispatcher );
 
 			const modelP1 = modelElement.getChild( 0 );
 			const modelP2 = modelElement.getChild( 1 );

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -19,8 +19,8 @@ import { parse as parseView, stringify as stringifyView } from '../../src/dev-ut
 import count from '@ckeditor/ckeditor5-utils/src/count';
 
 import {
-	upcastElementToElement,
-	upcastElementToAttribute
+	_upcastElementToElement,
+	_upcastElementToAttribute
 } from '../../src/conversion/upcast-converters';
 
 import {
@@ -68,7 +68,7 @@ describe( 'DataController', () => {
 		it( 'should set paragraph', () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 
-			upcastElementToElement( { view: 'p', model: 'paragraph' } )( data.upcastDispatcher );
+			_upcastElementToElement( { view: 'p', model: 'paragraph' } )( data.upcastDispatcher );
 
 			const output = data.parse( '<p>foo<b>bar</b></p>' );
 
@@ -79,7 +79,7 @@ describe( 'DataController', () => {
 		it( 'should set two paragraphs', () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 
-			upcastElementToElement( { view: 'p', model: 'paragraph' } )( data.upcastDispatcher );
+			_upcastElementToElement( { view: 'p', model: 'paragraph' } )( data.upcastDispatcher );
 
 			const output = data.parse( '<p>foo</p><p>bar</p>' );
 
@@ -93,8 +93,8 @@ describe( 'DataController', () => {
 				allowAttributes: [ 'bold' ]
 			} );
 
-			upcastElementToElement( { view: 'p', model: 'paragraph' } )( data.upcastDispatcher );
-			upcastElementToAttribute( { view: 'strong', model: 'bold' } )( data.upcastDispatcher );
+			_upcastElementToElement( { view: 'p', model: 'paragraph' } )( data.upcastDispatcher );
+			_upcastElementToAttribute( { view: 'strong', model: 'bold' } )( data.upcastDispatcher );
 
 			const output = data.parse( '<p>foo<strong>bar</strong></p>' );
 
@@ -119,7 +119,7 @@ describe( 'DataController', () => {
 		beforeEach( () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 
-			upcastElementToElement( { view: 'p', model: 'paragraph' } )( data.upcastDispatcher );
+			_upcastElementToElement( { view: 'p', model: 'paragraph' } )( data.upcastDispatcher );
 		} );
 
 		it( 'should convert content of an element #1', () => {

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -14,8 +14,7 @@ import View from '../../src/view/view';
 import Mapper from '../../src/conversion/mapper';
 import DowncastDispatcher from '../../src/conversion/downcastdispatcher';
 
-import { downcastElementToElement, downcastMarkerToHighlight } from '../../src/conversion/downcast-converters';
-
+import { _downcastElementToElement, _downcastMarkerToHighlight } from '../../src/conversion/downcast-converters';
 import Model from '../../src/model/model';
 import ModelPosition from '../../src/model/position';
 import ModelRange from '../../src/model/range';
@@ -91,9 +90,9 @@ describe( 'EditingController', () => {
 			model.schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 			model.schema.register( 'div', { inheritAllFrom: '$block' } );
 
-			downcastElementToElement( { model: 'paragraph', view: 'p' } )( editing.downcastDispatcher );
-			downcastElementToElement( { model: 'div', view: 'div' } )( editing.downcastDispatcher );
-			downcastMarkerToHighlight( { model: 'marker', view: {} } )( editing.downcastDispatcher );
+			_downcastElementToElement( { model: 'paragraph', view: 'p' } )( editing.downcastDispatcher );
+			_downcastElementToElement( { model: 'div', view: 'div' } )( editing.downcastDispatcher );
+			_downcastMarkerToHighlight( { model: 'marker', view: {} } )( editing.downcastDispatcher );
 
 			// Note: The below code is highly overcomplicated due to #455.
 			model.change( writer => {

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -645,6 +645,20 @@ describe( 'Conversion', () => {
 					testDowncast( '<paragraph><$text bold="true">Foo</$text> bar</paragraph>', '<p><strong>Foo</strong> bar</p>' );
 				} );
 			} );
+
+			describe( 'attributeToAttribute()', () => {
+				it( 'adds downcast converter', () => {
+					schema.register( 'image', {
+						inheritAllFrom: '$block',
+						allowAttributes: [ 'source' ]
+					} );
+
+					conversion.for( 'downcast' ).elementToElement( { model: 'image', view: 'img' } );
+					conversion.for( 'downcast' ).attributeToAttribute( { model: 'source', view: 'src' } );
+
+					testDowncast( '<image source="foo.jpg"></image>', '<img src="foo.jpg"></img>' );
+				} );
+			} );
 		} );
 
 		function testDowncast( input, expectedView ) {

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -636,6 +636,15 @@ describe( 'Conversion', () => {
 					testDowncast( '<paragraph>foo</paragraph>', '<p>foo</p>' );
 				} );
 			} );
+
+			describe( 'attributeToElement()', () => {
+				it( 'adds downcast converter', () => {
+					conversion.for( 'downcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
+					conversion.for( 'downcast' ).attributeToElement( { model: 'bold', view: 'strong' } );
+
+					testDowncast( '<paragraph><$text bold="true">Foo</$text> bar</paragraph>', '<p><strong>Foo</strong> bar</p>' );
+				} );
+			} );
 		} );
 
 		function testDowncast( input, expectedView ) {

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -27,15 +27,15 @@ describe( 'Conversion', () => {
 		dispA = Symbol( 'dispA' );
 		dispB = Symbol( 'dispB' );
 
-		conversion.register( 'ab', [ dispA, dispB ] );
-		conversion.register( 'a', [ dispA ] );
-		conversion.register( 'b', [ dispB ] );
+		conversion.register( { name: 'ab', dispatcher: [ dispA, dispB ] } );
+		conversion.register( { name: 'a', dispatcher: dispA } );
+		conversion.register( { name: 'b', dispatcher: dispB } );
 	} );
 
 	describe( 'register()', () => {
 		it( 'should throw when trying to use same group name twice', () => {
 			expect( () => {
-				conversion.register( 'ab' );
+				conversion.register( { name: 'ab' } );
 			} ).to.throw( CKEditorError, /conversion-register-group-exists/ );
 		} );
 	} );
@@ -113,8 +113,8 @@ describe( 'Conversion', () => {
 			viewDispatcher.on( 'documentFragment', convertToModelFragment(), { priority: 'lowest' } );
 
 			conversion = new Conversion();
-			conversion.register( 'upcast', [ viewDispatcher ] );
-			conversion.register( 'downcast', [ controller.downcastDispatcher ] );
+			conversion.register( { name: 'upcast', dispatcher: [ viewDispatcher ] } );
+			conversion.register( { name: 'downcast', dispatcher: [ controller.downcastDispatcher ] } );
 		} );
 
 		describe( 'elementToElement', () => {

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -720,6 +720,23 @@ describe( 'Conversion', () => {
 					testUpcast( '<p><strong>Foo</strong> bar</p>', '<paragraph><$text bold="true">Foo</$text> bar</paragraph>' );
 				} );
 			} );
+
+			describe( 'attributeToAttribute()', () => {
+				it( 'adds upcast converter', () => {
+					schema.register( 'image', {
+						inheritAllFrom: '$block',
+						allowAttributes: [ 'source' ]
+					} );
+
+					conversion.for( 'downcast' ).elementToElement( { model: 'image', view: 'img' } );
+					conversion.for( 'downcast' ).attributeToAttribute( { model: 'source', view: 'src' } );
+
+					conversion.for( 'upcast' ).elementToElement( { model: 'image', view: 'img' } );
+					conversion.for( 'upcast' ).attributeToAttribute( { model: 'source', view: 'src' } );
+
+					testUpcast( '<img src="foo.jpg"></img>', '<image source="foo.jpg"></image>' );
+				} );
+			} );
 		} );
 
 		function testDowncast( input, expectedView ) {

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -14,8 +14,9 @@ import EditingController from '../../src/controller/editingcontroller';
 
 import Model from '../../src/model/model';
 
-import { stringify as viewStringify, parse as viewParse } from '../../src/dev-utils/view';
-import { stringify as modelStringify } from '../../src/dev-utils/model';
+import { parse as viewParse, stringify as viewStringify } from '../../src/dev-utils/view';
+import { setData, stringify as modelStringify } from '../../src/dev-utils/model';
+import { helpers as downcastHelpers } from '../../src/conversion/downcast-converters';
 
 describe( 'Conversion', () => {
 	let conversion, dispA, dispB;
@@ -114,7 +115,7 @@ describe( 'Conversion', () => {
 
 			conversion = new Conversion();
 			conversion.register( { name: 'upcast', dispatcher: [ viewDispatcher ] } );
-			conversion.register( { name: 'downcast', dispatcher: [ controller.downcastDispatcher ] } );
+			conversion.register( { name: 'downcast', dispatcher: [ controller.downcastDispatcher ], helpers: downcastHelpers } );
 		} );
 
 		describe( 'elementToElement', () => {
@@ -626,6 +627,22 @@ describe( 'Conversion', () => {
 				);
 			} );
 		} );
+
+		describe( 'for( \'downcast\' )', () => {
+			describe( 'elementToElement()', () => {
+				it( 'adds downcast converter', () => {
+					conversion.for( 'downcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
+
+					testDowncast( '<paragraph>foo</paragraph>', '<p>foo</p>' );
+				} );
+			} );
+		} );
+
+		function testDowncast( input, expectedView ) {
+			setData( model, input );
+
+			expect( viewStringify( viewRoot, null, { ignoreRoot: true } ) ).to.equal( expectedView );
+		}
 
 		function test( input, expectedModel, expectedView = null ) {
 			loadData( input );

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -8,7 +8,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 import UpcastDispatcher from '../../src/conversion/upcastdispatcher';
 
-import { convertText, convertToModelFragment } from '../../src/conversion/upcast-converters';
+import { helpers as upcastHelpers, convertText, convertToModelFragment } from '../../src/conversion/upcast-converters';
 
 import EditingController from '../../src/controller/editingcontroller';
 
@@ -114,7 +114,7 @@ describe( 'Conversion', () => {
 			viewDispatcher.on( 'documentFragment', convertToModelFragment(), { priority: 'lowest' } );
 
 			conversion = new Conversion();
-			conversion.register( { name: 'upcast', dispatcher: [ viewDispatcher ] } );
+			conversion.register( { name: 'upcast', dispatcher: [ viewDispatcher ], helpers: upcastHelpers } );
 			conversion.register( { name: 'downcast', dispatcher: [ controller.downcastDispatcher ], helpers: downcastHelpers } );
 		} );
 
@@ -698,10 +698,28 @@ describe( 'Conversion', () => {
 			} );
 		} );
 
+		describe( 'for( \'upcast\' )', () => {
+			describe( 'elementToElement()', () => {
+				it( 'adds downcast converter', () => {
+					conversion.for( 'upcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
+					// TODO this shouldn't be required
+					conversion.for( 'downcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
+
+					testUpcast( '<p>foo</p>', '<paragraph>foo</paragraph>' );
+				} );
+			} );
+		} );
+
 		function testDowncast( input, expectedView ) {
 			setData( model, input );
 
 			expect( viewStringify( viewRoot, null, { ignoreRoot: true } ) ).to.equal( expectedView );
+		}
+
+		function testUpcast( input, expectedModel ) {
+			loadData( input );
+
+			expect( modelStringify( model.document.getRoot() ) ).to.equal( expectedModel );
 		}
 
 		function test( input, expectedModel, expectedView = null ) {

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -8,7 +8,8 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 import UpcastDispatcher from '../../src/conversion/upcastdispatcher';
 
-import { helpers as upcastHelpers, convertText, convertToModelFragment } from '../../src/conversion/upcast-converters';
+import { upcastHelpers, convertText, convertToModelFragment } from '../../src/conversion/upcast-converters';
+import { downcastHelpers } from '../../src/conversion/downcast-converters';
 
 import EditingController from '../../src/controller/editingcontroller';
 
@@ -16,7 +17,6 @@ import Model from '../../src/model/model';
 
 import { parse as viewParse, stringify as viewStringify } from '../../src/dev-utils/view';
 import { setData, stringify as modelStringify } from '../../src/dev-utils/model';
-import { helpers as downcastHelpers } from '../../src/conversion/downcast-converters';
 import ViewDocumentFragment from '../../src/view/documentfragment';
 import ViewText from '../../src/view/text';
 import ViewUIElement from '../../src/view/uielement';

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -659,6 +659,25 @@ describe( 'Conversion', () => {
 					testDowncast( '<image source="foo.jpg"></image>', '<img src="foo.jpg"></img>' );
 				} );
 			} );
+
+			describe( 'markerToElement()', () => {
+				it( 'adds downcast converter', () => {
+					conversion.for( 'downcast' ).markerToElement( { model: 'search', view: 'marker-search' } );
+
+					model.change( writer => {
+						writer.insertText( 'foo', modelRoot, 0 );
+
+						const range = writer.createRange(
+							writer.createPositionAt( modelRoot, 1 ),
+							writer.createPositionAt( modelRoot, 2 )
+						);
+						writer.addMarker( 'search', { range, usingOperation: false } );
+					} );
+
+					expect( viewStringify( viewRoot, null, { ignoreRoot: true } ) )
+						.to.equal( 'f<marker-search></marker-search>o<marker-search></marker-search>o' );
+				} );
+			} );
 		} );
 
 		function testDowncast( input, expectedView ) {

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -83,7 +83,7 @@ describe( 'Conversion', () => {
 		} );
 	} );
 
-	describe.only( 'converters', () => {
+	describe( 'converters', () => {
 		let viewDispatcher, model, schema, conversion, modelRoot, viewRoot;
 
 		beforeEach( () => {

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -678,6 +678,24 @@ describe( 'Conversion', () => {
 						.to.equal( 'f<marker-search></marker-search>o<marker-search></marker-search>o' );
 				} );
 			} );
+
+			describe( 'markerToHighlight()', () => {
+				it( 'adds downcast converter', () => {
+					conversion.for( 'downcast' ).markerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
+
+					model.change( writer => {
+						writer.insertText( 'foo', modelRoot, 0 );
+						const range = writer.createRange(
+							writer.createPositionAt( modelRoot, 0 ),
+							writer.createPositionAt( modelRoot, 3 )
+						);
+						writer.addMarker( 'comment', { range, usingOperation: false } );
+					} );
+
+					expect( viewStringify( viewRoot, null, { ignoreRoot: true } ) )
+						.to.equal( '<span class="comment">foo</span>' );
+				} );
+			} );
 		} );
 
 		function testDowncast( input, expectedView ) {

--- a/tests/conversion/conversion.js
+++ b/tests/conversion/conversion.js
@@ -83,7 +83,7 @@ describe( 'Conversion', () => {
 		} );
 	} );
 
-	describe( 'converters', () => {
+	describe.only( 'converters', () => {
 		let viewDispatcher, model, schema, conversion, modelRoot, viewRoot;
 
 		beforeEach( () => {
@@ -700,12 +700,24 @@ describe( 'Conversion', () => {
 
 		describe( 'for( \'upcast\' )', () => {
 			describe( 'elementToElement()', () => {
-				it( 'adds downcast converter', () => {
+				it( 'adds upcast converter', () => {
 					conversion.for( 'upcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
 					// TODO this shouldn't be required
 					conversion.for( 'downcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
 
 					testUpcast( '<p>foo</p>', '<paragraph>foo</paragraph>' );
+				} );
+			} );
+
+			describe( 'elementToAttribute()', () => {
+				it( 'adds upcast converter', () => {
+					conversion.for( 'upcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
+					conversion.for( 'downcast' ).elementToElement( { model: 'paragraph', view: 'p' } );
+
+					conversion.for( 'upcast' ).elementToAttribute( { model: 'bold', view: 'strong' } );
+					conversion.for( 'downcast' ).attributeToElement( { model: 'bold', view: 'strong' } );
+
+					testUpcast( '<p><strong>Foo</strong> bar</p>', '<paragraph><$text bold="true">Foo</$text> bar</paragraph>' );
 				} );
 			} );
 		} );

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -21,7 +21,11 @@ import log from '@ckeditor/ckeditor5-utils/src/log';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 import {
-	downcastElementToElement, downcastAttributeToElement, downcastAttributeToAttribute, downcastMarkerToElement, downcastMarkerToHighlight,
+	_downcastElementToElement,
+	_downcastAttributeToElement,
+	_downcastAttributeToAttribute,
+	_downcastMarkerToElement,
+	_downcastMarkerToHighlight,
 	insertElement, insertUIElement, changeAttribute, wrap, removeUIElement,
 	highlightElement, highlightText, removeHighlight, createViewElementFromHighlightDescriptor
 } from '../../src/conversion/downcast-converters';
@@ -48,9 +52,9 @@ describe( 'downcast-helpers', () => {
 		conversion.register( { name: 'downcast', dispatcher: controller.downcastDispatcher } );
 	} );
 
-	describe( 'downcastElementToElement', () => {
+	describe( '_downcastElementToElement', () => {
 		it( 'config.view is a string', () => {
-			const helper = downcastElementToElement( { model: 'paragraph', view: 'p' } );
+			const helper = _downcastElementToElement( { model: 'paragraph', view: 'p' } );
 
 			conversion.for( 'downcast' ).add( helper );
 
@@ -62,8 +66,8 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'can be overwritten using converterPriority', () => {
-			const helperA = downcastElementToElement( { model: 'paragraph', view: 'p' } );
-			const helperB = downcastElementToElement( { model: 'paragraph', view: 'foo', converterPriority: 'high' } );
+			const helperA = _downcastElementToElement( { model: 'paragraph', view: 'p' } );
+			const helperB = _downcastElementToElement( { model: 'paragraph', view: 'foo', converterPriority: 'high' } );
 
 			conversion.for( 'downcast' ).add( helperA ).add( helperB );
 
@@ -75,7 +79,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is a view element definition', () => {
-			const helper = downcastElementToElement( {
+			const helper = _downcastElementToElement( {
 				model: 'fancyParagraph',
 				view: {
 					name: 'p',
@@ -93,7 +97,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is a function', () => {
-			const helper = downcastElementToElement( {
+			const helper = _downcastElementToElement( {
 				model: 'heading',
 				view: ( modelElement, viewWriter ) => viewWriter.createContainerElement( 'h' + modelElement.getAttribute( 'level' ) )
 			} );
@@ -108,9 +112,9 @@ describe( 'downcast-helpers', () => {
 		} );
 	} );
 
-	describe( 'downcastAttributeToElement', () => {
+	describe( '_downcastAttributeToElement', () => {
 		it( 'config.view is a string', () => {
-			const helper = downcastAttributeToElement( { model: 'bold', view: 'strong' } );
+			const helper = _downcastAttributeToElement( { model: 'bold', view: 'strong' } );
 
 			conversion.for( 'downcast' ).add( helper );
 
@@ -122,8 +126,8 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'can be overwritten using converterPriority', () => {
-			const helperA = downcastAttributeToElement( { model: 'bold', view: 'strong' } );
-			const helperB = downcastAttributeToElement( { model: 'bold', view: 'b', converterPriority: 'high' } );
+			const helperA = _downcastAttributeToElement( { model: 'bold', view: 'strong' } );
+			const helperB = _downcastAttributeToElement( { model: 'bold', view: 'b', converterPriority: 'high' } );
 
 			conversion.for( 'downcast' ).add( helperA ).add( helperB );
 
@@ -135,7 +139,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is a view element definition', () => {
-			const helper = downcastAttributeToElement( {
+			const helper = _downcastAttributeToElement( {
 				model: 'invert',
 				view: {
 					name: 'span',
@@ -154,7 +158,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view allows specifying the element\'s priority', () => {
-			const helper = downcastAttributeToElement( {
+			const helper = _downcastAttributeToElement( {
 				model: 'invert',
 				view: {
 					name: 'span',
@@ -172,7 +176,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'model attribute value is enum', () => {
-			const helper = downcastAttributeToElement( {
+			const helper = _downcastAttributeToElement( {
 				model: {
 					key: 'fontSize',
 					values: [ 'big', 'small' ]
@@ -218,7 +222,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is a function', () => {
-			const helper = downcastAttributeToElement( {
+			const helper = _downcastAttributeToElement( {
 				model: 'bold',
 				view: ( modelAttributeValue, viewWriter ) => {
 					return viewWriter.createAttributeElement( 'span', { style: 'font-weight:' + modelAttributeValue } );
@@ -235,7 +239,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.model.name is given', () => {
-			const helper = downcastAttributeToElement( {
+			const helper = _downcastAttributeToElement( {
 				model: {
 					key: 'color',
 					name: '$text'
@@ -247,7 +251,7 @@ describe( 'downcast-helpers', () => {
 
 			conversion.for( 'downcast' )
 				.add( helper )
-				.add( downcastElementToElement( {
+				.add( _downcastElementToElement( {
 					model: 'smiley',
 					view: ( modelElement, viewWriter ) => {
 						return viewWriter.createEmptyElement( 'img', {
@@ -266,15 +270,15 @@ describe( 'downcast-helpers', () => {
 		} );
 	} );
 
-	describe( 'downcastAttributeToAttribute', () => {
+	describe( '_downcastAttributeToAttribute', () => {
 		testUtils.createSinonSandbox();
 
 		beforeEach( () => {
-			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'image', view: 'img' } ) );
+			conversion.for( 'downcast' ).add( _downcastElementToElement( { model: 'image', view: 'img' } ) );
 		} );
 
 		it( 'config.view is a string', () => {
-			const helper = downcastAttributeToAttribute( { model: 'source', view: 'src' } );
+			const helper = _downcastAttributeToAttribute( { model: 'source', view: 'src' } );
 
 			conversion.for( 'downcast' ).add( helper );
 
@@ -292,8 +296,8 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'can be overwritten using converterPriority', () => {
-			const helperA = downcastAttributeToAttribute( { model: 'source', view: 'href' } );
-			const helperB = downcastAttributeToAttribute( { model: 'source', view: 'src', converterPriority: 'high' } );
+			const helperA = _downcastAttributeToAttribute( { model: 'source', view: 'href' } );
+			const helperB = _downcastAttributeToAttribute( { model: 'source', view: 'src', converterPriority: 'high' } );
 
 			conversion.for( 'downcast' ).add( helperA ).add( helperB );
 
@@ -305,9 +309,9 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'model element name specified', () => {
-			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
+			conversion.for( 'downcast' ).add( _downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
 
-			const helper = downcastAttributeToAttribute( {
+			const helper = _downcastAttributeToAttribute( {
 				model: {
 					name: 'image',
 					key: 'source'
@@ -331,9 +335,9 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is an object, model attribute value is enum', () => {
-			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
+			conversion.for( 'downcast' ).add( _downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
 
-			const helper = downcastAttributeToAttribute( {
+			const helper = _downcastAttributeToAttribute( {
 				model: {
 					key: 'styled',
 					values: [ 'dark', 'light' ]
@@ -372,9 +376,9 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is an object, model attribute value is enum, view has style', () => {
-			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
+			conversion.for( 'downcast' ).add( _downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
 
-			const helper = downcastAttributeToAttribute( {
+			const helper = _downcastAttributeToAttribute( {
 				model: {
 					key: 'align',
 					values: [ 'right', 'center' ]
@@ -417,9 +421,9 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is an object, only name and key are provided', () => {
-			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
+			conversion.for( 'downcast' ).add( _downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
 
-			const helper = downcastAttributeToAttribute( {
+			const helper = _downcastAttributeToAttribute( {
 				model: {
 					name: 'paragraph',
 					key: 'class'
@@ -452,7 +456,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is a function', () => {
-			const helper = downcastAttributeToAttribute( {
+			const helper = _downcastAttributeToAttribute( {
 				model: 'styled',
 				view: attributeValue => ( { key: 'class', value: 'styled-' + attributeValue } )
 			} );
@@ -470,9 +474,9 @@ describe( 'downcast-helpers', () => {
 		it( 'config.view and config.model as strings in generic conversion (elements only)', () => {
 			const logSpy = testUtils.sinon.spy( log, 'warn' );
 
-			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
+			conversion.for( 'downcast' ).add( _downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
 
-			conversion.for( 'downcast' ).add( downcastAttributeToAttribute( { model: 'test', view: 'test' } ) );
+			conversion.for( 'downcast' ).add( _downcastAttributeToAttribute( { model: 'test', view: 'test' } ) );
 
 			model.change( writer => {
 				writer.insertElement( 'paragraph', { test: '1' }, modelRoot, 0 );
@@ -493,9 +497,9 @@ describe( 'downcast-helpers', () => {
 		it( 'config.view and config.model as strings in generic conversion (elements + text)', () => {
 			const logSpy = testUtils.sinon.spy( log, 'warn' );
 
-			conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
+			conversion.for( 'downcast' ).add( _downcastElementToElement( { model: 'paragraph', view: 'p' } ) );
 
-			conversion.for( 'downcast' ).add( downcastAttributeToAttribute( { model: 'test', view: 'test' } ) );
+			conversion.for( 'downcast' ).add( _downcastAttributeToAttribute( { model: 'test', view: 'test' } ) );
 
 			model.change( writer => {
 				writer.insertElement( 'paragraph', modelRoot, 0 );
@@ -517,9 +521,9 @@ describe( 'downcast-helpers', () => {
 		} );
 	} );
 
-	describe( 'downcastMarkerToElement', () => {
+	describe( '_downcastMarkerToElement', () => {
 		it( 'config.view is a string', () => {
-			const helper = downcastMarkerToElement( { model: 'search', view: 'marker-search' } );
+			const helper = _downcastMarkerToElement( { model: 'search', view: 'marker-search' } );
 
 			conversion.for( 'downcast' ).add( helper );
 
@@ -534,8 +538,8 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'can be overwritten using converterPriority', () => {
-			const helperA = downcastMarkerToElement( { model: 'search', view: 'marker-search' } );
-			const helperB = downcastMarkerToElement( { model: 'search', view: 'search', converterPriority: 'high' } );
+			const helperA = _downcastMarkerToElement( { model: 'search', view: 'marker-search' } );
+			const helperB = _downcastMarkerToElement( { model: 'search', view: 'search', converterPriority: 'high' } );
 
 			conversion.for( 'downcast' ).add( helperA ).add( helperB );
 
@@ -549,7 +553,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is a view element definition', () => {
-			const helper = downcastMarkerToElement( {
+			const helper = _downcastMarkerToElement( {
 				model: 'search',
 				view: {
 					name: 'span',
@@ -571,7 +575,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is a function', () => {
-			const helper = downcastMarkerToElement( {
+			const helper = _downcastMarkerToElement( {
 				model: 'search',
 				view: ( data, viewWriter ) => {
 					return viewWriter.createUIElement( 'span', { 'data-marker': 'search', 'data-start': data.isOpening } );
@@ -590,9 +594,9 @@ describe( 'downcast-helpers', () => {
 		} );
 	} );
 
-	describe( 'downcastMarkerToHighlight', () => {
+	describe( '_downcastMarkerToHighlight', () => {
 		it( 'config.view is a highlight descriptor', () => {
-			const helper = downcastMarkerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
+			const helper = _downcastMarkerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
 
 			conversion.for( 'downcast' ).add( helper );
 
@@ -606,8 +610,8 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'can be overwritten using converterPriority', () => {
-			const helperA = downcastMarkerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
-			const helperB = downcastMarkerToHighlight( { model: 'comment', view: { classes: 'new-comment' }, converterPriority: 'high' } );
+			const helperA = _downcastMarkerToHighlight( { model: 'comment', view: { classes: 'comment' } } );
+			const helperB = _downcastMarkerToHighlight( { model: 'comment', view: { classes: 'new-comment' }, converterPriority: 'high' } );
 
 			conversion.for( 'downcast' ).add( helperA ).add( helperB );
 
@@ -621,7 +625,7 @@ describe( 'downcast-helpers', () => {
 		} );
 
 		it( 'config.view is a function', () => {
-			const helper = downcastMarkerToHighlight( {
+			const helper = _downcastMarkerToHighlight( {
 				model: 'comment',
 				view: data => {
 					const commentType = data.markerName.split( ':' )[ 1 ];

--- a/tests/conversion/downcast-converters.js
+++ b/tests/conversion/downcast-converters.js
@@ -45,7 +45,7 @@ describe( 'downcast-helpers', () => {
 		viewRoot = controller.view.document.getRoot();
 
 		conversion = new Conversion();
-		conversion.register( 'downcast', [ controller.downcastDispatcher ] );
+		conversion.register( { name: 'downcast', dispatcher: controller.downcastDispatcher } );
 	} );
 
 	describe( 'downcastElementToElement', () => {

--- a/tests/conversion/upcast-converters.js
+++ b/tests/conversion/upcast-converters.js
@@ -49,7 +49,7 @@ describe( 'upcast-helpers', () => {
 		upcastDispatcher.on( 'documentFragment', convertToModelFragment(), { priority: 'lowest' } );
 
 		conversion = new Conversion();
-		conversion.register( 'upcast', [ upcastDispatcher ] );
+		conversion.register( { name: 'upcast', dispatcher: upcastDispatcher } );
 	} );
 
 	describe( 'upcastElementToElement', () => {

--- a/tests/conversion/upcast-converters.js
+++ b/tests/conversion/upcast-converters.js
@@ -20,7 +20,7 @@ import ModelRange from '../../src/model/range';
 import ModelPosition from '../../src/model/position';
 
 import {
-	upcastElementToElement, upcastElementToAttribute, upcastAttributeToAttribute, upcastElementToMarker,
+	_upcastElementToElement, _upcastElementToAttribute, _upcastAttributeToAttribute, _upcastElementToMarker,
 	convertToModelFragment, convertText
 } from '../../src/conversion/upcast-converters';
 
@@ -52,9 +52,9 @@ describe( 'upcast-helpers', () => {
 		conversion.register( { name: 'upcast', dispatcher: upcastDispatcher } );
 	} );
 
-	describe( 'upcastElementToElement', () => {
+	describe( '_upcastElementToElement', () => {
 		it( 'config.view is a string', () => {
-			const helper = upcastElementToElement( { view: 'p', model: 'paragraph' } );
+			const helper = _upcastElementToElement( { view: 'p', model: 'paragraph' } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -66,8 +66,8 @@ describe( 'upcast-helpers', () => {
 				inheritAllFrom: '$block'
 			} );
 
-			const helperA = upcastElementToElement( { view: 'p', model: 'p' } );
-			const helperB = upcastElementToElement( { view: 'p', model: 'paragraph', converterPriority: 'high' } );
+			const helperA = _upcastElementToElement( { view: 'p', model: 'p' } );
+			const helperB = _upcastElementToElement( { view: 'p', model: 'paragraph', converterPriority: 'high' } );
 
 			conversion.for( 'upcast' ).add( helperA ).add( helperB );
 
@@ -79,7 +79,7 @@ describe( 'upcast-helpers', () => {
 				inheritAllFrom: '$block'
 			} );
 
-			const helperFancy = upcastElementToElement( {
+			const helperFancy = _upcastElementToElement( {
 				view: {
 					name: 'p',
 					classes: 'fancy'
@@ -99,7 +99,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'level' ]
 			} );
 
-			const helper = upcastElementToElement( {
+			const helper = _upcastElementToElement( {
 				view: {
 					name: 'p',
 					classes: 'heading'
@@ -116,7 +116,7 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'should fire conversion of the element children', () => {
-			const helper = upcastElementToElement( { view: 'p', model: 'paragraph' } );
+			const helper = _upcastElementToElement( { view: 'p', model: 'paragraph' } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -124,7 +124,7 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'should not insert a model element if it is not allowed by schema', () => {
-			const helper = upcastElementToElement( { view: 'h2', model: 'heading' } );
+			const helper = _upcastElementToElement( { view: 'h2', model: 'heading' } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -136,8 +136,8 @@ describe( 'upcast-helpers', () => {
 				inheritAllFrom: '$block'
 			} );
 
-			const helperParagraph = upcastElementToElement( { view: 'p', model: 'paragraph' } );
-			const helperHeading = upcastElementToElement( { view: 'h2', model: 'heading' } );
+			const helperParagraph = _upcastElementToElement( { view: 'p', model: 'paragraph' } );
+			const helperHeading = _upcastElementToElement( { view: 'h2', model: 'heading' } );
 
 			conversion.for( 'upcast' ).add( helperParagraph ).add( helperHeading );
 
@@ -152,8 +152,8 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'should not do anything if returned model element is null', () => {
-			const helperA = upcastElementToElement( { view: 'p', model: 'paragraph' } );
-			const helperB = upcastElementToElement( { view: 'p', model: () => null, converterPriority: 'high' } );
+			const helperA = _upcastElementToElement( { view: 'p', model: 'paragraph' } );
+			const helperB = _upcastElementToElement( { view: 'p', model: () => null, converterPriority: 'high' } );
 
 			conversion.for( 'upcast' ).add( helperA ).add( helperB );
 
@@ -161,9 +161,9 @@ describe( 'upcast-helpers', () => {
 		} );
 	} );
 
-	describe( 'upcastElementToAttribute', () => {
+	describe( '_upcastElementToAttribute', () => {
 		it( 'config.view is string', () => {
-			const helper = upcastElementToAttribute( { view: 'strong', model: 'bold' } );
+			const helper = _upcastElementToAttribute( { view: 'strong', model: 'bold' } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -174,8 +174,8 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'can be overwritten using converterPriority', () => {
-			const helperA = upcastElementToAttribute( { view: 'strong', model: 'strong' } );
-			const helperB = upcastElementToAttribute( { view: 'strong', model: 'bold', converterPriority: 'high' } );
+			const helperA = _upcastElementToAttribute( { view: 'strong', model: 'strong' } );
+			const helperB = _upcastElementToAttribute( { view: 'strong', model: 'bold', converterPriority: 'high' } );
 
 			conversion.for( 'upcast' ).add( helperA ).add( helperB );
 
@@ -186,7 +186,7 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'config.view is an object', () => {
-			const helper = upcastElementToAttribute( {
+			const helper = _upcastElementToAttribute( {
 				view: {
 					name: 'span',
 					classes: 'bold'
@@ -209,7 +209,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'styled' ]
 			} );
 
-			const helper = upcastElementToAttribute( {
+			const helper = _upcastElementToAttribute( {
 				view: {
 					name: 'span',
 					classes: [ 'styled', 'styled-dark' ]
@@ -235,7 +235,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'fontSize' ]
 			} );
 
-			const helper = upcastElementToAttribute( {
+			const helper = _upcastElementToAttribute( {
 				view: {
 					name: 'span',
 					styles: {
@@ -278,7 +278,7 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'should not set an attribute if it is not allowed by schema', () => {
-			const helper = upcastElementToAttribute( { view: 'em', model: 'italic' } );
+			const helper = _upcastElementToAttribute( { view: 'em', model: 'italic' } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -289,8 +289,8 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'should not do anything if returned model attribute is null', () => {
-			const helperA = upcastElementToAttribute( { view: 'strong', model: 'bold' } );
-			const helperB = upcastElementToAttribute( {
+			const helperA = _upcastElementToAttribute( { view: 'strong', model: 'bold' } );
+			const helperB = _upcastElementToAttribute( {
 				view: 'strong',
 				model: {
 					key: 'bold',
@@ -308,12 +308,12 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'should allow two converters to convert attributes on the same element', () => {
-			const helperA = upcastElementToAttribute( {
+			const helperA = _upcastElementToAttribute( {
 				model: 'attribA',
 				view: { name: 'span', classes: 'attrib-a' }
 			} );
 
-			const helperB = upcastElementToAttribute( {
+			const helperB = _upcastElementToAttribute( {
 				model: 'attribB',
 				view: { name: 'span', styles: { color: 'attrib-b' } }
 			} );
@@ -327,17 +327,17 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'should consume element only when only is name specified', () => {
-			const helperBold = upcastElementToAttribute( {
+			const helperBold = _upcastElementToAttribute( {
 				model: 'bold',
 				view: { name: 'strong' }
 			} );
 
-			const helperA = upcastElementToAttribute( {
+			const helperA = _upcastElementToAttribute( {
 				model: 'attribA',
 				view: { name: 'strong' }
 			} );
 
-			const helperB = upcastElementToAttribute( {
+			const helperB = _upcastElementToAttribute( {
 				model: 'attribB',
 				view: { name: 'strong', classes: 'foo' }
 			} );
@@ -352,12 +352,12 @@ describe( 'upcast-helpers', () => {
 
 		// #1443.
 		it( 'should set attributes on the element\'s children', () => {
-			const helperBold = upcastElementToAttribute( {
+			const helperBold = _upcastElementToAttribute( {
 				model: 'bold',
 				view: { name: 'strong' }
 			} );
 
-			const helperP = upcastElementToElement( { view: 'p', model: 'paragraph' } );
+			const helperP = _upcastElementToElement( { view: 'p', model: 'paragraph' } );
 
 			conversion.for( 'upcast' ).add( helperP ).add( helperBold );
 
@@ -372,9 +372,9 @@ describe( 'upcast-helpers', () => {
 		} );
 	} );
 
-	describe( 'upcastAttributeToAttribute', () => {
+	describe( '_upcastAttributeToAttribute', () => {
 		beforeEach( () => {
-			conversion.for( 'upcast' ).add( upcastElementToElement( { view: 'img', model: 'image' } ) );
+			conversion.for( 'upcast' ).add( _upcastElementToElement( { view: 'img', model: 'image' } ) );
 
 			schema.register( 'image', {
 				inheritAllFrom: '$block'
@@ -386,7 +386,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'source' ]
 			} );
 
-			const helper = upcastAttributeToAttribute( { view: 'src', model: 'source' } );
+			const helper = _upcastAttributeToAttribute( { view: 'src', model: 'source' } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -401,7 +401,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'source' ]
 			} );
 
-			const helper = upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source' } );
+			const helper = _upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source' } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -416,7 +416,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'source' ]
 			} );
 
-			const helper = upcastAttributeToAttribute( { view: { name: 'img', key: 'src' }, model: { name: 'image', key: 'source' } } );
+			const helper = _upcastAttributeToAttribute( { view: { name: 'img', key: 'src' }, model: { name: 'image', key: 'source' } } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -431,8 +431,8 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'src', 'source' ]
 			} );
 
-			const helperA = upcastAttributeToAttribute( { view: { key: 'src' }, model: 'src' } );
-			const helperB = upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source', converterPriority: 'normal' } );
+			const helperA = _upcastAttributeToAttribute( { view: { key: 'src' }, model: 'src' } );
+			const helperB = _upcastAttributeToAttribute( { view: { key: 'src' }, model: 'source', converterPriority: 'normal' } );
 
 			conversion.for( 'upcast' ).add( helperA ).add( helperB );
 
@@ -447,7 +447,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'styled' ]
 			} );
 
-			const helper = upcastAttributeToAttribute( {
+			const helper = _upcastAttributeToAttribute( {
 				view: {
 					key: 'data-style',
 					value: /[\s\S]*/
@@ -468,7 +468,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'styled' ]
 			} );
 
-			const helper = upcastAttributeToAttribute( {
+			const helper = _upcastAttributeToAttribute( {
 				view: {
 					name: 'img',
 					key: 'class',
@@ -482,7 +482,7 @@ describe( 'upcast-helpers', () => {
 
 			conversion.for( 'upcast' )
 				.add( helper )
-				.add( upcastElementToElement( { view: 'p', model: 'paragraph' } ) );
+				.add( _upcastElementToElement( { view: 'p', model: 'paragraph' } ) );
 
 			expectResult(
 				new ViewContainerElement( 'img', { class: 'styled-dark' } ),
@@ -505,7 +505,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'styled' ]
 			} );
 
-			const helper = upcastAttributeToAttribute( {
+			const helper = _upcastAttributeToAttribute( {
 				view: {
 					key: 'class',
 					value: /styled-[\S]+/
@@ -530,7 +530,7 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'should not set an attribute if it is not allowed by schema', () => {
-			const helper = upcastAttributeToAttribute( { view: 'src', model: 'source' } );
+			const helper = _upcastAttributeToAttribute( { view: 'src', model: 'source' } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -545,7 +545,7 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'styled' ]
 			} );
 
-			const helperA = upcastAttributeToAttribute( {
+			const helperA = _upcastAttributeToAttribute( {
 				view: {
 					key: 'class',
 					value: 'styled'
@@ -556,7 +556,7 @@ describe( 'upcast-helpers', () => {
 				}
 			} );
 
-			const helperB = upcastAttributeToAttribute( {
+			const helperB = _upcastAttributeToAttribute( {
 				view: {
 					key: 'class',
 					value: 'styled'
@@ -584,10 +584,10 @@ describe( 'upcast-helpers', () => {
 				allowAttributes: [ 'border', 'shade' ]
 			} );
 
-			conversion.for( 'upcast' ).add( upcastElementToElement( { view: 'div', model: 'div' } ) );
+			conversion.for( 'upcast' ).add( _upcastElementToElement( { view: 'div', model: 'div' } ) );
 
-			const shadeHelper = upcastAttributeToAttribute( { view: { key: 'class', value: 'shade' }, model: 'shade' } );
-			const borderHelper = upcastAttributeToAttribute( { view: { key: 'class', value: 'border' }, model: 'border' } );
+			const shadeHelper = _upcastAttributeToAttribute( { view: { key: 'class', value: 'shade' }, model: 'shade' } );
+			const borderHelper = _upcastAttributeToAttribute( { view: { key: 'class', value: 'border' }, model: 'border' } );
 
 			conversion.for( 'upcast' ).add( shadeHelper );
 			conversion.for( 'upcast' ).add( borderHelper );
@@ -603,9 +603,9 @@ describe( 'upcast-helpers', () => {
 		} );
 	} );
 
-	describe( 'upcastElementToMarker', () => {
+	describe( '_upcastElementToMarker', () => {
 		it( 'config.view is a string', () => {
-			const helper = upcastElementToMarker( { view: 'marker-search', model: 'search' } );
+			const helper = _upcastElementToMarker( { view: 'marker-search', model: 'search' } );
 
 			conversion.for( 'upcast' ).add( helper );
 
@@ -623,8 +623,8 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'can be overwritten using converterPriority', () => {
-			const helperA = upcastElementToMarker( { view: 'marker-search', model: 'search-result' } );
-			const helperB = upcastElementToMarker( { view: 'marker-search', model: 'search', converterPriority: 'high' } );
+			const helperA = _upcastElementToMarker( { view: 'marker-search', model: 'search-result' } );
+			const helperB = _upcastElementToMarker( { view: 'marker-search', model: 'search', converterPriority: 'high' } );
 
 			conversion.for( 'upcast' ).add( helperA ).add( helperB );
 
@@ -642,7 +642,7 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'config.view is an object', () => {
-			const helper = upcastElementToMarker( {
+			const helper = _upcastElementToMarker( {
 				view: {
 					name: 'span',
 					'data-marker': 'search'
@@ -666,7 +666,7 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'config.model is a function', () => {
-			const helper = upcastElementToMarker( {
+			const helper = _upcastElementToMarker( {
 				view: 'comment',
 				model: viewElement => 'comment:' + viewElement.getAttribute( 'data-comment-id' )
 			} );
@@ -687,9 +687,9 @@ describe( 'upcast-helpers', () => {
 		} );
 
 		it( 'marker is in a block element', () => {
-			conversion.for( 'upcast' ).add( upcastElementToElement( { model: 'paragraph', view: 'p' } ) );
+			conversion.for( 'upcast' ).add( _upcastElementToElement( { model: 'paragraph', view: 'p' } ) );
 
-			const helper = upcastElementToMarker( { view: 'marker-search', model: 'search' } );
+			const helper = _upcastElementToMarker( { view: 'marker-search', model: 'search' } );
 
 			conversion.for( 'upcast' ).add( helper );
 

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -9,11 +9,6 @@ import {
 	upcastElementToElement,
 } from '../../src/conversion/upcast-converters';
 
-import {
-	downcastElementToElement,
-	downcastMarkerToHighlight
-} from '../../src/conversion/downcast-converters';
-
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
@@ -44,7 +39,7 @@ class FancyWidget extends Plugin {
 		} );
 		schema.extend( 'fancywidget', { allowIn: '$root' } );
 
-		conversion.for( 'editingDowncast' ).add( downcastElementToElement( {
+		conversion.for( 'editingDowncast' ).elementToElement( {
 			model: 'fancywidget',
 			view: ( modelItem, viewWriter ) => {
 				const widgetElement = viewWriter.createContainerElement( 'figure', { class: 'fancy-widget' } );
@@ -52,7 +47,7 @@ class FancyWidget extends Plugin {
 
 				return toWidget( widgetElement, viewWriter );
 			}
-		} ) );
+		} );
 
 		conversion.for( 'upcast' )
 			.add( upcastElementToElement( {
@@ -69,12 +64,12 @@ ClassicEditor.create( global.document.querySelector( '#editor' ), {
 	.then( editor => {
 		window.editor = editor;
 
-		editor.conversion.for( 'editingDowncast' ).add( downcastMarkerToHighlight( {
+		editor.conversion.for( 'editingDowncast' ).markerToHighlight( {
 			model: 'marker',
 			view: data => ( {
 				classes: 'highlight-' + data.markerName.split( ':' )[ 1 ]
 			} )
-		} ) );
+		} );
 
 		document.getElementById( 'add-marker-yellow' ).addEventListener( 'mousedown', evt => {
 			addMarker( editor, 'yellow' );

--- a/tests/manual/highlight.js
+++ b/tests/manual/highlight.js
@@ -5,10 +5,6 @@
 
 /* global console, window, document */
 
-import {
-	upcastElementToElement,
-} from '../../src/conversion/upcast-converters';
-
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
@@ -49,11 +45,10 @@ class FancyWidget extends Plugin {
 			}
 		} );
 
-		conversion.for( 'upcast' )
-			.add( upcastElementToElement( {
-				view: 'figure',
-				model: 'fancywidget'
-			} ) );
+		conversion.for( 'upcast' ).elementToElement( {
+			view: 'figure',
+			model: 'fancywidget'
+		} );
 	}
 }
 

--- a/tests/manual/markers.js
+++ b/tests/manual/markers.js
@@ -15,10 +15,6 @@ import List from '@ckeditor/ckeditor5-list/src/list';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 
-import {
-	downcastMarkerToHighlight
-} from '../../src/conversion/downcast-converters';
-
 import Position from '../../src/model/position';
 import Range from '../../src/model/range';
 
@@ -35,7 +31,7 @@ ClassicEditor
 		window.editor = editor;
 		model = editor.model;
 
-		editor.conversion.for( 'editingDowncast' ).add( downcastMarkerToHighlight( {
+		editor.conversion.for( 'editingDowncast' ).markerToHighlight( {
 			model: 'highlight',
 			view: data => {
 				const color = data.markerName.split( ':' )[ 1 ];
@@ -45,9 +41,9 @@ ClassicEditor
 					priority: 1
 				};
 			}
-		} ) );
+		} );
 
-		editor.conversion.for( 'dataDowncast' ).add( downcastMarkerToHighlight( {
+		editor.conversion.for( 'dataDowncast' ).markerToHighlight( {
 			model: 'highlight',
 			view: data => {
 				const color = data.markerName.split( ':' )[ 1 ];
@@ -57,7 +53,7 @@ ClassicEditor
 					priority: 1
 				};
 			}
-		} ) );
+		} );
 
 		window.document.getElementById( 'add-yellow' ).addEventListener( 'mousedown', e => {
 			e.preventDefault();

--- a/tests/manual/nestededitable.js
+++ b/tests/manual/nestededitable.js
@@ -9,10 +9,6 @@ import {
 	upcastElementToElement
 } from '../../src/conversion/upcast-converters';
 
-import {
-	downcastElementToElement
-} from '../../src/conversion/downcast-converters';
-
 import { getData } from '../../src/dev-utils/model';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
@@ -41,7 +37,7 @@ class NestedEditable extends Plugin {
 			allowIn: [ 'figure', 'figcaption' ]
 		} );
 
-		editor.conversion.for( 'downcast' ).add( downcastElementToElement( {
+		editor.conversion.for( 'downcast' ).elementToElement( {
 			model: 'figure',
 			view: {
 				name: 'figure',
@@ -49,14 +45,14 @@ class NestedEditable extends Plugin {
 					contenteditable: 'false'
 				}
 			}
-		} ) );
+		} );
 
 		editor.conversion.for( 'upcast' ).add( upcastElementToElement( {
 			model: 'figure',
 			view: 'figure'
 		} ) );
 
-		editor.conversion.for( 'downcast' ).add( downcastElementToElement( {
+		editor.conversion.for( 'downcast' ).elementToElement( {
 			model: 'figcaption',
 			view: ( modelItem, viewWriter ) => {
 				const element = viewWriter.createEditableElement( 'figcaption', { contenteditable: 'true' } );
@@ -71,7 +67,7 @@ class NestedEditable extends Plugin {
 
 				return element;
 			}
-		} ) );
+		} );
 
 		editor.conversion.for( 'upcast' ).add( upcastElementToElement( {
 			model: 'figcaption',

--- a/tests/manual/nestededitable.js
+++ b/tests/manual/nestededitable.js
@@ -5,10 +5,6 @@
 
 /* global console */
 
-import {
-	upcastElementToElement
-} from '../../src/conversion/upcast-converters';
-
 import { getData } from '../../src/dev-utils/model';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
@@ -47,10 +43,10 @@ class NestedEditable extends Plugin {
 			}
 		} );
 
-		editor.conversion.for( 'upcast' ).add( upcastElementToElement( {
+		editor.conversion.for( 'upcast' ).elementToElement( {
 			model: 'figure',
 			view: 'figure'
-		} ) );
+		} );
 
 		editor.conversion.for( 'downcast' ).elementToElement( {
 			model: 'figcaption',
@@ -69,10 +65,10 @@ class NestedEditable extends Plugin {
 			}
 		} );
 
-		editor.conversion.for( 'upcast' ).add( upcastElementToElement( {
+		editor.conversion.for( 'upcast' ).elementToElement( {
 			model: 'figcaption',
 			view: 'figcaption'
-		} ) );
+		} );
 	}
 }
 

--- a/tests/manual/selection.js
+++ b/tests/manual/selection.js
@@ -14,7 +14,6 @@ import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
-import { upcastElementToElement } from '../../src/conversion/upcast-converters';
 
 import './selection.css';
 import { toWidget, toWidgetEditable } from '@ckeditor/ckeditor5-widget/src/utils';
@@ -42,9 +41,9 @@ class SelectionTest extends Plugin {
 			isLimit: true
 		} );
 
-		editor.conversion.for( 'upcast' ).add( upcastElementToElement( { model: 'table', view: 'table' } ) );
-		editor.conversion.for( 'upcast' ).add( upcastElementToElement( { model: 'tableRow', view: 'tr' } ) );
-		editor.conversion.for( 'upcast' ).add( upcastElementToElement( { model: 'tableCell', view: 'td' } ) );
+		editor.conversion.for( 'upcast' ).elementToElement( { model: 'table', view: 'table' } );
+		editor.conversion.for( 'upcast' ).elementToElement( { model: 'tableRow', view: 'tr' } );
+		editor.conversion.for( 'upcast' ).elementToElement( { model: 'tableCell', view: 'td' } );
 
 		editor.conversion.for( 'downcast' ).elementToElement( {
 			model: 'table',

--- a/tests/manual/selection.js
+++ b/tests/manual/selection.js
@@ -5,8 +5,6 @@
 
 /* global console */
 
-import { downcastElementToElement } from '../../src/conversion/downcast-converters';
-
 import { getData } from '../../src/dev-utils/model';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
@@ -48,20 +46,20 @@ class SelectionTest extends Plugin {
 		editor.conversion.for( 'upcast' ).add( upcastElementToElement( { model: 'tableRow', view: 'tr' } ) );
 		editor.conversion.for( 'upcast' ).add( upcastElementToElement( { model: 'tableCell', view: 'td' } ) );
 
-		editor.conversion.for( 'downcast' ).add( downcastElementToElement( {
+		editor.conversion.for( 'downcast' ).elementToElement( {
 			model: 'table',
 			view: ( modelItem, viewWriter ) => {
 				return toWidget( viewWriter.createContainerElement( 'table' ), viewWriter );
 			}
-		} ) );
-		editor.conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'tableRow', view: 'tr' } ) );
+		} );
+		editor.conversion.for( 'downcast' ).elementToElement( { model: 'tableRow', view: 'tr' } );
 
-		editor.conversion.for( 'downcast' ).add( downcastElementToElement( {
+		editor.conversion.for( 'downcast' ).elementToElement( {
 			model: 'tableCell',
 			view: ( modelItem, viewWriter ) => {
 				return toWidgetEditable( viewWriter.createEditableElement( 'td' ), viewWriter );
 			}
-		} ) );
+		} );
 	}
 }
 

--- a/tests/manual/tickets/475/1.js
+++ b/tests/manual/tickets/475/1.js
@@ -15,10 +15,6 @@ import {
 	upcastElementToAttribute
 } from '../../../../src/conversion/upcast-converters';
 
-import {
-	downcastAttributeToElement,
-} from '../../../../src/conversion/downcast-converters';
-
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
@@ -31,12 +27,12 @@ class Link extends Plugin {
 		// Allow bold attribute on all inline nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: 'link' } );
 
-		editor.conversion.for( 'downcast' ).add( downcastAttributeToElement( {
+		editor.conversion.for( 'downcast' ).attributeToElement( {
 			model: 'link',
 			view: ( modelAttributeValue, viewWriter ) => {
 				return viewWriter.createAttributeElement( 'a', { href: modelAttributeValue } );
 			}
-		} ) );
+		} );
 
 		editor.conversion.for( 'upcast' ).add( upcastElementToAttribute( {
 			view: 'a',

--- a/tests/manual/tickets/475/1.js
+++ b/tests/manual/tickets/475/1.js
@@ -11,10 +11,6 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Range from '../../../../src/model/range';
 import LivePosition from '../../../../src/model/liveposition';
 
-import {
-	upcastElementToAttribute
-} from '../../../../src/conversion/upcast-converters';
-
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
@@ -34,13 +30,13 @@ class Link extends Plugin {
 			}
 		} );
 
-		editor.conversion.for( 'upcast' ).add( upcastElementToAttribute( {
+		editor.conversion.for( 'upcast' ).elementToAttribute( {
 			view: 'a',
 			model: {
 				key: 'link',
 				value: viewElement => viewElement.getAttribute( 'href' )
 			}
-		} ) );
+		} );
 	}
 }
 

--- a/tests/manual/tickets/ckeditor5-721/1.js
+++ b/tests/manual/tickets/ckeditor5-721/1.js
@@ -13,7 +13,6 @@ import { toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 
 import ViewPosition from '../../../../src/view/position';
-import { downcastElementToElement } from '../../../../src/conversion/downcast-converters';
 import { setData } from '../../../../src/dev-utils/model';
 
 ClassicEditor
@@ -41,7 +40,7 @@ ClassicEditor
 		} );
 
 		editor.conversion.for( 'downcast' )
-			.add( downcastElementToElement( {
+			.elementToElement( {
 				model: 'widget',
 				view: ( modelItem, writer ) => {
 					const b = writer.createAttributeElement( 'b' );
@@ -51,11 +50,11 @@ ClassicEditor
 
 					return toWidget( div, writer, { label: 'element label' } );
 				}
-			} ) )
-			.add( downcastElementToElement( {
+			} )
+			.elementToElement( {
 				model: 'nested',
 				view: ( item, writer ) => writer.createEditableElement( 'figcaption', { contenteditable: true } )
-			} ) );
+			} );
 
 		setData( editor.model,
 			'<paragraph>foo[]</paragraph>' +

--- a/tests/tickets/699.js
+++ b/tests/tickets/699.js
@@ -8,10 +8,6 @@
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
-import {
-	upcastElementToElement
-} from '../../src/conversion/upcast-converters';
-
 import { getData as getModelData } from '../../src/dev-utils/model';
 import { getData as getViewData } from '../../src/dev-utils/view';
 
@@ -55,8 +51,8 @@ function WidgetPlugin( editor ) {
 		view: 'widget'
 	} );
 
-	editor.conversion.for( 'upcast' ).add( upcastElementToElement( {
+	editor.conversion.for( 'upcast' ).elementToElement( {
 		model: 'widget',
 		view: 'widget'
-	} ) );
+	} );
 }

--- a/tests/tickets/699.js
+++ b/tests/tickets/699.js
@@ -12,10 +12,6 @@ import {
 	upcastElementToElement
 } from '../../src/conversion/upcast-converters';
 
-import {
-	downcastElementToElement
-} from '../../src/conversion/downcast-converters';
-
 import { getData as getModelData } from '../../src/dev-utils/model';
 import { getData as getViewData } from '../../src/dev-utils/view';
 
@@ -54,10 +50,10 @@ function WidgetPlugin( editor ) {
 	} );
 	schema.extend( 'widget', { allowIn: '$root' } );
 
-	editor.conversion.for( 'downcast' ).add( downcastElementToElement( {
+	editor.conversion.for( 'downcast' ).elementToElement( {
 		model: 'widget',
 		view: 'widget'
-	} ) );
+	} );
 
 	editor.conversion.for( 'upcast' ).add( upcastElementToElement( {
 		model: 'widget',

--- a/tests/utils/bindtwostepcarettoattribute.js
+++ b/tests/utils/bindtwostepcarettoattribute.js
@@ -11,7 +11,6 @@ import DomEventData from '../../src/view/observer/domeventdata';
 import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import bindTwoStepCaretToAttribute from '../../src/utils/bindtwostepcarettoattribute';
 import Position from '../../src/model/position';
-import { upcastElementToAttribute } from '../../src/conversion/upcast-converters';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import { setData } from '../../src/dev-utils/model';
 
@@ -37,9 +36,9 @@ describe( 'bindTwoStepCaretToAttribute()', () => {
 			} );
 
 			model.schema.register( 'paragraph', { inheritAllFrom: '$block' } );
-			editor.conversion.for( 'upcast' ).add( upcastElementToAttribute( { view: 'a', model: 'a' } ) );
-			editor.conversion.for( 'upcast' ).add( upcastElementToAttribute( { view: 'b', model: 'b' } ) );
-			editor.conversion.for( 'upcast' ).add( upcastElementToAttribute( { view: 'c', model: 'c' } ) );
+			editor.conversion.for( 'upcast' ).elementToAttribute( { view: 'a', model: 'a' } );
+			editor.conversion.for( 'upcast' ).elementToAttribute( { view: 'b', model: 'b' } );
+			editor.conversion.for( 'upcast' ).elementToAttribute( { view: 'c', model: 'c' } );
 			editor.conversion.elementToElement( { model: 'paragraph', view: 'p' } );
 
 			bindTwoStepCaretToAttribute( editor.editing.view, editor.model, emitter, 'a' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Enhancement: Expose conversion utilities. Closes #1556.

BREAKING CHANGE: The `conversion.register()` method now accepts single options object as a parameter.
BREAKING CHANGE: The `downcastElementToElement()` helper was removed from public API. Use `conversion.for( 'downcast' ).elementToElement()` instead.
BREAKING CHANGE: The `downcastAttributeToElement()` helper was removed from public API. Use `conversion.for( 'downcast' ).attributeToElement()` instead.
BREAKING CHANGE: The `downcastAttributeToAttribute()` helper was removed from public API. Use `conversion.for( 'downcast' ).attributeToAttribute()` instead.
BREAKING CHANGE: The `downcastMarkerToElement()` helper was removed from public API. Use `conversion.for( 'downcast' ).markerToElement()` instead.
BREAKING CHANGE: The `downcastMarkerToHighlight()` helper was removed from public API. Use `conversion.for( 'downcast' ).markerToHighlight()` instead.
BREAKING CHANGE: The `upcastElementToElement()` helper was removed from public API. Use `conversion.for( 'upcast' ).elementToElement()` instead.
BREAKING CHANGE: The `upcastElementToAttribute()` helper was removed from public API. Use `conversion.for( 'upcast' ).elementToAttribute()` instead.
BREAKING CHANGE: The `upcastAttributeToAttribute()` helper was removed from public API. Use `conversion.for( 'upcast' ).attributeToAttribute()` instead.
BREAKING CHANGE: The `upcastElementToMarker()` helper was removed from public API. Use `conversion.for( 'upcast' ).elementToMarker()` instead.

---

### Additional information

* This PR comes with constelation of change gathered in [ckeditor5 branch](https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-engine/1556).
* I think that I've exposed all the required utilities:
	* For downcast (model-to-view conversion), these are:
		* `elementToElement`
		* `attributeToElement`
		* `attributeToAttribute`
		* `markerToElement`
		* `markerToHighlight`
	* For upcast (view-to-model conversion), these are:
		* `elementToElement`
		* `elementToAttribute`
		* `attributeToAttribute`
		* `elementToMarker`
* All above converter methods are marked as `@protected` and underscored.
* The API is still chainable (the helpers uses `this.add()` internally to add a protected converter):
	```js
	editor.conversion.for( 'upcast' )
		.add( customConverterA )
		.elementToElement( { model: 'foo', view: 'bar' } )
		.add( customConverterB )
		.elementToAttribute( { model: 'baz', view: 'bez' } );
	```

---
Some questions:
- There are other exported methods in those files - what to do with them? Chceck the code end remove exports if used internally? Methods like `convertText()`, `convertToModelFragment()` etc.
- The functions were left in place to not loose `git blame` immediate history in those functions. Also in this file export and private methods are mixed - should we sort them as `public export > protected export > internal/private`?