### PR TITLE
Stop invoking `view.render()` by `EditingController` when the model document isn't changed

### DIFF
--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -78,9 +78,9 @@ export default class EditingController {
 			this.view._renderingDisabled = true;
 		}, { priority: 'highest' } );
 
-		this.listenTo( this.model, '_afterChanges', ( data, { modelChanged } ) => {
+		this.listenTo( this.model, '_afterChanges', ( data, { hasModelDocumentChanged } ) => {
 			this.view._renderingDisabled = false;
-			if ( modelChanged ) {
+			if ( hasModelDocumentChanged ) {
 				this.view.render();
 			}
 		}, { priority: 'lowest' } );

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -78,9 +78,11 @@ export default class EditingController {
 			this.view._renderingDisabled = true;
 		}, { priority: 'highest' } );
 
-		this.listenTo( this.model, '_afterChanges', () => {
+		this.listenTo( this.model, '_afterChanges', ( data, { modelChanged } ) => {
 			this.view._renderingDisabled = false;
-			this.view.render();
+			if ( modelChanged ) {
+				this.view.render();
+			}
 		}, { priority: 'lowest' } );
 
 		// Whenever model document is changed, convert those changes to the view (using model.Document#differ).

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -78,7 +78,7 @@ export default class EditingController {
 			this.view._renderingDisabled = true;
 		}, { priority: 'highest' } );
 
-		this.listenTo( this.model, '_afterChanges', ( data, { hasModelDocumentChanged } ) => {
+		this.listenTo( this.model, '_afterChanges', ( evt, { hasModelDocumentChanged } ) => {
 			this.view._renderingDisabled = false;
 			if ( hasModelDocumentChanged ) {
 				this.view.render();

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -151,6 +151,7 @@ export default class Document {
 			}
 		}, { priority: 'low' } );
 
+		// Listen to selection changes. If selection changed, mark it.
 		this.listenTo( this.selection, 'change', () => {
 			this._hasSelectionChangedFromTheLastChangeBlock = true;
 		} );

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -303,8 +303,8 @@ export default class Document {
 	 * @fires change:data
 	 * @param {module:engine/model/writer~Writer writer} writer The writer on which post-fixers will be called.
 	 */
-	_runPostFixersAndResetDiffer( writer ) {
-		if ( this._hasDocumentChanged() ) {
+	_handleChangeBlock( writer ) {
+		if ( this._hasDocumentChangedFromTheLastChangeBlock() ) {
 			this._callPostFixers( writer );
 
 			if ( this.differ.hasDataChanges() ) {
@@ -325,9 +325,9 @@ export default class Document {
 	 * or {@link module:engine/model/model~Model#change `change()` block}.
 	 *
 	 * @protected
-	 * @returns {Boolean} Returns `true` if document has changed from the differ's reset.
+	 * @returns {Boolean} Returns `true` if document has changed from the last `change()` or `enqueueChange()` block.
 	 */
-	_hasDocumentChanged() {
+	_hasDocumentChangedFromTheLastChangeBlock() {
 		return !this.differ.isEmpty || this._hasSelectionChangedFromTheLastChangeBlock;
 	}
 

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -279,6 +279,21 @@ export default class Document {
 	}
 
 	/**
+	 * A custom `toJSON()` method to solve child-parent circular dependencies.
+	 *
+	 * @returns {Object} A clone of this object with the document property changed to a string.
+	 */
+	toJSON() {
+		const json = clone( this );
+
+		// Due to circular references we need to remove parent reference.
+		json.selection = '[engine.model.DocumentSelection]';
+		json.model = '[engine.model.Model]';
+
+		return json;
+	}
+
+	/**
 	 * Check if there were any changes done on document, and if so, call post-fixers,
 	 * fire `change` event for features and conversion and then reset the differ.
 	 * Fire `change:data` event when at least one operation or buffered marker changes the data.
@@ -289,7 +304,7 @@ export default class Document {
 	 * @param {module:engine/model/writer~Writer writer} writer The writer on which post-fixers will be called.
 	 */
 	_runPostFixersAndResetDiffer( writer ) {
-		if ( this._hasDocumentChangedFromTheLastChangeBlock() ) {
+		if ( this._hasDocumentChanged() ) {
 			this._callPostFixers( writer );
 
 			if ( this.differ.hasDataChanges() ) {
@@ -310,25 +325,10 @@ export default class Document {
 	 * or {@link module:engine/model/model~Model#change `change()` block}.
 	 *
 	 * @protected
-	 * @returns {Boolean} Returns `true` when document has changed from the last change block.
+	 * @returns {Boolean} Returns `true` if document has changed from the differ's reset.
 	 */
-	_hasDocumentChangedFromTheLastChangeBlock() {
+	_hasDocumentChanged() {
 		return !this.differ.isEmpty || this._hasSelectionChangedFromTheLastChangeBlock;
-	}
-
-	/**
-	 * A custom `toJSON()` method to solve child-parent circular dependencies.
-	 *
-	 * @returns {Object} A clone of this object with the document property changed to a string.
-	 */
-	toJSON() {
-		const json = clone( this );
-
-		// Due to circular references we need to remove parent reference.
-		json.selection = '[engine.model.DocumentSelection]';
-		json.model = '[engine.model.Model]';
-
-		return json;
 	}
 
 	/**

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -282,11 +282,12 @@ export default class Document {
 	 * fire `change` event for features and conversion and then reset the differ.
 	 * Fire `change:data` event when at least one operation or buffered marker changes the data.
 	 *
+	 * @protected
 	 * @fires change
 	 * @fires change:data
 	 * @param {module:engine/model/writer~Writer writer} writer The writer on which post-fixers will be called.
 	 */
-	runPostFixersAndResetDiffer( writer ) {
+	_runPostFixersAndResetDiffer( writer ) {
 		if ( this._hasDocumentChangedFromTheLastChangeBlock() ) {
 			this._callPostFixers( writer );
 

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -305,7 +305,8 @@ export default class Document {
 	}
 
 	/**
-	 * Returns whether there is a buffered change or if the selection has changed from the last `{@link module:engine/model/model~Model#enqueueChange `enqueueChange()` block}
+	 * Returns whether there is a buffered change or if the selection has changed from the last
+	 * {@link module:engine/model/model~Model#enqueueChange `enqueueChange()` block}
 	 * or {@link module:engine/model/model~Model#change `change()` block}.
 	 *
 	 * @protected

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -155,7 +155,11 @@ export default class Document {
 		// fire `change` event for features and conversion and then reset the differ.
 		// Fire `change:data` event when at least one operation or buffered marker changes the data.
 		this.listenTo( model, '_change', ( evt, writer ) => {
-			if ( !this.differ.isEmpty || hasSelectionChanged ) {
+			const documentChanged = !this.differ.isEmpty || hasSelectionChanged;
+
+			evt.return = documentChanged;
+
+			if ( documentChanged ) {
 				this._callPostFixers( writer );
 
 				if ( this.differ.hasDataChanges() ) {

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -46,7 +46,7 @@ export default class Document {
 		 * The {@link module:engine/model/model~Model model} that the document is a part of.
 		 *
 		 * @readonly
-		 * @member {module:engine/model/model~Model}
+		 * @type {module:engine/model/model~Model}
 		 */
 		this.model = model;
 
@@ -58,7 +58,7 @@ export default class Document {
 		 * a {@link module:utils/ckeditorerror~CKEditorError model-document-applyOperation-wrong-version} error is thrown.
 		 *
 		 * @readonly
-		 * @member {Number}
+		 * @type {Number}
 		 */
 		this.version = 0;
 
@@ -66,7 +66,7 @@ export default class Document {
 		 * The document's history.
 		 *
 		 * @readonly
-		 * @member {module:engine/model/history~History}
+		 * @type {module:engine/model/history~History}
 		 */
 		this.history = new History( this );
 
@@ -74,7 +74,7 @@ export default class Document {
 		 * The selection in this document.
 		 *
 		 * @readonly
-		 * @member {module:engine/model/documentselection~DocumentSelection}
+		 * @type {module:engine/model/documentselection~DocumentSelection}
 		 */
 		this.selection = new DocumentSelection( this );
 
@@ -83,7 +83,7 @@ export default class Document {
 		 * {@link #getRoot} to manipulate it.
 		 *
 		 * @readonly
-		 * @member {module:utils/collection~Collection}
+		 * @type {module:utils/collection~Collection}
 		 */
 		this.roots = new Collection( { idProperty: 'rootName' } );
 
@@ -91,7 +91,7 @@ export default class Document {
 		 * The model differ object. Its role is to buffer changes done on the model document and then calculate a diff of those changes.
 		 *
 		 * @readonly
-		 * @member {module:engine/model/differ~Differ}
+		 * @type {module:engine/model/differ~Differ}
 		 */
 		this.differ = new Differ( model.markers );
 
@@ -99,9 +99,17 @@ export default class Document {
 		 * Post-fixer callbacks registered to the model document.
 		 *
 		 * @private
-		 * @member {Set}
+		 * @type {Set.<Function>}
 		 */
 		this._postFixers = new Set();
+
+		/**
+		 * A boolean indicates whether the selection has changed until
+		 *
+		 * @private
+		 * @type {Boolean}
+		 */
+		this._hasSelectionChangedFromTheLastChangeBlock = false;
 
 		// Graveyard tree root. Document always have a graveyard root, which stores removed nodes.
 		this.createRoot( '$root', graveyardName );
@@ -143,34 +151,8 @@ export default class Document {
 			}
 		}, { priority: 'low' } );
 
-		// Listen to selection changes. If selection changed, mark it.
-		let hasSelectionChanged = false;
-
 		this.listenTo( this.selection, 'change', () => {
-			hasSelectionChanged = true;
-		} );
-
-		// Wait for `_change` event from model, which signalizes that outermost change block has finished.
-		// When this happens, check if there were any changes done on document, and if so, call post-fixers,
-		// fire `change` event for features and conversion and then reset the differ.
-		// Fire `change:data` event when at least one operation or buffered marker changes the data.
-		this.listenTo( model, '_change', ( evt, writer ) => {
-			const documentChanged = !this.differ.isEmpty || hasSelectionChanged;
-
-			evt.return = documentChanged;
-
-			if ( documentChanged ) {
-				this._callPostFixers( writer );
-
-				if ( this.differ.hasDataChanges() ) {
-					this.fire( 'change:data', writer.batch );
-				} else {
-					this.fire( 'change', writer.batch );
-				}
-
-				this.differ.reset();
-				hasSelectionChanged = false;
-			}
+			this._hasSelectionChangedFromTheLastChangeBlock = true;
 		} );
 
 		// Buffer marker changes.
@@ -296,6 +278,42 @@ export default class Document {
 	}
 
 	/**
+	 * Check if there were any changes done on document, and if so, call post-fixers,
+	 * fire `change` event for features and conversion and then reset the differ.
+	 * Fire `change:data` event when at least one operation or buffered marker changes the data.
+	 *
+	 * @fires change
+	 * @fires change:data
+	 * @param {module:engine/model/writer~Writer writer} writer The writer on which post-fixers will be called.
+	 */
+	runPostFixersAndResetDiffer( writer ) {
+		if ( this._hasDocumentChangedFromTheLastChangeBlock() ) {
+			this._callPostFixers( writer );
+
+			if ( this.differ.hasDataChanges() ) {
+				this.fire( 'change:data', writer.batch );
+			} else {
+				this.fire( 'change', writer.batch );
+			}
+
+			this.differ.reset();
+		}
+
+		this._hasSelectionChangedFromTheLastChangeBlock = false;
+	}
+
+	/**
+	 * Returns whether there is a buffered change or if the selection has changed from the last `{@link module:engine/model/model~Model#enqueueChange `enqueueChange()` block}
+	 * or {@link module:engine/model/model~Model#change `change()` block}.
+	 *
+	 * @protected
+	 * @returns {Boolean} Returns `true` when document has changed from the last change block.
+	 */
+	_hasDocumentChangedFromTheLastChangeBlock() {
+		return !this.differ.isEmpty || this._hasSelectionChangedFromTheLastChangeBlock;
+	}
+
+	/**
 	 * A custom `toJSON()` method to solve child-parent circular dependencies.
 	 *
 	 * @returns {Object} A clone of this object with the document property changed to a string.
@@ -363,6 +381,7 @@ export default class Document {
 	 * Performs post-fixer loops. Executes post-fixer callbacks as long as none of them has done any changes to the model.
 	 *
 	 * @private
+	 * @param {module:engine/model/writer~Writer writer} writer The writer on which post-fixer callbacks will be called.
 	 */
 	_callPostFixers( writer ) {
 		let wasFixed = false;

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -699,9 +699,10 @@ export default class Model {
 			// Collect an information whether the model document has changed during from the last pending change callback.
 			hasModelDocumentChanged = hasModelDocumentChanged || this.document._hasDocumentChangedFromTheLastChangeBlock();
 
-			this.document._runPostFixersAndResetDiffer( this._currentWriter );
-
+			// Fire '_change' event before resetting differ.
 			this.fire( '_change', this._currentWriter );
+
+			this.document._runPostFixersAndResetDiffer( this._currentWriter );
 
 			this._pendingChanges.shift();
 			this._currentWriter = null;

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -741,7 +741,7 @@ export default class Model {
 	 * @protected
 	 * @event _afterChanges
 	 * @param {Object} options
-	 * @param {Boolean} options.hasDocumentChanged A boolean indicates whether the model document has changed during the {@link module:engine/model/model~Model#change} blocks.
+	 * @param {Boolean} options.hasModelDocumentChanged A boolean indicates whether the model document has changed during the {@link module:engine/model/model~Model#change} blocks.
 	 */
 
 	/**

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -696,8 +696,6 @@ export default class Model {
 			const callbackReturnValue = this._pendingChanges[ 0 ].callback( this._currentWriter );
 			ret.push( callbackReturnValue );
 
-			this.document.callPostFixers
-
 			// Collect an information whether the model document has changed during from the last pending change callback.
 			hasModelDocumentChanged = hasModelDocumentChanged || this.document._hasDocumentChangedFromTheLastChangeBlock();
 
@@ -741,7 +739,8 @@ export default class Model {
 	 * @protected
 	 * @event _afterChanges
 	 * @param {Object} options
-	 * @param {Boolean} options.hasModelDocumentChanged A boolean indicates whether the model document has changed during the {@link module:engine/model/model~Model#change} blocks.
+	 * @param {Boolean} options.hasModelDocumentChanged A boolean indicates whether the model document has changed during the
+	 * {@link module:engine/model/model~Model#change} blocks.
 	 */
 
 	/**

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -696,8 +696,9 @@ export default class Model {
 			const callbackReturnValue = this._pendingChanges[ 0 ].callback( this._currentWriter );
 			ret.push( callbackReturnValue );
 
-			// Fire internal `_change` event and collect the change result.
-			modelChanged = modelChanged || this.fire( '_change', this._currentWriter );
+			// Fire internal `_change` event and collect the information whether the model is changed after the callback.
+			const modelChangedAfterCallback = this.fire( '_change', this._currentWriter );
+			modelChanged = modelChanged || modelChangedAfterCallback;
 
 			this._pendingChanges.shift();
 			this._currentWriter = null;
@@ -733,6 +734,8 @@ export default class Model {
 	 *
 	 * @protected
 	 * @event _afterChanges
+	 * @param {Object} options
+	 * @param {Boolean} options.modelChanged A boolean indicates whether the model was changed during the {@link module:engine/model/model~Model#change} blocks.
 	 */
 
 	/**

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -697,12 +697,12 @@ export default class Model {
 			ret.push( callbackReturnValue );
 
 			// Collect an information whether the model document has changed during from the last pending change.
-			hasModelDocumentChanged = hasModelDocumentChanged || this.document._hasDocumentChanged();
+			hasModelDocumentChanged = hasModelDocumentChanged || this.document._hasDocumentChangedFromTheLastChangeBlock();
 
 			// Fire '_change' event before resetting differ.
 			this.fire( '_change', this._currentWriter );
 
-			this.document._runPostFixersAndResetDiffer( this._currentWriter );
+			this.document._handleChangeBlock( this._currentWriter );
 
 			this._pendingChanges.shift();
 			this._currentWriter = null;

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -696,8 +696,8 @@ export default class Model {
 			const callbackReturnValue = this._pendingChanges[ 0 ].callback( this._currentWriter );
 			ret.push( callbackReturnValue );
 
-			// Collect an information whether the model document has changed during from the last pending change callback.
-			hasModelDocumentChanged = hasModelDocumentChanged || this.document._hasDocumentChangedFromTheLastChangeBlock();
+			// Collect an information whether the model document has changed during from the last pending change.
+			hasModelDocumentChanged = hasModelDocumentChanged || this.document._hasDocumentChanged();
 
 			// Fire '_change' event before resetting differ.
 			this.fire( '_change', this._currentWriter );
@@ -740,8 +740,8 @@ export default class Model {
 	 * @protected
 	 * @event _afterChanges
 	 * @param {Object} options
-	 * @param {Boolean} options.hasModelDocumentChanged A boolean indicates whether the model document has changed during the
-	 * {@link module:engine/model/model~Model#change} blocks.
+	 * @param {Boolean} options.hasModelDocumentChanged `true` if the model document has changed during the
+	 * {@link module:engine/model/model~Model#change} or {@link module:engine/model/model~Model#enqueueChange} blocks.
 	 */
 
 	/**

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -683,6 +683,7 @@ export default class Model {
 	 */
 	_runPendingChanges() {
 		const ret = [];
+		let modelChanged = false;
 
 		this.fire( '_beforeChanges' );
 
@@ -695,14 +696,14 @@ export default class Model {
 			const callbackReturnValue = this._pendingChanges[ 0 ].callback( this._currentWriter );
 			ret.push( callbackReturnValue );
 
-			// Fire internal `_change` event.
-			this.fire( '_change', this._currentWriter );
+			// Fire internal `_change` event and collect the change result.
+			modelChanged = modelChanged || this.fire( '_change', this._currentWriter );
 
 			this._pendingChanges.shift();
 			this._currentWriter = null;
 		}
 
-		this.fire( '_afterChanges' );
+		this.fire( '_afterChanges', { modelChanged } );
 
 		return ret;
 	}

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -683,7 +683,7 @@ export default class Model {
 	 */
 	_runPendingChanges() {
 		const ret = [];
-		let hasDocumentChanged = false;
+		let hasModelDocumentChanged = false;
 
 		this.fire( '_beforeChanges' );
 
@@ -699,18 +699,17 @@ export default class Model {
 			this.document.callPostFixers
 
 			// Collect an information whether the model document has changed during from the last pending change callback.
-			hasDocumentChanged = hasDocumentChanged || this.document._hasDocumentChangedFromTheLastChangeBlock();
+			hasModelDocumentChanged = hasModelDocumentChanged || this.document._hasDocumentChangedFromTheLastChangeBlock();
 
 			this.document._runPostFixersAndResetDiffer( this._currentWriter );
 
-			// With <3 for @scofalic.
 			this.fire( '_change', this._currentWriter );
 
 			this._pendingChanges.shift();
 			this._currentWriter = null;
 		}
 
-		this.fire( '_afterChanges', { hasDocumentChanged } );
+		this.fire( '_afterChanges', { hasModelDocumentChanged } );
 
 		return ret;
 	}

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -683,7 +683,7 @@ export default class Model {
 	 */
 	_runPendingChanges() {
 		const ret = [];
-		let modelChanged = false;
+		let hasDocumentChanged = false;
 
 		this.fire( '_beforeChanges' );
 
@@ -696,15 +696,21 @@ export default class Model {
 			const callbackReturnValue = this._pendingChanges[ 0 ].callback( this._currentWriter );
 			ret.push( callbackReturnValue );
 
-			// Fire internal `_change` event and collect the information whether the model is changed after the callback.
-			const modelChangedAfterCallback = this.fire( '_change', this._currentWriter );
-			modelChanged = modelChanged || modelChangedAfterCallback;
+			this.document.callPostFixers
+
+			// Collect an information whether the model document has changed during from the last pending change callback.
+			hasDocumentChanged = hasDocumentChanged || this.document._hasDocumentChangedFromTheLastChangeBlock();
+
+			this.document.runPostFixersAndResetDiffer( this._currentWriter );
+
+			// With <3 for @scofalic.
+			this.fire( '_change', this._currentWriter );
 
 			this._pendingChanges.shift();
 			this._currentWriter = null;
 		}
 
-		this.fire( '_afterChanges', { modelChanged } );
+		this.fire( '_afterChanges', { hasDocumentChanged } );
 
 		return ret;
 	}
@@ -715,6 +721,7 @@ export default class Model {
 	 *
 	 * **Note:** This is an internal event! Use {@link module:engine/model/document~Document#event:change} instead.
 	 *
+	 * @deprecated
 	 * @protected
 	 * @event _change
 	 * @param {module:engine/model/writer~Writer} writer `Writer` instance that has been used in the change block.
@@ -735,7 +742,7 @@ export default class Model {
 	 * @protected
 	 * @event _afterChanges
 	 * @param {Object} options
-	 * @param {Boolean} options.modelChanged A boolean indicates whether the model was changed during the {@link module:engine/model/model~Model#change} blocks.
+	 * @param {Boolean} options.hasDocumentChanged A boolean indicates whether the model document has changed during the {@link module:engine/model/model~Model#change} blocks.
 	 */
 
 	/**

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -701,7 +701,7 @@ export default class Model {
 			// Collect an information whether the model document has changed during from the last pending change callback.
 			hasDocumentChanged = hasDocumentChanged || this.document._hasDocumentChangedFromTheLastChangeBlock();
 
-			this.document.runPostFixersAndResetDiffer( this._currentWriter );
+			this.document._runPostFixersAndResetDiffer( this._currentWriter );
 
 			// With <3 for @scofalic.
 			this.fire( '_change', this._currentWriter );

--- a/tests/tickets/1653.js
+++ b/tests/tickets/1653.js
@@ -21,7 +21,7 @@ describe( 'Bug ckeditor5-engine#1653', () => {
 				editor = newEditor;
 
 				const spy = sinon.spy( editor.editing.view, 'render' );
-				const output = editor.data.parse( '<p></p>' );
+				editor.data.parse( '<p></p>' );
 
 				sinon.assert.notCalled( spy );
 			} )

--- a/tests/tickets/1653.js
+++ b/tests/tickets/1653.js
@@ -1,0 +1,34 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals document */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+
+describe( 'Bug ckeditor5-engine#1653', () => {
+	it( '`DataController.parse()` should not invoke `editing.view.render()`', () => {
+		let editor;
+
+		const element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		return ClassicTestEditor
+			.create( element, { plugins: [ Paragraph ] } )
+			.then( newEditor => {
+				editor = newEditor;
+
+				const spy = sinon.spy( editor.editing.view, 'render' );
+				const output = editor.data.parse( '<p></p>' );
+
+				sinon.assert.notCalled( spy );
+			} )
+			.then( () => {
+				element.remove();
+
+				return editor.destroy();
+			} );
+	} )
+} );

--- a/tests/tickets/1653.js
+++ b/tests/tickets/1653.js
@@ -30,5 +30,5 @@ describe( 'Bug ckeditor5-engine#1653', () => {
 
 				return editor.destroy();
 			} );
-	} )
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Stopped invoking `view.render()` by `EditingController` when the model document isn't changed. Closes #1653.

---

### Additional information

* `Model#_change` event marked as deprecated.
* Introduced protected method: `_handleChangeBlock()`.
* Introduced protected method: `_hasDocumentChangedFromTheLastChangeBlock()`.