### PR TITLE
Fix: MarkerOperation OT cases for undo

### DIFF
--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -504,13 +504,12 @@ export default class Writer {
 		this._assertWriterUsedCorrectly();
 
 		const rangeToRemove = itemOrRange instanceof Range ? itemOrRange : Range._createOn( itemOrRange );
-
-		// If part of the marker is removed, create additional marker operation for undo purposes.
-		this._addOperationForAffectedMarkers( 'move', rangeToRemove );
-
 		const ranges = rangeToRemove.getMinimalFlatRanges().reverse();
 
 		for ( const flat of ranges ) {
+			// If part of the marker is removed, create additional marker operation for undo purposes.
+			this._addOperationForAffectedMarkers( 'move', flat );
+
 			applyRemoveOperation( flat.start, flat.end.offset - flat.start.offset, this.batch, this.model );
 		}
 	}

--- a/tests/model/operation/transform/undo.js
+++ b/tests/model/operation/transform/undo.js
@@ -463,4 +463,68 @@ describe( 'transform', () => {
 
 		expectClients( '<paragraph><m1:start></m1:start>Foo<m1:end></m1:end>bar</paragraph><paragraph></paragraph>' );
 	} );
+
+	it( 'marker on closing and opening tag - remove multiple elements #1', () => {
+		john.setData(
+			'<paragraph>Abc</paragraph>' +
+			'<paragraph>Foo[</paragraph>' +
+			'<paragraph>]Bar</paragraph>'
+		);
+
+		john.setMarker( 'm1' );
+		john.setSelection( [ 0, 1 ], [ 2, 2 ] );
+		john._processExecute( 'delete' );
+
+		expectClients( '<paragraph>A<m1:start></m1:start>r</paragraph>' );
+
+		john.undo();
+
+		expectClients(
+			'<paragraph>Abc</paragraph>' +
+			'<paragraph>Foo<m1:start></m1:start></paragraph>' +
+			'<paragraph><m1:end></m1:end>Bar</paragraph>'
+		);
+	} );
+
+	it( 'marker on closing and opening tag - remove multiple elements #2', () => {
+		john.setData(
+			'<paragraph>Foo[</paragraph>' +
+			'<paragraph>]Bar</paragraph>' +
+			'<paragraph>Xyz</paragraph>'
+		);
+
+		john.setMarker( 'm1' );
+		john.setSelection( [ 0, 1 ], [ 2, 2 ] );
+		john._processExecute( 'delete' );
+
+		expectClients( '<paragraph>F<m1:start></m1:start>z</paragraph>' );
+
+		john.undo();
+
+		expectClients(
+			'<paragraph>Foo<m1:start></m1:start></paragraph>' +
+			'<paragraph><m1:end></m1:end>Bar</paragraph>' +
+			'<paragraph>Xyz</paragraph>'
+		);
+	} );
+
+	it( 'marker on closing and opening tag + some text - merge elements + remove text', () => {
+		john.setData(
+			'<paragraph>Foo[</paragraph>' +
+			'<paragraph>B]ar</paragraph>'
+		);
+
+		john.setMarker( 'm1' );
+		john.setSelection( [ 0, 1 ], [ 1, 2 ] );
+		john._processExecute( 'delete' );
+
+		expectClients( '<paragraph>F<m1:start></m1:start>r</paragraph>' );
+
+		john.undo();
+
+		expectClients(
+			'<paragraph>Foo<m1:start></m1:start></paragraph>' +
+			'<paragraph>B<m1:end></m1:end>ar</paragraph>'
+		);
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `MarkerOperation` OT cases for undo. Closes #1650.