### PR TITLE
The selection.getSelectedBlocks() should not return parent nodes beyond limit ancestors.

### DIFF
--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -809,10 +809,25 @@ function isUnvisitedBlockContainer( element, visited ) {
 }
 
 // Finds the lowest element in position's ancestors which is a block.
+// It will search until first ancestor that is a limit element.
 // Marks all ancestors as already visited to not include any of them later on.
 function getParentBlock( position, visited ) {
+	const schema = position.parent.document.model.schema;
+
 	const ancestors = position.parent.getAncestors( { parentFirst: true, includeSelf: true } );
-	const block = ancestors.find( element => isUnvisitedBlockContainer( element, visited ) );
+
+	let hasParentLimit = false;
+
+	const block = ancestors.find( element => {
+		// Stop searching after first parent node that is limit element.
+		if ( hasParentLimit ) {
+			return false;
+		}
+
+		hasParentLimit = schema.isLimit( element );
+
+		return !hasParentLimit && isUnvisitedBlockContainer( element, visited );
+	} );
 
 	// Mark all ancestors of this position's parent, because find() might've stopped early and
 	// the found block may be a child of another block.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `selection.getTopMostBlocks()` should not return blocks above ancestor of "limit" type. Closes ckeditor/ckeditor5-table#163.

---

### Additional information

* As it turned out the `selection.getSelectedBlocks()` used inside `<table>` returned wrong blocks - it was not respecting elements of type "limit" - https://github.com/ckeditor/ckeditor5-table/issues/163#issuecomment-456800669.
* More integration tests added in block quote feature: https://github.com/ckeditor/ckeditor5-block-quote/pull/31.
* PR in image: https://github.com/ckeditor/ckeditor5-image/pull/272.