### PR TITLE
Introduced `model.isEmpty()` method. `DataController.get()` method can now trim empty data

### DIFF
--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -118,8 +118,8 @@ export default class DataController {
 	 * @param {Object} [options]
 	 * @param {String} [options.rootName='main'] Root name.
 	 * @param {String} [options.trim='empty'] Whether returned data should be trimmed. This option is set to `empty` by default,
-	 * which means whenever editor content is considered empty, the empty string will be returned. To turn off trimming completely
-	 * use `none`. In such cases exact content will be returned (for example `<p>&nbsp;</p>` for empty editor).
+	 * which means whenever editor content is considered empty, an empty string will be returned. To turn off trimming completely
+	 * use `'none'`. In such cases exact content will be returned (for example `<p>&nbsp;</p>` for an empty editor).
 	 * @returns {String} Output data.
 	 */
 	get( options ) {
@@ -131,7 +131,7 @@ export default class DataController {
 			 * is called with non-existent root name. For example, if there is an editor instance with only `main` root,
 			 * calling {@link #get} like:
 			 *
-			 * 		data.get( 'root2' );
+			 *		data.get( 'root2' );
 			 *
 			 * will throw this error.
 			 *
@@ -142,8 +142,11 @@ export default class DataController {
 
 		const root = this.model.document.getRoot( rootName );
 
-		// Get model range.
-		return trim === 'empty' && !this.model.hasContent( root, { trimWhitespaces: true } ) ? '' : this.stringify( root );
+		if ( trim === 'empty' && !this.model.hasContent( root, { ignoreWhitespaces: true } ) ) {
+			return '';
+		}
+
+		return this.stringify( root );
 	}
 
 	/**

--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -123,10 +123,7 @@ export default class DataController {
 	 * @returns {String} Output data.
 	 */
 	get( options ) {
-		options = options || {};
-
-		const rootName = options.rootName || 'main';
-		const trim = options.trim || 'empty';
+		const { rootName = 'main', trim = 'empty' } = options || {};
 
 		if ( !this._checkIfRootsExists( [ rootName ] ) ) {
 			/**
@@ -143,8 +140,10 @@ export default class DataController {
 			throw new CKEditorError( 'datacontroller-get-non-existent-root: Attempting to get data from a non-existing root.' );
 		}
 
+		const root = this.model.document.getRoot( rootName );
+
 		// Get model range.
-		return this.stringify( this.model.document.getRoot( rootName ), trim === 'empty' );
+		return trim === 'empty' && !this.model.hasContent( root, { trimWhitespaces: true } ) ? '' : this.stringify( root );
 	}
 
 	/**
@@ -154,21 +153,14 @@ export default class DataController {
 	 *
 	 * @param {module:engine/model/element~Element|module:engine/model/documentfragment~DocumentFragment} modelElementOrFragment
 	 * Element whose content will be stringified.
-	 * @param {Boolean} [skipEmpty=false] Whether content considered empty should be skipped. The method
-	 * will return an empty string in such cases.
 	 * @returns {String} Output data.
 	 */
-	stringify( modelElementOrFragment, skipEmpty = false ) {
-		if ( skipEmpty && this.model.isEmpty( modelElementOrFragment ) ) {
-			// If skipEmpty and model is considered empty return empty string.
-			return '';
-		} else {
-			// Model -> view.
-			const viewDocumentFragment = this.toView( modelElementOrFragment );
+	stringify( modelElementOrFragment ) {
+		// Model -> view.
+		const viewDocumentFragment = this.toView( modelElementOrFragment );
 
-			// View -> data.
-			return this.processor.toData( viewDocumentFragment );
-		}
+		// View -> data.
+		return this.processor.toData( viewDocumentFragment );
 	}
 
 	/**

--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -117,8 +117,10 @@ export default class DataController {
 	 * @returns {String} Output data.
 	 */
 	get( options ) {
-		const rootName = ( options || {} ).rootName || 'main';
-		const trim = ( options || {} ).trim || 'empty';
+		options = options || {};
+
+		const rootName = options.rootName || 'main';
+		const trim = options.trim || 'empty';
 
 		if ( !this._checkIfRootsExists( [ rootName ] ) ) {
 			/**
@@ -152,7 +154,7 @@ export default class DataController {
 	 */
 	stringify( modelElementOrFragment, skipEmpty = false ) {
 		if ( skipEmpty && this.model.isEmpty( modelElementOrFragment ) ) {
-			// If trimEmpty is true && model is considered empty return empty string.
+			// If skipEmpty and model is considered empty return empty string.
 			return '';
 		} else {
 			// Model -> view.

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -445,14 +445,15 @@ export default class Model {
 
 	/**
 	 * Checks whether the given {@link module:engine/model/range~Range range} or
-	 * {@link module:engine/model/element~Element element}
-	 * has any content.
+	 * {@link module:engine/model/element~Element element} has any meaningful content.
 	 *
-	 * Content is any text node or element which is registered in the {@link module:engine/model/schema~Schema schema}.
-	 *
-	 * **Note**: To check if editor or any part of the content contains meaningful data, use {@link #isEmpty}.
+	 * Meaningful content is any text node, element which is registered in the {@link module:engine/model/schema~Schema schema}
+	 * or any {@link module:engine/model/markercollection~Marker marker} which
+	 * {@link module:engine/model/markercollection~Marker#_affectsData affects data}.
 	 *
 	 * @param {module:engine/model/range~Range|module:engine/model/element~Element} rangeOrElement Range or element to check.
+	 * @param {Object} [options]
+	 * @param {Boolean} [options.trimWhitespaces] Whether text node with whitespaces only should be considered to be empty element.
 	 * @returns {Boolean}
 	 */
 	hasContent( rangeOrElement, options ) {

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -485,7 +485,7 @@ export default class Model {
 	 * 		* Non-plain `AttributeElement` (for example comment)
 	 *
 	 * 	This method should be used to check if the element/range/editor contains any printable/meaningful content.
-	 * 	It is the proper method to check if editor is empty.
+	 * 	It is also the correct method to check if editor is empty.
 	 *
 	 * @param {module:engine/model/range~Range|module:engine/model/element~Element} rangeOrElement Range or element to check.
 	 * @returns {Boolean}
@@ -499,6 +499,13 @@ export default class Model {
 			return true;
 		}
 
+		// Check if there are any markers which affects data in a given range.
+		for ( const intersectingMarker of this.markers.getMarkersIntersectingRange( rangeOrElement ) ) {
+			if ( intersectingMarker.affectsData ) {
+				return false;
+			}
+		}
+
 		for ( const item of rangeOrElement.getItems() ) {
 			// Remember, `TreeWalker` returns always `textProxy` nodes.
 			if ( item.is( 'textProxy' ) && item.data.match( /\S+/gi ) !== null ) {
@@ -506,8 +513,6 @@ export default class Model {
 			} else if ( this.schema.isObject( item ) || item.is( 'emptyElement' ) ) {
 				return false;
 			}
-			// Check for Non-plain `ContainerElement`
-			// Check for Non-plain `AttributeElement`
 		}
 
 		return true;

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -450,6 +450,8 @@ export default class Model {
 	 *
 	 * Content is any text node or element which is registered in the {@link module:engine/model/schema~Schema schema}.
 	 *
+	 * **Note**: To check if editor or any part of the content contains meaningful data, use {@link #isEmpty}.
+	 *
 	 * @param {module:engine/model/range~Range|module:engine/model/element~Element} rangeOrElement Range or element to check.
 	 * @returns {Boolean}
 	 */
@@ -470,6 +472,45 @@ export default class Model {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks whether the given {@link module:engine/model/range~Range range} or
+	 * {@link module:engine/model/element~Element element} is considered empty.
+	 *
+	 * The range or element is considered non-empty if it contains any:
+	 * 		* EmptyElement
+	 * 		* Text node containing at least one non-whitepsace character
+	 * 		* Non-plain `ContainerElement` (for example widget)
+	 * 		* Non-plain `AttributeElement` (for example comment)
+	 *
+	 * 	This method should be used to check if the element/range/editor contains any printable/meaningful content.
+	 * 	It is the proper method to check if editor is empty.
+	 *
+	 * @param {module:engine/model/range~Range|module:engine/model/element~Element} rangeOrElement Range or element to check.
+	 * @returns {Boolean}
+	 */
+	isEmpty( rangeOrElement ) {
+		if ( rangeOrElement instanceof ModelElement ) {
+			rangeOrElement = ModelRange._createIn( rangeOrElement );
+		}
+
+		if ( rangeOrElement.isCollapsed ) {
+			return true;
+		}
+
+		for ( const item of rangeOrElement.getItems() ) {
+			// Remember, `TreeWalker` returns always `textProxy` nodes.
+			if ( item.is( 'textProxy' ) && item.data.match( /\S+/gi ) !== null ) {
+				return false;
+			} else if ( this.schema.isObject( item ) || item.is( 'emptyElement' ) ) {
+				return false;
+			}
+			// Check for Non-plain `ContainerElement`
+			// Check for Non-plain `AttributeElement`
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -499,7 +499,7 @@ export default class Model {
 			return true;
 		}
 
-		// Check if there are any markers which affects data in a given range.
+		// Check if there are any markers which affects data in this given range.
 		for ( const intersectingMarker of this.markers.getMarkersIntersectingRange( rangeOrElement ) ) {
 			if ( intersectingMarker.affectsData ) {
 				return false;
@@ -507,7 +507,6 @@ export default class Model {
 		}
 
 		for ( const item of rangeOrElement.getItems() ) {
-			// Remember, `TreeWalker` returns always `textProxy` nodes.
 			if ( item.is( 'textProxy' ) && item.data.match( /\S+/gi ) !== null ) {
 				return false;
 			} else if ( this.schema.isObject( item ) || item.is( 'emptyElement' ) ) {

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -447,44 +447,47 @@ export default class Model {
 	 * Checks whether the given {@link module:engine/model/range~Range range} or
 	 * {@link module:engine/model/element~Element element} has any meaningful content.
 	 *
-	 * Meaningful content is any text node, element which is registered in the {@link module:engine/model/schema~Schema schema}
-	 * or any {@link module:engine/model/markercollection~Marker marker} which
+	 * Meaningful content is:
+	 *
+	 * * any text node (`options.ignoreWhitespaces` allows controlling whether this text node must also contain
+	 * any non-whitespace characters),
+	 * * or any {@link module:engine/model/schema~Schema#isObject object element},
+	 * * or any {@link module:engine/model/markercollection~Marker marker} which
 	 * {@link module:engine/model/markercollection~Marker#_affectsData affects data}.
+	 *
+	 * This means that a range containing an empty `<paragraph></paragraph>` is not considered to have a meaningful content.
+	 * However, a range containing an `<image></image>` (which would normally be marked in the schema as an object element)
+	 * is considered non-empty.
 	 *
 	 * @param {module:engine/model/range~Range|module:engine/model/element~Element} rangeOrElement Range or element to check.
 	 * @param {Object} [options]
-	 * @param {Boolean} [options.trimWhitespaces] Whether text node with whitespaces only should be considered to be empty element.
+	 * @param {Boolean} [options.ignoreWhitespaces] Whether text node with whitespaces only should be considered empty.
 	 * @returns {Boolean}
 	 */
 	hasContent( rangeOrElement, options ) {
-		if ( rangeOrElement instanceof ModelElement ) {
-			rangeOrElement = ModelRange._createIn( rangeOrElement );
-		}
+		const range = rangeOrElement instanceof ModelElement ? ModelRange._createIn( rangeOrElement ) : rangeOrElement;
 
-		if ( rangeOrElement.isCollapsed ) {
+		if ( range.isCollapsed ) {
 			return false;
 		}
 
 		// Check if there are any markers which affects data in this given range.
-		for ( const intersectingMarker of this.markers.getMarkersIntersectingRange( rangeOrElement ) ) {
+		for ( const intersectingMarker of this.markers.getMarkersIntersectingRange( range ) ) {
 			if ( intersectingMarker.affectsData ) {
 				return true;
 			}
 		}
 
-		const { trimWhitespaces = false } = options || {};
+		const { ignoreWhitespaces = false } = options || {};
 
-		for ( const item of rangeOrElement.getItems() ) {
-			// Remember, `TreeWalker` returns always `textProxy` nodes.
+		for ( const item of range.getItems() ) {
 			if ( item.is( 'textProxy' ) ) {
-				if ( !trimWhitespaces ) {
+				if ( !ignoreWhitespaces ) {
 					return true;
-				} else if ( item.data.match( /\S+/gi ) !== null ) {
+				} else if ( item.data.search( /\S/ ) !== -1 ) {
 					return true;
 				}
-			}
-
-			if ( this.schema.isObject( item ) ) {
+			} else if ( this.schema.isObject( item ) ) {
 				return true;
 			}
 		}

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -355,6 +355,7 @@ describe( 'DataController', () => {
 
 			downcastHelpers.elementToElement( { model: 'paragraph', view: 'p' } );
 
+			expect( data.get() ).to.equal( '' );
 			expect( data.get( { trim: 'empty' } ) ).to.equal( '' );
 		} );
 

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -336,15 +336,25 @@ describe( 'DataController', () => {
 			downcastHelpers.elementToElement( { model: 'paragraph', view: 'p' } );
 
 			expect( data.get() ).to.equal( '<p>foo</p>' );
+			expect( data.get( { trim: 'empty' } ) ).to.equal( '<p>foo</p>' );
 		} );
 
-		it( 'should get empty paragraph', () => {
+		it( 'should trim empty paragraph by default', () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 			setData( model, '<paragraph></paragraph>' );
 
 			downcastHelpers.elementToElement( { model: 'paragraph', view: 'p' } );
 
-			expect( data.get() ).to.equal( '<p>&nbsp;</p>' );
+			expect( data.get( { trim: 'empty' } ) ).to.equal( '' );
+		} );
+
+		it( 'should get empty paragraph (with trim=none)', () => {
+			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
+			setData( model, '<paragraph></paragraph>' );
+
+			downcastHelpers.elementToElement( { model: 'paragraph', view: 'p' } );
+
+			expect( data.get( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
 		} );
 
 		it( 'should get two paragraphs', () => {
@@ -354,6 +364,7 @@ describe( 'DataController', () => {
 			downcastHelpers.elementToElement( { model: 'paragraph', view: 'p' } );
 
 			expect( data.get() ).to.equal( '<p>foo</p><p>bar</p>' );
+			expect( data.get( { trim: 'empty' } ) ).to.equal( '<p>foo</p><p>bar</p>' );
 		} );
 
 		it( 'should get text directly in root', () => {
@@ -361,6 +372,7 @@ describe( 'DataController', () => {
 			setData( model, 'foo' );
 
 			expect( data.get() ).to.equal( 'foo' );
+			expect( data.get( { trim: 'empty' } ) ).to.equal( 'foo' );
 		} );
 
 		it( 'should get paragraphs without bold', () => {
@@ -370,6 +382,7 @@ describe( 'DataController', () => {
 			downcastHelpers.elementToElement( { model: 'paragraph', view: 'p' } );
 
 			expect( data.get() ).to.equal( '<p>foobar</p>' );
+			expect( data.get( { trim: 'empty' } ) ).to.equal( '<p>foobar</p>' );
 		} );
 
 		it( 'should get paragraphs with bold', () => {
@@ -380,6 +393,7 @@ describe( 'DataController', () => {
 			downcastHelpers.attributeToElement( { model: 'bold', view: 'strong' } );
 
 			expect( data.get() ).to.equal( '<p>foo<strong>bar</strong></p>' );
+			expect( data.get( { trim: 'empty' } ) ).to.equal( '<p>foo<strong>bar</strong></p>' );
 		} );
 
 		it( 'should get root name as a parameter', () => {
@@ -393,13 +407,13 @@ describe( 'DataController', () => {
 			downcastHelpers.attributeToElement( { model: 'bold', view: 'strong' } );
 
 			expect( data.get() ).to.equal( '<p>foo</p>' );
-			expect( data.get( 'main' ) ).to.equal( '<p>foo</p>' );
-			expect( data.get( 'title' ) ).to.equal( 'Bar' );
+			expect( data.get( { rootName: 'main' } ) ).to.equal( '<p>foo</p>' );
+			expect( data.get( { rootName: 'title' } ) ).to.equal( 'Bar' );
 		} );
 
 		it( 'should throw an error when non-existent root is used', () => {
 			expect( () => {
-				data.get( 'nonexistent' );
+				data.get( { rootName: 'nonexistent' } );
 			} ).to.throw(
 				CKEditorError,
 				'datacontroller-get-non-existent-root: Attempting to get data from a non-existing root.'

--- a/tests/model/model.js
+++ b/tests/model/model.js
@@ -528,10 +528,10 @@ describe( 'Model', () => {
 			expect( model.hasContent( pFoo ) ).to.be.true;
 		} );
 
-		it( 'should return true if given element has text node (trimWhitespaces)', () => {
+		it( 'should return true if given element has text node (ignoreWhitespaces)', () => {
 			const pFoo = root.getChild( 1 );
 
-			expect( model.hasContent( pFoo, { trimWhitespaces: true } ) ).to.be.true;
+			expect( model.hasContent( pFoo, { ignoreWhitespaces: true } ) ).to.be.true;
 		} );
 
 		it( 'should return true if given element has text node containing spaces only', () => {
@@ -545,7 +545,7 @@ describe( 'Model', () => {
 			expect( model.hasContent( pEmpty ) ).to.be.true;
 		} );
 
-		it( 'should false true if given element has text node containing spaces only (trimWhitespaces)', () => {
+		it( 'should false true if given element has text node containing spaces only (ignoreWhitespaces)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
 			model.enqueueChange( 'transparent', writer => {
@@ -553,7 +553,7 @@ describe( 'Model', () => {
 				writer.insertText( '    ', pEmpty, 'end' );
 			} );
 
-			expect( model.hasContent( pEmpty, { trimWhitespaces: true } ) ).to.be.false;
+			expect( model.hasContent( pEmpty, { ignoreWhitespaces: true } ) ).to.be.false;
 		} );
 
 		it( 'should return true if given element has element that is an object', () => {
@@ -622,7 +622,7 @@ describe( 'Model', () => {
 			} );
 
 			expect( model.hasContent( pEmpty ) ).to.be.false;
-			expect( model.hasContent( pEmpty, { trimWhitespaces: true } ) ).to.be.false;
+			expect( model.hasContent( pEmpty, { ignoreWhitespaces: true } ) ).to.be.false;
 		} );
 
 		it( 'should return false for empty element with marker (usingOperation=true, affectsData=false)', () => {
@@ -635,10 +635,10 @@ describe( 'Model', () => {
 			} );
 
 			expect( model.hasContent( pEmpty ) ).to.be.false;
-			expect( model.hasContent( pEmpty, { trimWhitespaces: true } ) ).to.be.false;
+			expect( model.hasContent( pEmpty, { ignoreWhitespaces: true } ) ).to.be.false;
 		} );
 
-		it( 'should return false (trimWhitespaces) for empty text with marker (usingOperation=false, affectsData=false)', () => {
+		it( 'should return false (ignoreWhitespaces) for empty text with marker (usingOperation=false, affectsData=false)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
 			model.enqueueChange( 'transparent', writer => {
@@ -651,7 +651,7 @@ describe( 'Model', () => {
 				writer.addMarker( 'comment1', { range, usingOperation: false, affectsData: false } );
 			} );
 
-			expect( model.hasContent( pEmpty, { trimWhitespaces: true } ) ).to.be.false;
+			expect( model.hasContent( pEmpty, { ignoreWhitespaces: true } ) ).to.be.false;
 		} );
 
 		it( 'should return true for empty text with marker (usingOperation=false, affectsData=false)', () => {
@@ -680,7 +680,7 @@ describe( 'Model', () => {
 			} );
 
 			expect( model.hasContent( pEmpty ) ).to.be.false;
-			expect( model.hasContent( pEmpty, { trimWhitespaces: true } ) ).to.be.false;
+			expect( model.hasContent( pEmpty, { ignoreWhitespaces: true } ) ).to.be.false;
 		} );
 
 		it( 'should return false for empty element with marker (usingOperation=true, affectsData=true)', () => {
@@ -693,10 +693,10 @@ describe( 'Model', () => {
 			} );
 
 			expect( model.hasContent( pEmpty ) ).to.be.false;
-			expect( model.hasContent( pEmpty, { trimWhitespaces: true } ) ).to.be.false;
+			expect( model.hasContent( pEmpty, { ignoreWhitespaces: true } ) ).to.be.false;
 		} );
 
-		it( 'should return true (trimWhitespaces) for empty text with marker (usingOperation=false, affectsData=true)', () => {
+		it( 'should return true (ignoreWhitespaces) for empty text with marker (usingOperation=false, affectsData=true)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
 			model.enqueueChange( 'transparent', writer => {
@@ -710,7 +710,7 @@ describe( 'Model', () => {
 			} );
 
 			expect( model.hasContent( pEmpty ) ).to.be.true;
-			expect( model.hasContent( pEmpty, { trimWhitespaces: true } ) ).to.be.true;
+			expect( model.hasContent( pEmpty, { ignoreWhitespaces: true } ) ).to.be.true;
 		} );
 	} );
 

--- a/tests/model/model.js
+++ b/tests/model/model.js
@@ -11,7 +11,6 @@ import ModelPosition from '../../src/model/position';
 import ModelSelection from '../../src/model/selection';
 import ModelDocumentFragment from '../../src/model/documentfragment';
 import Batch from '../../src/model/batch';
-import Writer from '../../src/model/writer';
 import { getData, setData, stringify } from '../../src/dev-utils/model';
 
 describe( 'Model', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `model.isEmpty()` method. `DataController.get()` method can now trim empty data. Closes ckeditor/ckeditor5#401.

BREAKING CHANGE: `DataController.get()` method now returns an empty string by default when editor content is empty.

---

### Additional information

See ckeditor/ckeditor5#401. I have also created https://github.com/ckeditor/ckeditor5/tree/t/401 branch for easier testing.

There are a few related PRs which should be closed together with this one:

* https://github.com/ckeditor/ckeditor5-core/pull/161
* https://github.com/ckeditor/ckeditor5-block-quote/pull/32
* https://github.com/ckeditor/ckeditor5-enter/pull/61
* https://github.com/ckeditor/ckeditor5-paragraph/pull/41
* https://github.com/ckeditor/ckeditor5-table/pull/169
* https://github.com/ckeditor/ckeditor5-typing/pull/180