### PR TITLE
Fix: Moving to the same position is not handled by the Differ as a change

### DIFF
--- a/src/model/differ.js
+++ b/src/model/differ.js
@@ -151,7 +151,10 @@ export default class Differ {
 			case 'reinsert': {
 				// When range is moved to the same position then not mark it as a change.
 				// See: https://github.com/ckeditor/ckeditor5-engine/issues/1664.
-				if ( operation.sourcePosition.isEqual( operation.targetPosition ) ) {
+				if (
+					operation.sourcePosition.isEqual( operation.targetPosition ) ||
+					operation.sourcePosition.getShiftedBy( operation.howMany ).isEqual( operation.targetPosition )
+				) {
 					return;
 				}
 

--- a/src/model/differ.js
+++ b/src/model/differ.js
@@ -149,6 +149,12 @@ export default class Differ {
 			case 'remove':
 			case 'move':
 			case 'reinsert': {
+				// When range is moved to the same position then not mark it as a change.
+				// See: https://github.com/ckeditor/ckeditor5-engine/issues/1664.
+				if ( operation.sourcePosition.isEqual( operation.targetPosition ) ) {
+					return;
+				}
+
 				const sourceParentInserted = this._isInInsertedElement( operation.sourcePosition.parent );
 				const targetParentInserted = this._isInInsertedElement( operation.targetPosition.parent );
 

--- a/tests/model/differ.js
+++ b/tests/model/differ.js
@@ -629,6 +629,17 @@ describe( 'Differ', () => {
 				] );
 			} );
 		} );
+
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1664
+		it( 'move to the same position', () => {
+			const position = new Position( root, [ 0 ] );
+
+			model.change( () => {
+				move( position, 1, position );
+
+				expectChanges( [] );
+			} );
+		} );
 	} );
 
 	describe( 'rename', () => {

--- a/tests/model/differ.js
+++ b/tests/model/differ.js
@@ -646,13 +646,10 @@ describe( 'Differ', () => {
 			const sourcePosition = new Position( root, [ 0 ] );
 			const targetPosition = new Position( root, [ 2 ] );
 
+			// Add two more elements to the root, now there are 4 paragraphs.
 			root._appendChild( [
-				new Element( 'paragraph', null, [
-					new Text( 'x' )
-				] ),
-				new Element( 'paragraph', null, [
-					new Text( 'y' )
-				] )
+				new Element( 'paragraph' ),
+				new Element( 'paragraph' )
 			] );
 
 			model.change( () => {

--- a/tests/model/differ.js
+++ b/tests/model/differ.js
@@ -631,11 +631,32 @@ describe( 'Differ', () => {
 		} );
 
 		// https://github.com/ckeditor/ckeditor5-engine/issues/1664
-		it( 'move to the same position', () => {
+		it( 'move to the same position #1', () => {
 			const position = new Position( root, [ 0 ] );
 
 			model.change( () => {
 				move( position, 1, position );
+
+				expectChanges( [] );
+			} );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1664
+		it( 'move to the same position #2', () => {
+			const sourcePosition = new Position( root, [ 0 ] );
+			const targetPosition = new Position( root, [ 2 ] );
+
+			root._appendChild( [
+				new Element( 'paragraph', null, [
+					new Text( 'x' )
+				] ),
+				new Element( 'paragraph', null, [
+					new Text( 'y' )
+				] )
+			] );
+
+			model.change( () => {
+				move( sourcePosition, 2, targetPosition );
 
 				expectChanges( [] );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Moving to the same position is not handled by the Differ as a change. Closes #1664.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
