### PR TITLE
Tests: Remove all usages of `view.editableElement`

### DIFF
--- a/tests/tickets/ckeditor5-692.js
+++ b/tests/tickets/ckeditor5-692.js
@@ -29,7 +29,7 @@ describe( 'Bug ckeditor5#692', () => {
 				editor = newEditor;
 				view = editor.editing.view;
 				mutationObserver = view.getObserver( MutationObserver );
-				domEditor = editor.ui.view.editableElement;
+				domEditor = editor.ui.getEditableElement();
 			} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Remove all usages of `view.editableElement`.

---

### Additional information

Reporting ticket is https://github.com/ckeditor/ckeditor5/issues/1489.
