### PR TITLE
T/1616: Hide wrap from public API

### DIFF
--- a/src/conversion/downcasthelpers.js
+++ b/src/conversion/downcasthelpers.js
@@ -444,10 +444,11 @@ export function createViewElementFromHighlightDescriptor( descriptor ) {
  * The converter automatically consumes the corresponding value from the consumables list and stops the event (see
  * {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher}).
  *
- *		modelDispatcher.on( 'attribute:bold', wrapItem( ( modelAttributeValue, viewWriter ) => {
+ *		modelDispatcher.on( 'attribute:bold', wrap( ( modelAttributeValue, viewWriter ) => {
  *			return viewWriter.createAttributeElement( 'strong' );
  *		} );
  *
+ * @protected
  * @param {Function} elementCreator Function returning a view element that will be used for wrapping.
  * @returns {Function} Set/change attribute converter.
  */

--- a/tests/conversion/downcast-selection-converters.js
+++ b/tests/conversion/downcast-selection-converters.js
@@ -16,7 +16,7 @@ import {
 	clearAttributes,
 } from '../../src/conversion/downcast-selection-converters';
 
-import DowncastHelpers, { insertText, wrap } from '../../src/conversion/downcasthelpers';
+import DowncastHelpers, { insertText } from '../../src/conversion/downcasthelpers';
 
 import createViewRoot from '../view/_utils/createroot';
 import { stringify as stringifyView } from '../../src/dev-utils/view';
@@ -45,10 +45,8 @@ describe( 'downcast-selection-converters', () => {
 
 		dispatcher.on( 'insert:$text', insertText() );
 
-		const strongCreator = ( modelAttributeValue, viewWriter ) => viewWriter.createAttributeElement( 'strong' );
-		dispatcher.on( 'attribute:bold', wrap( strongCreator ) );
-
 		downcastHelpers = new DowncastHelpers( dispatcher );
+		downcastHelpers.attributeToElement( { model: 'bold', view: 'strong' } );
 		downcastHelpers.markerToHighlight( { model: 'marker', view: { classes: 'marker' }, converterPriority: 1 } );
 
 		// Default selection converters.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove wrap from public API. Closes #1616.

BREAKING CHANGE: The `wrap()` conversion helper was removed from public API.

---

### Additional information

* After #1624.
