### PR TITLE
Prevented `View` from firing the `render` event if there were no changes since the last `view.render()` call

### DIFF
--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -75,12 +75,11 @@ export default class EditingController {
 		//
 		// See  https://github.com/ckeditor/ckeditor5-engine/issues/1528
 		this.listenTo( this.model, '_beforeChanges', () => {
-			this.view._renderingDisabled = true;
+			this.view._disableRendering( true );
 		}, { priority: 'highest' } );
 
 		this.listenTo( this.model, '_afterChanges', () => {
-			this.view._renderingDisabled = false;
-			this.view.render();
+			this.view._disableRendering( false );
 		}, { priority: 'lowest' } );
 
 		// Whenever model document is changed, convert those changes to the view (using model.Document#differ).

--- a/src/controller/editingcontroller.js
+++ b/src/controller/editingcontroller.js
@@ -78,11 +78,9 @@ export default class EditingController {
 			this.view._renderingDisabled = true;
 		}, { priority: 'highest' } );
 
-		this.listenTo( this.model, '_afterChanges', ( evt, { hasModelDocumentChanged } ) => {
+		this.listenTo( this.model, '_afterChanges', () => {
 			this.view._renderingDisabled = false;
-			if ( hasModelDocumentChanged ) {
-				this.view.render();
-			}
+			this.view.render();
 		}, { priority: 'lowest' } );
 
 		// Whenever model document is changed, convert those changes to the view (using model.Document#differ).

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -240,8 +240,8 @@ export default class Document {
 	}
 
 	/**
-	 * Used to register a post-fixer callback. A post-fixer mechanism guarantees that the features that listen to
-	 * the {@link module:engine/model/model~Model#event:_change model's change event} will operate on a correct model state.
+	 * Used to register a post-fixer callback. A post-fixer mechanism guarantees that the features
+	 * will operate on a correct model state.
 	 *
 	 * An execution of a feature may lead to an incorrect document tree state. The callbacks are used to fix the document tree after
 	 * it has changed. Post-fixers are fired just after all changes from the outermost change block were applied but

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -683,7 +683,6 @@ export default class Model {
 	 */
 	_runPendingChanges() {
 		const ret = [];
-		let hasModelDocumentChanged = false;
 
 		this.fire( '_beforeChanges' );
 
@@ -696,9 +695,6 @@ export default class Model {
 			const callbackReturnValue = this._pendingChanges[ 0 ].callback( this._currentWriter );
 			ret.push( callbackReturnValue );
 
-			// Collect an information whether the model document has changed during from the last pending change.
-			hasModelDocumentChanged = hasModelDocumentChanged || this.document._hasDocumentChangedFromTheLastChangeBlock();
-
 			// Fire '_change' event before resetting differ.
 			this.fire( '_change', this._currentWriter );
 
@@ -708,7 +704,7 @@ export default class Model {
 			this._currentWriter = null;
 		}
 
-		this.fire( '_afterChanges', { hasModelDocumentChanged } );
+		this.fire( '_afterChanges' );
 
 		return ret;
 	}
@@ -739,8 +735,6 @@ export default class Model {
 	 *
 	 * @protected
 	 * @event _afterChanges
-	 * @param {Object} options
-	 * @param {Boolean} options.hasModelDocumentChanged `true` if the model document has changed during the
 	 * {@link module:engine/model/model~Model#change} or {@link module:engine/model/model~Model#enqueueChange} blocks.
 	 */
 

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -116,7 +116,7 @@ export default class Document {
 	 * instance connected with the executed changes block.
 	 *
 	 * Note that registering a post-fixer won't re-render the editor's view. If the view should change after registering the post-fixer then
-	 * it should be done manually calling `view.render( { force: true } );`.
+	 * it should be done manually calling `view.forceRender();`.
 	 *
 	 * @param {Function} postFixer
 	 */

--- a/src/view/document.js
+++ b/src/view/document.js
@@ -115,6 +115,9 @@ export default class Document {
 	 * As a parameter, a post-fixer callback receives a {@link module:engine/view/downcastwriter~DowncastWriter downcast writer}
 	 * instance connected with the executed changes block.
 	 *
+	 * Note that registering a post-fixer won't re-render the editor's view. If the view should change after registering the post-fixer then
+	 * it should be done manually calling `view.render( { force: true } );`.
+	 *
 	 * @param {Function} postFixer
 	 */
 	registerPostFixer( postFixer ) {

--- a/src/view/observer/focusobserver.js
+++ b/src/view/observer/focusobserver.js
@@ -37,7 +37,7 @@ export default class FocusObserver extends DomEventObserver {
 			// overwrite new DOM selection with selection from the view.
 			// See https://github.com/ckeditor/ckeditor5-engine/issues/795 for more details.
 			// Long timeout is needed to solve #676 and https://github.com/ckeditor/ckeditor5-engine/issues/1157 issues.
-			this._renderTimeoutId = setTimeout( () => view.render(), 50 );
+			this._renderTimeoutId = setTimeout( () => view.render( { force: true } ), 50 );
 		} );
 
 		document.on( 'blur', ( evt, data ) => {
@@ -47,7 +47,7 @@ export default class FocusObserver extends DomEventObserver {
 				document.isFocused = false;
 
 				// Re-render the document to update view elements.
-				view.render();
+				view.render( { force: true } );
 			}
 		} );
 

--- a/src/view/observer/focusobserver.js
+++ b/src/view/observer/focusobserver.js
@@ -37,7 +37,7 @@ export default class FocusObserver extends DomEventObserver {
 			// overwrite new DOM selection with selection from the view.
 			// See https://github.com/ckeditor/ckeditor5-engine/issues/795 for more details.
 			// Long timeout is needed to solve #676 and https://github.com/ckeditor/ckeditor5-engine/issues/1157 issues.
-			this._renderTimeoutId = setTimeout( () => view.render( { force: true } ), 50 );
+			this._renderTimeoutId = setTimeout( () => view.forceRender(), 50 );
 		} );
 
 		document.on( 'blur', ( evt, data ) => {
@@ -47,7 +47,7 @@ export default class FocusObserver extends DomEventObserver {
 				document.isFocused = false;
 
 				// Re-render the document to update view elements.
-				view.render( { force: true } );
+				view.forceRender();
 			}
 		} );
 

--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -248,7 +248,7 @@ export default class MutationObserver extends Observer {
 
 		// If nothing changes on `mutations` event, at this point we have "dirty DOM" (changed) and de-synched
 		// view (which has not been changed). In order to "reset DOM" we render the view again.
-		this.view.render();
+		this.view.render( { force: true } );
 
 		function sameNodes( child1, child2 ) {
 			// First level of comparison (array of children vs array of children) – use the Lodash's default behavior.

--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -248,7 +248,7 @@ export default class MutationObserver extends Observer {
 
 		// If nothing changes on `mutations` event, at this point we have "dirty DOM" (changed) and de-synched
 		// view (which has not been changed). In order to "reset DOM" we render the view again.
-		this.view.render( { force: true } );
+		this.view.forceRender();
 
 		function sameNodes( child1, child2 ) {
 			// First level of comparison (array of children vs array of children) – use the Lodash's default behavior.

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -166,7 +166,7 @@ export default class SelectionObserver extends Observer {
 		if ( this.selection.isSimilar( newViewSelection ) ) {
 			// If selection was equal and we are at this point of algorithm, it means that it was incorrect.
 			// Just re-render it, no need to fire any events, etc.
-			this.view.render( { force: true } );
+			this.view.forceRender();
 		} else {
 			const data = {
 				oldSelection: this.selection,

--- a/src/view/observer/selectionobserver.js
+++ b/src/view/observer/selectionobserver.js
@@ -166,7 +166,7 @@ export default class SelectionObserver extends Observer {
 		if ( this.selection.isSimilar( newViewSelection ) ) {
 			// If selection was equal and we are at this point of algorithm, it means that it was incorrect.
 			// Just re-render it, no need to fire any events, etc.
-			this.view.render();
+			this.view.render( { force: true } );
 		} else {
 			const data = {
 				oldSelection: this.selection,

--- a/src/view/placeholder.js
+++ b/src/view/placeholder.js
@@ -40,7 +40,7 @@ export function attachPlaceholder( view, element, placeholderText, checkFunction
 	} );
 
 	// Update view right away.
-	view.render();
+	view.render( { force: true } );
 }
 
 /**

--- a/src/view/placeholder.js
+++ b/src/view/placeholder.js
@@ -38,9 +38,6 @@ export function attachPlaceholder( view, element, placeholderText, checkFunction
 		placeholderText,
 		checkFunction
 	} );
-
-	// Update view right away.
-	view.render( { force: true } );
 }
 
 /**

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -66,7 +66,7 @@ export default class View {
 		 * Instance of the {@link module:engine/view/document~Document} associated with this view controller.
 		 *
 		 * @readonly
-		 * @member {module:engine/view/document~Document} module:engine/view/view~View#document
+		 * @type {module:engine/view/document~Document}
 		 */
 		this.document = new Document();
 
@@ -76,7 +76,7 @@ export default class View {
 		 * and {@link module:engine/view/observer/observer~Observer observers}.
 		 *
 		 * @readonly
-		 * @member {module:engine/view/domconverter~DomConverter} module:engine/view/view~View#domConverter
+		 * @type {module:engine/view/domconverter~DomConverter}
 		 */
 		this.domConverter = new DomConverter();
 
@@ -84,7 +84,7 @@ export default class View {
 		 * Instance of the {@link module:engine/view/renderer~Renderer renderer}.
 		 *
 		 * @protected
-		 * @member {module:engine/view/renderer~Renderer} module:engine/view/view~View#renderer
+		 * @type {module:engine/view/renderer~Renderer}
 		 */
 		this._renderer = new Renderer( this.domConverter, this.document.selection );
 		this._renderer.bind( 'isFocused' ).to( this.document );
@@ -93,7 +93,7 @@ export default class View {
 		 * Roots of the DOM tree. Map on the `HTMLElement`s with roots names as keys.
 		 *
 		 * @readonly
-		 * @member {Map} module:engine/view/view~View#domRoots
+		 * @type {Map.<String, HTMLElement>}
 		 */
 		this.domRoots = new Map();
 
@@ -101,7 +101,7 @@ export default class View {
 		 * Map of registered {@link module:engine/view/observer/observer~Observer observers}.
 		 *
 		 * @private
-		 * @member {Map.<Function, module:engine/view/observer/observer~Observer>} module:engine/view/view~View#_observers
+		 * @type {Map.<Function, module:engine/view/observer/observer~Observer>}
 		 */
 		this._observers = new Map();
 
@@ -109,7 +109,7 @@ export default class View {
 		 * Is set to `true` when {@link #change view changes} are currently in progress.
 		 *
 		 * @private
-		 * @member {Boolean} module:engine/view/view~View#_ongoingChange
+		 * @type {Boolean}
 		 */
 		this._ongoingChange = false;
 
@@ -117,7 +117,7 @@ export default class View {
 		 * Used to prevent calling {@link #render} and {@link #change} during rendering view to the DOM.
 		 *
 		 * @private
-		 * @member {Boolean} module:engine/view/view~View#_renderingInProgress
+		 * @type {Boolean}
 		 */
 		this._renderingInProgress = false;
 
@@ -125,7 +125,7 @@ export default class View {
 		 * Used to prevent calling {@link #render} and {@link #change} during rendering view to the DOM.
 		 *
 		 * @private
-		 * @member {Boolean} module:engine/view/view~View#_renderingInProgress
+		 * @type {Boolean}
 		 */
 		this._postFixersInProgress = false;
 
@@ -133,7 +133,7 @@ export default class View {
 		 * Internal flag to temporary disable rendering. See usage in the editing controller.
 		 *
 		 * @protected
-		 * @member {Boolean} module:engine/view/view~View#_renderingDisabled
+		 * @type {Boolean}
 		 */
 		this._renderingDisabled = false;
 
@@ -141,7 +141,7 @@ export default class View {
 		 * DowncastWriter instance used in {@link #change change method) callbacks.
 		 *
 		 * @private
-		 * @member {module:engine/view/downcastwriter~DowncastWriter} module:engine/view/view~View#_writer
+		 * @type {module:engine/view/downcastwriter~DowncastWriter}
 		 */
 		this._writer = new DowncastWriter( this.document );
 

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -330,9 +330,10 @@ export default class View {
 
 	/**
 	 * The `change()` method is the primary way of changing the view. You should use it to modify any node in the view tree.
-	 * It makes sure that after all changes are made the view is rendered to the DOM (assuming that the view will be changed inside the callback).
-	 * It prevents situations when the DOM is updated when the view state is not yet correct.It allows to nest calls one inside another and still
-	 * performs a single rendering after all those changes are made. It also returns the return value of its callback.
+	 * It makes sure that after all changes are made the view is rendered to the DOM (assuming that the view will be changed
+	 * inside the callback). It prevents situations when the DOM is updated when the view state is not yet correct.It allows
+	 * to nest calls one inside another and still performs a single rendering after all those changes are made.
+	 * It also returns the return value of its callback.
 	 *
 	 *		const text = view.change( writer => {
 	 *			const newText = writer.createText( 'foo' );

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -405,7 +405,7 @@ export default class View {
 	/**
 	 * Renders {@link module:engine/view/document~Document view document} to DOM. If any view changes are
 	 * currently in progress, rendering will start after all {@link #change change blocks} are processed.
-	 * If no changes are detected view will not re-render, unless the `options.force` is set to `true`.
+	 * If no changes were detected since the last rendering, the view will not re-render, unless the `options.force` is set to `true`.
 	 *
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `applying-view-changes-on-rendering` when
 	 * trying to re-render when rendering to DOM has already started.

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -582,7 +582,6 @@ export default class View {
 		}
 	}
 
-
 	/**
 	 * Renders all changes. In order to avoid triggering the observers (e.g. mutations) all observers are disabled
 	 * before rendering and re-enabled after that.

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -177,7 +177,11 @@ export default class View {
 		} );
 
 		// Listen to the selection changes.
-		this.listenTo( this.document.selection, 'change', () => {
+		this.listenTo( this.document, 'selectionChange', () => {
+			this._hasChangedSinceTheLastRendering = true;
+		} );
+
+		this.listenTo( this.document, 'selectionChange', () => {
 			this._hasChangedSinceTheLastRendering = true;
 		} );
 	}
@@ -312,9 +316,8 @@ export default class View {
 			const editable = this.document.selection.editableElement;
 
 			if ( editable ) {
-				this._hasChangedSinceTheLastRendering = true;
 				this.domConverter.focus( editable );
-				this.render();
+				this.render( { force: true } );
 			} else {
 				/**
 				 * Before focusing view document, selection should be placed inside one of the view's editables.
@@ -404,11 +407,19 @@ export default class View {
 	/**
 	 * Renders {@link module:engine/view/document~Document view document} to DOM. If any view changes are
 	 * currently in progress, rendering will start after all {@link #change change blocks} are processed.
+	 * If no changes are detected view will not re-render, unless the `options.force` is set to `true`.
 	 *
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `applying-view-changes-on-rendering` when
 	 * trying to re-render when rendering to DOM has already started.
+	 *
+	 * @param {Object} [options] Rendering options
+	 * @param {Boolean} [options.force=false] A flag ensures that the view will re-render even when nothing has changed.
 	 */
-	render() {
+	render( options = {} ) {
+		if ( options.force ) {
+			this._hasChangedSinceTheLastRendering = true;
+		}
+
 		this.change( () => {} );
 	}
 

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -184,22 +184,6 @@ export default class View {
 	}
 
 	/**
-	 * Disables or enables rendering. If the flag is set to `true` then the rendering will be disabled.
-	 * If the flag is set to `false` and if there was some change in the meantime, then the rendering action will be performed.
-	 *
-	 * @protected
-	 * @param {Boolean} flag A flag indicates whether the rendering should be disabled.
-	 */
-	_disableRendering( flag ) {
-		this._renderingDisabled = flag;
-
-		if ( flag == false ) {
-			// Render when you stop blocking rendering.
-			this.change( () => {} );
-		}
-	}
-
-	/**
 	 * Attaches DOM root element to the view element and enable all observers on that element.
 	 * Also {@link module:engine/view/renderer~Renderer#markToSync mark element} to be synchronized with the view
 	 * what means that all child nodes will be removed and replaced with content of the view root.
@@ -586,6 +570,23 @@ export default class View {
 	createSelection( selectable, placeOrOffset, options ) {
 		return new Selection( selectable, placeOrOffset, options );
 	}
+
+	/**
+	 * Disables or enables rendering. If the flag is set to `true` then the rendering will be disabled.
+	 * If the flag is set to `false` and if there was some change in the meantime, then the rendering action will be performed.
+	 *
+	 * @protected
+	 * @param {Boolean} flag A flag indicates whether the rendering should be disabled.
+	 */
+	_disableRendering( flag ) {
+		this._renderingDisabled = flag;
+
+		if ( flag == false ) {
+			// Render when you stop blocking rendering.
+			this.change( () => {} );
+		}
+	}
+
 
 	/**
 	 * Renders all changes. In order to avoid triggering the observers (e.g. mutations) all observers are disabled

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -331,7 +331,7 @@ export default class View {
 	/**
 	 * The `change()` method is the primary way of changing the view. You should use it to modify any node in the view tree.
 	 * It makes sure that after all changes are made the view is rendered to the DOM (assuming that the view will be changed
-	 * inside the callback). It prevents situations when the DOM is updated when the view state is not yet correct.It allows
+	 * inside the callback). It prevents situations when the DOM is updated when the view state is not yet correct. It allows
 	 * to nest calls one inside another and still performs a single rendering after all those changes are made.
 	 * It also returns the return value of its callback.
 	 *

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -402,11 +402,6 @@ export default class View {
 		return callbackResult;
 	}
 
-	render() {
-		console.log( 'deprecated usage.' );
-		this.forceRender();
-	}
-
 	/**
 	 * Renders {@link module:engine/view/document~Document view document} to DOM. If any view changes are
 	 * currently in progress, rendering will start after all {@link #change change blocks} are processed.

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -329,9 +329,9 @@ export default class View {
 
 	/**
 	 * The `change()` method is the primary way of changing the view. You should use it to modify any node in the view tree.
-	 * It makes sure that after all changes are made the view is rendered to the DOM. It prevents situations when the DOM is updated
-	 * when the view state is not yet correct. It allows to nest calls one inside another and still performs a single rendering
-	 * after all those changes are made. It also returns the return value of its callback.
+	 * It makes sure that after all changes are made the view is rendered to the DOM (assuming that the view will be changed inside the callback).
+	 * It prevents situations when the DOM is updated when the view state is not yet correct.It allows to nest calls one inside another and still
+	 * performs a single rendering after all those changes are made. It also returns the return value of its callback.
 	 *
 	 *		const text = view.change( writer => {
 	 *			const newText = writer.createText( 'foo' );

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -183,6 +183,14 @@ export default class View {
 		} );
 	}
 
+	_disablRendering( flag ) {
+		this._renderingDisabled = flag;
+
+		if ( flag == false ) {
+			this.change( () => {} );
+		}
+	}
+
 	/**
 	 * Attaches DOM root element to the view element and enable all observers on that element.
 	 * Also {@link module:engine/view/renderer~Renderer#markToSync mark element} to be synchronized with the view
@@ -314,7 +322,7 @@ export default class View {
 
 			if ( editable ) {
 				this.domConverter.focus( editable );
-				this.render( { force: true } );
+				this.forceRender();
 			} else {
 				/**
 				 * Before focusing view document, selection should be placed inside one of the view's editables.
@@ -413,12 +421,9 @@ export default class View {
 	 * @param {Object} [options] Rendering options
 	 * @param {Boolean} [options.force=false] A flag ensures that the view will re-render even when nothing has changed.
 	 */
-	render( options = {} ) {
-		if ( options.force ) {
-			this._hasChangedSinceTheLastRendering = true;
-		}
-
-		this.change( () => { } );
+	forceRender() {
+		this._hasChangedSinceTheLastRendering = true;
+		this.change( () => {} );
 	}
 
 	/**

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -137,10 +137,16 @@ export default class View {
 		 */
 		this._renderingDisabled = false;
 
+		/**
+		 * Internal flag to disable rendering when there are no changes since the last rendering.
+		 *
+		 * @private
+		 * @type {Boolean}
+		 */
 		this._hasChangedSinceTheLastRendering = false;
 
 		/**
-		 * DowncastWriter instance used in {@link #change change method) callbacks.
+		 * DowncastWriter instance used in {@link #change change method} callbacks.
 		 *
 		 * @private
 		 * @type {module:engine/view/downcastwriter~DowncastWriter}

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -132,7 +132,7 @@ export default class View {
 		/**
 		 * Internal flag to temporary disable rendering. See usage in the editing controller.
 		 *
-		 * @protected
+		 * @private
 		 * @type {Boolean}
 		 */
 		this._renderingDisabled = false;
@@ -183,10 +183,17 @@ export default class View {
 		} );
 	}
 
-	_disablRendering( flag ) {
+	/**
+	 * [_disableRendering description]
+	 *
+	 * @protected
+	 * @param {Boolean} flag [description]
+	 */
+	_disableRendering( flag ) {
 		this._renderingDisabled = flag;
 
 		if ( flag == false ) {
+			// Render when you stop blocking rendering.
 			this.change( () => {} );
 		}
 	}

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -418,6 +418,11 @@ export default class View {
 		return callbackResult;
 	}
 
+	render() {
+		console.log( 'deprecated usage.' );
+		this.forceRender();
+	}
+
 	/**
 	 * Renders {@link module:engine/view/document~Document view document} to DOM. If any view changes are
 	 * currently in progress, rendering will start after all {@link #change change blocks} are processed.

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -138,7 +138,8 @@ export default class View {
 		this._renderingDisabled = false;
 
 		/**
-		 * Internal flag to disable rendering when there are no changes since the last rendering.
+		 * Internal flag that disables rendering when there are no changes since the last rendering.
+		 * It stores information about changed selection and changed elements from attached document roots.
 		 *
 		 * @private
 		 * @type {Boolean}

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -176,12 +176,8 @@ export default class View {
 			this._hasChangedSinceTheLastRendering = false;
 		} );
 
-		// Listen to the selection changes.
-		this.listenTo( this.document, 'selectionChange', () => {
-			this._hasChangedSinceTheLastRendering = true;
-		} );
-
-		this.listenTo( this.document, 'selectionChange', () => {
+		// Listen to the document selection changes directly.
+		this.listenTo( this.document.selection, 'change', () => {
 			this._hasChangedSinceTheLastRendering = true;
 		} );
 	}
@@ -420,7 +416,7 @@ export default class View {
 			this._hasChangedSinceTheLastRendering = true;
 		}
 
-		this.change( () => {} );
+		this.change( () => { } );
 	}
 
 	/**

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -130,7 +130,7 @@ export default class View {
 		this._postFixersInProgress = false;
 
 		/**
-		 * Internal flag to temporary disable rendering. See usage in the editing controller.
+		 * Internal flag to temporary disable rendering. See the usage in the {@link #_disableRendering}.
 		 *
 		 * @private
 		 * @type {Boolean}
@@ -184,10 +184,11 @@ export default class View {
 	}
 
 	/**
-	 * [_disableRendering description]
+	 * Disables or enables rendering. If the flag is set to `true` then the rendering will be disabled.
+	 * If the flag is set to `false` and if there was some change in the meantime, then the rendering action will be performed.
 	 *
 	 * @protected
-	 * @param {Boolean} flag [description]
+	 * @param {Boolean} flag A flag indicates whether the rendering should be disabled.
 	 */
 	_disableRendering( flag ) {
 		this._renderingDisabled = flag;
@@ -420,13 +421,9 @@ export default class View {
 	/**
 	 * Renders {@link module:engine/view/document~Document view document} to DOM. If any view changes are
 	 * currently in progress, rendering will start after all {@link #change change blocks} are processed.
-	 * If no changes were detected since the last rendering, the view will not re-render, unless the `options.force` is set to `true`.
 	 *
 	 * Throws {@link module:utils/ckeditorerror~CKEditorError CKEditorError} `applying-view-changes-on-rendering` when
 	 * trying to re-render when rendering to DOM has already started.
-	 *
-	 * @param {Object} [options] Rendering options
-	 * @param {Boolean} [options.force=false] A flag ensures that the view will re-render even when nothing has changed.
 	 */
 	forceRender() {
 		this._hasChangedSinceTheLastRendering = true;

--- a/tests/controller/editingcontroller.js
+++ b/tests/controller/editingcontroller.js
@@ -186,7 +186,7 @@ describe( 'EditingController', () => {
 			} );
 
 			editing.view.document.isFocused = true;
-			editing.view.render();
+			editing.view.forceRender();
 
 			const domSelection = document.getSelection();
 			domSelection.removeAllRanges();

--- a/tests/tickets/1653.js
+++ b/tests/tickets/1653.js
@@ -9,7 +9,7 @@ import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictest
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
 describe( 'Bug ckeditor5-engine#1653', () => {
-	it( '`DataController.parse()` should not invoke `editing.view.render()`', () => {
+	it( '`DataController.parse()` should not fire `editing.view#render`', () => {
 		let editor;
 
 		const element = document.createElement( 'div' );
@@ -20,10 +20,12 @@ describe( 'Bug ckeditor5-engine#1653', () => {
 			.then( newEditor => {
 				editor = newEditor;
 
-				const spy = sinon.spy( editor.editing.view, 'render' );
+				const editingViewSpy = sinon.spy();
+
+				editor.editing.view.on( 'fire', editingViewSpy );
 				editor.data.parse( '<p></p>' );
 
-				sinon.assert.notCalled( spy );
+				sinon.assert.notCalled( editingViewSpy );
 			} )
 			.then( () => {
 				element.remove();

--- a/tests/view/manual/immutable.js
+++ b/tests/view/manual/immutable.js
@@ -24,7 +24,7 @@ setData( view,
 viewDocument.on( 'selectionChange', () => {
 	// Re-render view selection each time selection is changed.
 	// See https://github.com/ckeditor/ckeditor5-engine/issues/796.
-	view.render();
+	view.forceRender();
 } );
 
 view.focus();

--- a/tests/view/manual/noselection.js
+++ b/tests/view/manual/noselection.js
@@ -17,7 +17,7 @@ view.attachDomRoot( document.getElementById( 'editor' ) );
 viewDocument.on( 'selectionChange', () => {
 	// Re-render view selection each time selection is changed.
 	// See https://github.com/ckeditor/ckeditor5-engine/issues/796.
-	view.render();
+	view.forceRender();
 } );
 
 setData( view,

--- a/tests/view/observer/domeventobserver.js
+++ b/tests/view/observer/domeventobserver.js
@@ -183,7 +183,7 @@ describe( 'DomEventObserver', () => {
 			view.attachDomRoot( domRoot );
 			uiElement = createUIElement( 'p' );
 			viewRoot._appendChild( uiElement );
-			view.render();
+			view.render( { force: true } );
 
 			domEvent = new MouseEvent( 'click', { bubbles: true } );
 			evtSpy = sinon.spy();

--- a/tests/view/observer/domeventobserver.js
+++ b/tests/view/observer/domeventobserver.js
@@ -183,7 +183,7 @@ describe( 'DomEventObserver', () => {
 			view.attachDomRoot( domRoot );
 			uiElement = createUIElement( 'p' );
 			viewRoot._appendChild( uiElement );
-			view.render( { force: true } );
+			view.forceRender();
 
 			domEvent = new MouseEvent( 'click', { bubbles: true } );
 			evtSpy = sinon.spy();

--- a/tests/view/observer/focusobserver.js
+++ b/tests/view/observer/focusobserver.js
@@ -136,7 +136,8 @@ describe( 'FocusObserver', () => {
 		} );
 
 		it( 'should not call render if destroyed', () => {
-			const renderSpy = sinon.spy( view, 'render' );
+			const renderSpy = sinon.spy();
+			view.on( 'render', renderSpy );
 			const clock = sinon.useFakeTimers();
 
 			observer.onDomEvent( { type: 'focus', target: domMain } );

--- a/tests/view/observer/focusobserver.js
+++ b/tests/view/observer/focusobserver.js
@@ -169,6 +169,8 @@ describe( 'FocusObserver', () => {
 			setData( view, '<div contenteditable="true">foo bar</div>' );
 			view.render();
 
+			console.log( 1 );
+
 			viewDocument.on( 'selectionChange', selectionChangeSpy );
 			view.on( 'render', renderSpy );
 

--- a/tests/view/observer/focusobserver.js
+++ b/tests/view/observer/focusobserver.js
@@ -58,7 +58,8 @@ describe( 'FocusObserver', () => {
 		} );
 
 		it( 'should render document after blurring', () => {
-			const renderSpy = sinon.spy( view, 'render' );
+			const renderSpy = sinon.spy();
+			view.on( 'render', renderSpy );
 
 			observer.onDomEvent( { type: 'blur', target: document.body } );
 
@@ -122,7 +123,8 @@ describe( 'FocusObserver', () => {
 		} );
 
 		it( 'should delay rendering by 50ms', () => {
-			const renderSpy = sinon.spy( view, 'render' );
+			const renderSpy = sinon.spy();
+			view.on( 'render', renderSpy );
 			const clock = sinon.useFakeTimers();
 
 			observer.onDomEvent( { type: 'focus', target: domMain } );
@@ -167,7 +169,7 @@ describe( 'FocusObserver', () => {
 			const renderSpy = sinon.spy();
 
 			setData( view, '<div contenteditable="true">foo bar</div>' );
-			view.render();
+			view.forceRender();
 
 			viewDocument.on( 'selectionChange', selectionChangeSpy );
 			view.on( 'render', renderSpy );
@@ -188,7 +190,7 @@ describe( 'FocusObserver', () => {
 			const renderSpy = sinon.spy();
 
 			setData( view, '<div contenteditable="true">foo bar</div>' );
-			view.render();
+			view.forceRender();
 			const domEditable = domRoot.childNodes[ 0 ];
 
 			viewDocument.on( 'selectionChange', selectionChangeSpy );

--- a/tests/view/observer/focusobserver.js
+++ b/tests/view/observer/focusobserver.js
@@ -169,8 +169,6 @@ describe( 'FocusObserver', () => {
 			setData( view, '<div contenteditable="true">foo bar</div>' );
 			view.render();
 
-			console.log( 1 );
-
 			viewDocument.on( 'selectionChange', selectionChangeSpy );
 			view.on( 'render', renderSpy );
 

--- a/tests/view/observer/mutationobserver.js
+++ b/tests/view/observer/mutationobserver.js
@@ -39,7 +39,7 @@ describe( 'MutationObserver', () => {
 
 		viewRoot._appendChild( parse( '<container:p>foo</container:p><container:p>bar</container:p>' ) );
 
-		view.render( { render: true } );
+		view.forceRender();
 	} );
 
 	afterEach( () => {
@@ -98,7 +98,7 @@ describe( 'MutationObserver', () => {
 	it( 'should handle unbold', () => {
 		viewRoot._removeChildren( 0, viewRoot.childCount );
 		viewRoot._appendChild( parse( '<container:p><attribute:b>foo</attribute:b></container:p>' ) );
-		view.render();
+		view.forceRender();
 
 		const domP = domEditor.childNodes[ 0 ];
 		const domB = domP.childNodes[ 0 ];
@@ -207,7 +207,7 @@ describe( 'MutationObserver', () => {
 			parse( '<container:p>foo</container:p><container:p>bar</container:p>' ) );
 
 		// Render AdditionalEditor (first editor has been rendered in the beforeEach function)
-		view.render();
+		view.forceRender();
 
 		domEditor.childNodes[ 0 ].childNodes[ 0 ].data = 'foom';
 		domAdditionalEditor.childNodes[ 0 ].childNodes[ 0 ].data = 'foom';
@@ -378,7 +378,7 @@ describe( 'MutationObserver', () => {
 	it( 'should have no block filler in mutation', () => {
 		viewRoot._appendChild( parse( '<container:p></container:p>' ) );
 
-		view.render();
+		view.forceRender();
 
 		const domP = domEditor.childNodes[ 2 ];
 		domP.removeChild( domP.childNodes[ 0 ] );
@@ -397,7 +397,7 @@ describe( 'MutationObserver', () => {
 	it( 'should ignore mutation with bogus br inserted on the end of the empty paragraph', () => {
 		viewRoot._appendChild( parse( '<container:p></container:p>' ) );
 
-		view.render();
+		view.forceRender();
 
 		const domP = domEditor.childNodes[ 2 ];
 		domP.appendChild( document.createElement( 'br' ) );
@@ -410,7 +410,7 @@ describe( 'MutationObserver', () => {
 	it( 'should ignore mutation with bogus br inserted on the end of the paragraph with text', () => {
 		viewRoot._appendChild( parse( '<container:p>foo</container:p>' ) );
 
-		view.render();
+		view.forceRender();
 
 		const domP = domEditor.childNodes[ 2 ];
 		domP.appendChild( document.createElement( 'br' ) );
@@ -423,7 +423,7 @@ describe( 'MutationObserver', () => {
 	it( 'should ignore mutation with bogus br inserted on the end of the paragraph while processing text mutations', () => {
 		viewRoot._appendChild( parse( '<container:p>foo</container:p>' ) );
 
-		view.render();
+		view.forceRender();
 
 		const domP = domEditor.childNodes[ 2 ];
 		domP.childNodes[ 0 ].data = 'foo ';
@@ -440,7 +440,7 @@ describe( 'MutationObserver', () => {
 	it( 'should ignore child mutations which resulted in no changes – when element contains elements', () => {
 		viewRoot._appendChild( parse( '<container:p><container:x></container:x></container:p>' ) );
 
-		view.render();
+		view.forceRender();
 
 		const domP = domEditor.childNodes[ 2 ];
 		const domY = document.createElement( 'y' );
@@ -474,7 +474,7 @@ describe( 'MutationObserver', () => {
 	it( 'should not ignore mutation with br inserted not on the end of the paragraph', () => {
 		viewRoot._appendChild( parse( '<container:p>foo</container:p>' ) );
 
-		view.render();
+		view.forceRender();
 
 		const domP = domEditor.childNodes[ 2 ];
 		domP.insertBefore( document.createElement( 'br' ), domP.childNodes[ 0 ] );
@@ -493,7 +493,7 @@ describe( 'MutationObserver', () => {
 	it( 'should not ignore mutation inserting element different than br on the end of the empty paragraph', () => {
 		viewRoot._appendChild( parse( '<container:p></container:p>' ) );
 
-		view.render();
+		view.forceRender();
 
 		const domP = domEditor.childNodes[ 2 ];
 		domP.appendChild( document.createElement( 'span' ) );
@@ -511,7 +511,7 @@ describe( 'MutationObserver', () => {
 	it( 'should not ignore mutation inserting element different than br on the end of the paragraph with text', () => {
 		viewRoot._appendChild( parse( '<container:p>foo</container:p>' ) );
 
-		view.render();
+		view.forceRender();
 
 		const domP = domEditor.childNodes[ 2 ];
 		domP.appendChild( document.createElement( 'span' ) );
@@ -545,7 +545,7 @@ describe( 'MutationObserver', () => {
 			const uiElement = createUIElement( 'div' );
 			viewRoot._appendChild( uiElement );
 
-			view.render();
+			view.forceRender();
 		} );
 
 		it( 'should not collect text mutations from UIElement', () => {

--- a/tests/view/observer/mutationobserver.js
+++ b/tests/view/observer/mutationobserver.js
@@ -39,7 +39,7 @@ describe( 'MutationObserver', () => {
 
 		viewRoot._appendChild( parse( '<container:p>foo</container:p><container:p>bar</container:p>' ) );
 
-		view.render();
+		view.render( { render: true } );
 	} );
 
 	afterEach( () => {

--- a/tests/view/observer/selectionobserver.js
+++ b/tests/view/observer/selectionobserver.js
@@ -311,6 +311,7 @@ describe( 'SelectionObserver', () => {
 		const domParagraph = domMain.childNodes[ 0 ];
 		const domText = domParagraph.childNodes[ 0 ];
 		const domUI = domParagraph.childNodes[ 1 ];
+		const viewRenderSpy = sinon.spy();
 
 		// Add rendering on selectionChange event to check this feature.
 		viewDocument.on( 'selectionChange', () => {
@@ -330,7 +331,7 @@ describe( 'SelectionObserver', () => {
 
 			selectionObserver.listenTo( domDocument, 'selectionchange', () => {
 				// 4. Check if view was re-rendered.
-				expect( view.render.called ).to.be.true;
+				sinon.assert.calledOnce( viewRenderSpy );
 
 				done();
 			}, { priority: 'lowest' } );
@@ -339,7 +340,7 @@ describe( 'SelectionObserver', () => {
 			// Current and new selection position are similar in view (but not equal!).
 			// Also add a spy to `viewDocument#render` to see if view will be re-rendered.
 			sel.collapse( domUI, 0 );
-			sinon.spy( view, 'render' );
+			view.on( 'render', viewRenderSpy );
 
 			// Some browsers like Safari won't allow to put selection inside empty ui element.
 			// In that situation selection should stay in correct place.

--- a/tests/view/placeholder.js
+++ b/tests/view/placeholder.js
@@ -84,7 +84,7 @@ describe( 'placeholder', () => {
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 
 			result = false;
-			view.render();
+			view.render( { force: true } );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 

--- a/tests/view/placeholder.js
+++ b/tests/view/placeholder.js
@@ -25,7 +25,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
-			view.render( { force: true } );
+			view.forceRender();
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -36,7 +36,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
-			view.render( { force: true } );
+			view.forceRender();
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
@@ -47,7 +47,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
-			view.render( { force: true } );
+			view.forceRender();
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -58,7 +58,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
-			view.render( { force: true } );
+			view.forceRender();
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
@@ -70,7 +70,7 @@ describe( 'placeholder', () => {
 			viewDocument.isFocused = false;
 
 			attachPlaceholder( view, element, 'foo bar baz' );
-			view.render( { force: true } );
+			view.forceRender();
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -83,14 +83,14 @@ describe( 'placeholder', () => {
 			const spy = sinon.spy( () => result );
 
 			attachPlaceholder( view, element, 'foo bar baz', spy );
-			view.render( { force: true } );
+			view.forceRender();
 
 			sinon.assert.called( spy );
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 
 			result = false;
-			view.render( { force: true } );
+			view.forceRender();
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -99,7 +99,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
-			view.render( { force: true } );
+			view.forceRender();
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -117,7 +117,7 @@ describe( 'placeholder', () => {
 
 			attachPlaceholder( view, element, 'foo bar baz' );
 			attachPlaceholder( view, element, 'new text' );
-			view.render( { force: true } );
+			view.forceRender();
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'new text' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -130,7 +130,7 @@ describe( 'placeholder', () => {
 			attachPlaceholder( view, element, 'foo bar baz' );
 			setData( view, '<p>paragraph</p>' );
 
-			view.render();
+			view.forceRender();
 		} );
 
 		it( 'should allow to add placeholder to elements from different documents', () => {
@@ -146,8 +146,8 @@ describe( 'placeholder', () => {
 
 			attachPlaceholder( view, element, 'first placeholder' );
 			attachPlaceholder( secondView, secondElement, 'second placeholder' );
-			view.render( { force: true } );
-			secondView.render( { force: true } );
+			view.forceRender();
+			secondView.forceRender();
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'first placeholder' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -176,7 +176,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
-			view.render( { force: true } );
+			view.forceRender();
 
 			view.change( writer => {
 				writer.setSelection( ViewRange._createIn( element ) );
@@ -197,7 +197,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
-			view.render( { force: true } );
+			view.forceRender();
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;

--- a/tests/view/placeholder.js
+++ b/tests/view/placeholder.js
@@ -25,6 +25,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
+			view.render( { force: true } );
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -35,6 +36,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
+			view.render( { force: true } );
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
@@ -45,6 +47,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
+			view.render( { force: true } );
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -55,6 +58,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
+			view.render( { force: true } );
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
@@ -66,6 +70,7 @@ describe( 'placeholder', () => {
 			viewDocument.isFocused = false;
 
 			attachPlaceholder( view, element, 'foo bar baz' );
+			view.render( { force: true } );
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -78,6 +83,7 @@ describe( 'placeholder', () => {
 			const spy = sinon.spy( () => result );
 
 			attachPlaceholder( view, element, 'foo bar baz', spy );
+			view.render( { force: true } );
 
 			sinon.assert.called( spy );
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
@@ -93,6 +99,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
+			view.render( { force: true } );
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -110,6 +117,7 @@ describe( 'placeholder', () => {
 
 			attachPlaceholder( view, element, 'foo bar baz' );
 			attachPlaceholder( view, element, 'new text' );
+			view.render( { force: true } );
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'new text' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -138,6 +146,8 @@ describe( 'placeholder', () => {
 
 			attachPlaceholder( view, element, 'first placeholder' );
 			attachPlaceholder( secondView, secondElement, 'second placeholder' );
+			view.render( { force: true } );
+			secondView.render( { force: true } );
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'first placeholder' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
@@ -166,6 +176,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
+			view.render( { force: true } );
 
 			view.change( writer => {
 				writer.setSelection( ViewRange._createIn( element ) );
@@ -186,6 +197,7 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			attachPlaceholder( view, element, 'foo bar baz' );
+			view.render( { force: true } );
 
 			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -3224,7 +3224,7 @@ describe( 'Renderer', () => {
 			);
 
 			// Render it to DOM to create initial DOM <-> view mappings.
-			view.render();
+			view.forceRender();
 
 			// Unwrap italic attribute element.
 			view.change( writer => {
@@ -3234,7 +3234,7 @@ describe( 'Renderer', () => {
 			expect( getViewData( view ) ).to.equal( '<p>[<strong>foo</strong>]</p>' );
 
 			// Re-render changes in view to DOM.
-			view.render();
+			view.forceRender();
 
 			// Check if DOM is rendered correctly.
 			expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p><strong>foo</strong></p>' );
@@ -3250,7 +3250,7 @@ describe( 'Renderer', () => {
 				'</container:p>' );
 
 			// Render it to DOM to create initial DOM <-> view mappings.
-			view.render();
+			view.forceRender();
 
 			// Unwrap italic attribute element and change text inside.
 			view.change( writer => {
@@ -3261,7 +3261,7 @@ describe( 'Renderer', () => {
 			expect( getViewData( view ) ).to.equal( '<p>[<strong>bar</strong>]</p>' );
 
 			// Re-render changes in view to DOM.
-			view.render();
+			view.forceRender();
 
 			// Check if DOM is rendered correctly.
 			expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p><strong>bar</strong></p>' );
@@ -3274,7 +3274,7 @@ describe( 'Renderer', () => {
 			);
 
 			// Render it to DOM to create initial DOM <-> view mappings.
-			view.render();
+			view.forceRender();
 
 			// Change text and insert new element into paragraph.
 			const textNode = viewRoot.getChild( 0 ).getChild( 0 );
@@ -3287,7 +3287,7 @@ describe( 'Renderer', () => {
 			expect( getViewData( view ) ).to.equal( '<p>foobar<img></img></p>' );
 
 			// Re-render changes in view to DOM.
-			view.render();
+			view.forceRender();
 
 			// Check if DOM is rendered correctly.
 			expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p>foobar<img></img></p>' );
@@ -3300,7 +3300,7 @@ describe( 'Renderer', () => {
 			);
 
 			// Render it to DOM to create initial DOM <-> view mappings.
-			view.render();
+			view.forceRender();
 
 			// Change text and insert new element into paragraph.
 			const textNode = viewRoot.getChild( 0 ).getChild( 0 );
@@ -3313,7 +3313,7 @@ describe( 'Renderer', () => {
 			expect( getViewData( view ) ).to.equal( '<p><img></img>foobar</p>' );
 
 			// Re-render changes in view to DOM.
-			view.render();
+			view.forceRender();
 
 			// Check if DOM is rendered correctly.
 			expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p><img></img>foobar</p>' );
@@ -3330,7 +3330,7 @@ describe( 'Renderer', () => {
 			);
 
 			// Render it to DOM to create initial DOM <-> view mappings.
-			view.render();
+			view.forceRender();
 
 			// Remove first element and reinsert it at the end.
 			const container = viewRoot.getChild( 0 );
@@ -3344,7 +3344,7 @@ describe( 'Renderer', () => {
 			expect( getViewData( view ) ).to.equal( '<p><i></i><span></span><b></b></p>' );
 
 			// Re-render changes in view to DOM.
-			view.render();
+			view.forceRender();
 
 			// Check if DOM is rendered correctly.
 			expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p><i></i><span></span><b></b></p>' );

--- a/tests/view/view/jumpoverinlinefiller.js
+++ b/tests/view/view/jumpoverinlinefiller.js
@@ -42,7 +42,7 @@ describe( 'View', () => {
 	describe( 'jump over inline filler hack', () => {
 		it( 'should jump over inline filler when left arrow is pressed after inline filler', () => {
 			setData( view, '<container:p>foo<attribute:b>[]</attribute:b>bar</container:p>' );
-			view.render();
+			view.forceRender();
 
 			viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowleft, domTarget: view.domRoots.get( 'main' ) } );
 
@@ -64,7 +64,7 @@ describe( 'View', () => {
 
 		it( 'should do nothing when another key is pressed', () => {
 			setData( view, '<container:p>foo<attribute:b>[]</attribute:b>bar</container:p>' );
-			view.render();
+			view.forceRender();
 
 			viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowright, domTarget: view.domRoots.get( 'main' ) } );
 
@@ -77,7 +77,7 @@ describe( 'View', () => {
 
 		it( 'should do nothing if range is not collapsed', () => {
 			setData( view, '<container:p>foo<attribute:b>{x}</attribute:b>bar</container:p>' );
-			view.render();
+			view.forceRender();
 
 			viewDocument.fire( 'keydown', { keyCode: keyCodes.arrowleft, domTarget: view.domRoots.get( 'main' ) } );
 

--- a/tests/view/view/jumpoveruielement.js
+++ b/tests/view/view/jumpoveruielement.js
@@ -62,7 +62,7 @@ describe( 'View', () => {
 	} );
 
 	function renderAndFireKeydownEvent( options ) {
-		view.render();
+		view.forceRender();
 
 		const eventData = Object.assign( { keyCode: keyCodes.arrowright, domTarget: view.domRoots.get( 'main' ) }, options );
 		viewDocument.fire( 'keydown', eventData );

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -204,7 +204,7 @@ describe( 'view', () => {
 
 		it( 'should be disabled and re-enabled on render', () => {
 			const observerMock = view.addObserver( ObserverMock );
-			view.render( { force: true } );
+			view.forceRender();
 
 			sinon.assert.calledOnce( observerMock.disable );
 			sinon.assert.calledOnce( view._renderer.render );
@@ -327,7 +327,7 @@ describe( 'view', () => {
 
 		it( 'should focus editable with selection', () => {
 			const converterFocusSpy = testUtils.sinon.spy( view.domConverter, 'focus' );
-			const renderSpy = testUtils.sinon.spy( view, 'render' );
+			const renderSpy = testUtils.sinon.spy( view, 'forceRender' );
 
 			view.focus();
 
@@ -344,7 +344,7 @@ describe( 'view', () => {
 
 		it( 'should not focus if document is already focused', () => {
 			const converterFocusSpy = testUtils.sinon.spy( view.domConverter, 'focus' );
-			const renderSpy = testUtils.sinon.spy( view, 'render' );
+			const renderSpy = testUtils.sinon.spy( view, 'forceRender' );
 			viewDocument.isFocused = true;
 
 			view.focus();
@@ -377,37 +377,24 @@ describe( 'view', () => {
 		} );
 	} );
 
-	describe( 'render()', () => {
+	describe( 'forceRender()', () => {
 		it( 'disable observers, renders and enable observers', () => {
 			const observerMock = view.addObserver( ObserverMock );
 			const renderStub = sinon.stub( view._renderer, 'render' );
 
-			view.render( { force: true } );
+			view.forceRender();
 
 			sinon.assert.callOrder( observerMock.disable, renderStub, observerMock.enable );
 		} );
 
-		it( 'should not fire `render` and `layoutChanged` without the `force` flag if there were no changes', () => {
+		it( 'should fire `render` and `layoutChanged` even if there were no changes', () => {
 			const renderSpy = sinon.spy();
 			const layoutChangedSpy = sinon.spy();
 
 			view.on( 'render', renderSpy );
 			view.document.on( 'layoutChanged', layoutChangedSpy );
 
-			view.render();
-
-			sinon.assert.notCalled( renderSpy );
-			sinon.assert.notCalled( layoutChangedSpy );
-		} );
-
-		it( 'should fire `render` and `layoutChanged` if there were no changes but the `force` flag was set', () => {
-			const renderSpy = sinon.spy();
-			const layoutChangedSpy = sinon.spy();
-
-			view.on( 'render', renderSpy );
-			view.document.on( 'layoutChanged', layoutChangedSpy );
-
-			view.render( { force: true } );
+			view.forceRender();
 
 			sinon.assert.calledOnce( renderSpy );
 			sinon.assert.calledOnce( layoutChangedSpy );
@@ -421,7 +408,7 @@ describe( 'view', () => {
 			view.document.on( 'layoutChanged', layoutChangedSpy );
 
 			view.document.selection._setTo( null );
-			view.render();
+			view.forceRender();
 
 			sinon.assert.calledOnce( renderSpy );
 			sinon.assert.calledOnce( layoutChangedSpy );
@@ -440,7 +427,7 @@ describe( 'view', () => {
 
 			createViewRoot( viewDocument, 'div', 'main' );
 			view.attachDomRoot( domDiv );
-			view.render( { force: true } );
+			view.forceRender();
 
 			expect( domDiv.childNodes.length ).to.equal( 1 );
 			expect( isBlockFiller( domDiv.childNodes[ 0 ], BR_FILLER ) ).to.be.true;
@@ -458,7 +445,7 @@ describe( 'view', () => {
 			view.attachDomRoot( domDiv );
 
 			viewDocument.getRoot()._appendChild( new ViewElement( 'p' ) );
-			view.render();
+			view.forceRender();
 
 			expect( domDiv.childNodes.length ).to.equal( 1 );
 			expect( domDiv.childNodes[ 0 ].tagName ).to.equal( 'P' );
@@ -477,13 +464,13 @@ describe( 'view', () => {
 
 			const viewP = new ViewElement( 'p', { class: 'foo' } );
 			viewRoot._appendChild( viewP );
-			view.render();
+			view.forceRender();
 
 			expect( domRoot.childNodes.length ).to.equal( 1 );
 			expect( domRoot.childNodes[ 0 ].getAttribute( 'class' ) ).to.equal( 'foo' );
 
 			viewP._setAttribute( 'class', 'bar' );
-			view.render();
+			view.forceRender();
 
 			expect( domRoot.childNodes.length ).to.equal( 1 );
 			expect( domRoot.childNodes[ 0 ].getAttribute( 'class' ) ).to.equal( 'bar' );
@@ -529,7 +516,7 @@ describe( 'view', () => {
 				} ).to.throw( CKEditorError, /^cannot-change-view-tree/ );
 			} );
 
-			view.render();
+			view.forceRender();
 			domDiv.remove();
 		} );
 
@@ -581,12 +568,12 @@ describe( 'view', () => {
 			view.on( 'render', eventSpy );
 
 			view.change( () => {
-				view.render( { force: true } );
+				view.forceRender();
 				view.change( writer => {
 					writer.setSelection( null );
-					view.render( { force: true } );
+					view.forceRender();
 				} );
-				view.render( { force: true } );
+				view.forceRender();
 			} );
 
 			sinon.assert.calledOnce( renderSpy );

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -411,7 +411,7 @@ describe( 'view', () => {
 
 			sinon.assert.calledOnce( renderSpy );
 			sinon.assert.calledOnce( layoutChangedSpy );
-		} )
+		} );
 
 		it( 'should fire `render` and `layoutChanged` if there is some buffered change', () => {
 			const renderSpy = sinon.spy();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevented `View` from firing the `render` event if there were no changes since the last rendering. Closes #1653. Closes #1660.


---

### Additional information

* BREAKING CHANGE: The `editing.view.render()` method was renamed to `editing.view.forceRender()`. It should be used with caution as it will re-render editing view and repaint the UI.
