### PR TITLE
Rename `editor#dataReady` event as `editor.data#ready`

### DIFF
--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -103,6 +103,12 @@ export default class DataController {
 		this.upcastDispatcher.on( 'documentFragment', convertToModelFragment(), { priority: 'lowest' } );
 
 		this.decorate( 'init' );
+
+		// Fire `ready` event when initialisation has completed. Such low level listener gives possibility
+		// to plug into initialisation pipeline without interrupting the initialisation flow.
+		this.on( 'init', () => {
+			this.fire( 'ready' );
+		}, { priority: 'lowest' } );
 	}
 
 	/**
@@ -371,6 +377,12 @@ export default class DataController {
 
 		return true;
 	}
+
+	/**
+	 * Event fired once data initialisation has finished.
+	 *
+	 * @event ready
+	 */
 
 	/**
 	 * Event fired by decorated {@link #init} method.

--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -386,7 +386,7 @@ export default class DataController {
 
 	/**
 	 * Event fired after {@link #init init() method} has been run. It can be {@link #listenTo listened to} to adjust/modify
-	 * the initialisation flow. However, if the `init` event is stopped or prevented, the {@link #event:ready} event
+	 * the initialisation flow. However, if the `init` event is stopped or prevented, the {@link #event:ready ready event}
 	 * should be fired manually.
 	 *
 	 * The `init` event is fired by decorated {@link #init} method.

--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -385,7 +385,11 @@ export default class DataController {
 	 */
 
 	/**
-	 * Event fired by decorated {@link #init} method.
+	 * Event fired after {@link #init init() method} has been run. It can be {@link #listenTo listened to} to adjust/modify
+	 * the initialisation flow. However, if the `init` event is stopped or prevented, the {@link #event:ready} event
+	 * should be fired manually.
+	 *
+	 * The `init` event is fired by decorated {@link #init} method.
 	 * See {@link module:utils/observablemixin~ObservableMixin.decorate} for more information and samples.
 	 *
 	 * @event init

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -160,6 +160,16 @@ describe( 'DataController', () => {
 			sinon.assert.calledWithExactly( spy, sinon.match.any, [ 'foo bar' ] );
 		} );
 
+		it( 'should fire ready event after init', () => {
+			const spy = sinon.spy();
+
+			data.on( 'ready', spy );
+
+			data.init( 'foo bar' );
+
+			sinon.assert.called( spy );
+		} );
+
 		it( 'should throw an error when document data is already initialized', () => {
 			data.init( '<p>Foo</p>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Introduced `editor.data#ready` event.

BREAKING CHANGE: The `editor#dataReady` event was removed. The `editor.data#ready` event has been introduced and should be used instead.

---

### Additional information

See https://github.com/ckeditor/ckeditor5/issues/1477 for more details. This PR mostly covers renaming `dataReady` event (but also necessary adjustments to new `plugins#ready` event). The second PR (renaming `pluginsReady` event) is https://github.com/ckeditor/ckeditor5-core/pull/157.

Created `ckeditor5` branch with all the changes - https://github.com/ckeditor/ckeditor5/tree/t/1477.

The list of related PRs in other repos which needed adjustments:
* `ckeditor5-autosave` - https://github.com/ckeditor/ckeditor5-autosave/pull/22
* `ckeditor5-core` - https://github.com/ckeditor/ckeditor5-core/pull/157
* `ckeditor5-editor-balloon` - https://github.com/ckeditor/ckeditor5-editor-balloon/pull/27
* `ckeditor5-editor-classic` - https://github.com/ckeditor/ckeditor5-editor-classic/pull/80
* `ckeditor5-editor-decoupled` - https://github.com/ckeditor/ckeditor5-editor-decoupled/pull/26
* `ckeditor5-editor-inline` - https://github.com/ckeditor/ckeditor5-editor-inline/pull/46
* `ckeditor5-ui` - https://github.com/ckeditor/ckeditor5-ui/pull/464
* `ckeditor5-paragraph` - https://github.com/ckeditor/ckeditor5-paragraph/pull/40
