### PR TITLE
Swapped the order of parameters in "Schema#findAllowedParent()"

### DIFF
--- a/src/conversion/upcastdispatcher.js
+++ b/src/conversion/upcastdispatcher.js
@@ -263,7 +263,7 @@ export default class UpcastDispatcher {
 	 */
 	_splitToAllowedParent( node, modelCursor ) {
 		// Try to find allowed parent.
-		const allowedParent = this.conversionApi.schema.findAllowedParent( node, modelCursor );
+		const allowedParent = this.conversionApi.schema.findAllowedParent( modelCursor, node );
 
 		// When there is no parent that allows to insert node then return `null`.
 		if ( !allowedParent ) {

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -588,11 +588,11 @@ export default class Schema {
 	 * as long as {@link module:engine/model/schema~Schema#isLimit limit element},
 	 * {@link module:engine/model/schema~Schema#isObject object element} or top-most ancestor won't be reached.
 	 *
-	 * @params {module:engine/model/node~Node|String} node Node for which allowed parent should be found or its name.
 	 * @params {module:engine/model/position~Position} position Position from searching will start.
+	 * @params {module:engine/model/node~Node|String} node Node for which allowed parent should be found or its name.
 	 * @returns {module:engine/model/element~Element|null} element Allowed parent or null if nothing was found.
 	 */
-	findAllowedParent( node, position ) {
+	findAllowedParent( position, node ) {
 		let parent = position.parent;
 
 		while ( parent ) {

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -1574,13 +1574,13 @@ describe( 'Schema', () => {
 		it( 'should return position ancestor that allows to insert given node to it', () => {
 			const node = new Element( 'paragraph' );
 
-			const allowedParent = schema.findAllowedParent( node, Position._createAt( r1bQp, 0 ) );
+			const allowedParent = schema.findAllowedParent( Position._createAt( r1bQp, 0 ), node );
 
 			expect( allowedParent ).to.equal( r1bQ );
 		} );
 
 		it( 'should return position ancestor that allows to insert given node to it - works with a string too', () => {
-			const allowedParent = schema.findAllowedParent( 'paragraph', Position._createAt( r1bQp, 0 ) );
+			const allowedParent = schema.findAllowedParent( Position._createAt( r1bQp, 0 ), 'paragraph' );
 
 			expect( allowedParent ).to.equal( r1bQ );
 		} );
@@ -1588,7 +1588,7 @@ describe( 'Schema', () => {
 		it( 'should return position ancestor that allows to insert given node to it when position is already i such an element', () => {
 			const node = new Text( 'text' );
 
-			const parent = schema.findAllowedParent( node, Position._createAt( r1bQp, 0 ) );
+			const parent = schema.findAllowedParent( Position._createAt( r1bQp, 0 ), node );
 
 			expect( parent ).to.equal( r1bQp );
 		} );
@@ -1602,7 +1602,7 @@ describe( 'Schema', () => {
 			} );
 			const node = new Element( 'div' );
 
-			const parent = schema.findAllowedParent( node, Position._createAt( r1bQp, 0 ) );
+			const parent = schema.findAllowedParent( Position._createAt( r1bQp, 0 ), node );
 
 			expect( parent ).to.null;
 		} );
@@ -1616,7 +1616,7 @@ describe( 'Schema', () => {
 			} );
 			const node = new Element( 'div' );
 
-			const parent = schema.findAllowedParent( node, Position._createAt( r1bQp, 0 ) );
+			const parent = schema.findAllowedParent( Position._createAt( r1bQp, 0 ), node );
 
 			expect( parent ).to.null;
 		} );
@@ -1624,13 +1624,13 @@ describe( 'Schema', () => {
 		it( 'should return null when there is no allowed ancestor for given position', () => {
 			const node = new Element( 'section' );
 
-			const parent = schema.findAllowedParent( node, Position._createAt( r1bQp, 0 ) );
+			const parent = schema.findAllowedParent( Position._createAt( r1bQp, 0 ), node );
 
 			expect( parent ).to.null;
 		} );
 
 		it( 'should return null when there is no allowed ancestor for given position – works with a string too', () => {
-			const parent = schema.findAllowedParent( 'section', Position._createAt( r1bQp, 0 ) );
+			const parent = schema.findAllowedParent( Position._createAt( r1bQp, 0 ), 'section' );
 
 			expect( parent ).to.null;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Swapped the order of parameters in `Schema#findAllowedParent()`. Closes #1636.

BREAKING CHANGE: Swapped the order of parameters in `Schema#findAllowedParent()`. Now those parameters match to parameters in other methods of the `Schema` class.
