### PR TITLE
Feature: Implemented Selection#is() and DocumentSelection#is() methods.

### DIFF
--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -361,7 +361,7 @@ export default class DocumentSelection {
 
 	/**
 	 * Checks whether object is of given type following the convention set by
-	 * {@link module:engine/model/node~Node#is}.
+	 * {@link module:engine/model/node~Node#is `Node#is()`}.
 	 *
 	 *		const selection = new DocumentSelection( ... );
 	 *

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -360,6 +360,24 @@ export default class DocumentSelection {
 	}
 
 	/**
+	 * Checks whether object is of given type following the convention set by
+	 * {@link module:engine/model/node~Node#is}.
+	 *
+	 *		const selection = new DocumentSelection( ... );
+	 *
+	 *		selection.is( 'selection' ); // true
+	 *		selection.is( 'documentSelection' ); // true
+	 *		selection.is( 'node' ); // false
+	 *		selection.is( 'element' ); // false
+	 *
+	 * @param {String} type
+	 * @returns {Boolean}
+	 */
+	is( type ) {
+		return type == 'selection' || type == 'documentSelection';
+	}
+
+	/**
 	 * Moves {@link module:engine/model/documentselection~DocumentSelection#focus} to the specified location.
 	 * Should be used only within the {@link module:engine/model/writer~Writer#setSelectionFocus} method.
 	 *

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -610,7 +610,7 @@ export default class Selection {
 
 	/**
 	 * Checks whether object is of given type following the convention set by
-	 * {@link module:engine/model/node~Node#is}.
+	 * {@link module:engine/model/node~Node#is `Node#is()`}.
 	 *
 	 *		const selection = new Selection( ... );
 	 *

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -609,6 +609,23 @@ export default class Selection {
 	}
 
 	/**
+	 * Checks whether object is of given type following the convention set by
+	 * {@link module:engine/model/node~Node#is}.
+	 *
+	 *		const selection = new Selection( ... );
+	 *
+	 *		selection.is( 'selection' ); // true
+	 *		selection.is( 'node' ); // false
+	 *		selection.is( 'element' ); // false
+	 *
+	 * @param {String} type
+	 * @returns {Boolean}
+	 */
+	is( type ) {
+		return type == 'selection';
+	}
+
+	/**
 	 * Gets elements of type "block" touched by the selection.
 	 *
 	 * This method's result can be used for example to apply block styling to all blocks covered by this selection.

--- a/src/view/documentselection.js
+++ b/src/view/documentselection.js
@@ -275,6 +275,24 @@ export default class DocumentSelection {
 	}
 
 	/**
+	 * Checks whether object is of given type following the convention set by
+	 * {@link module:engine/view/node~Node#is `Node#is()`}.
+	 *
+	 *		const selection = new DocumentSelection( ... );
+	 *
+	 *		selection.is( 'selection' ); // true
+	 *		selection.is( 'documentSelection' ); // true
+	 *		selection.is( 'node' ); // false
+	 *		selection.is( 'element' ); // false
+	 *
+	 * @param {String} type
+	 * @returns {Boolean}
+	 */
+	is( type ) {
+		return type == 'selection' || type == 'documentSelection';
+	}
+
+	/**
 	 * Sets this selection's ranges and direction to the specified location based on the given
 	 * {@link module:engine/view/selection~Selectable selectable}.
 	 *

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -578,6 +578,23 @@ export default class Selection {
 	}
 
 	/**
+	 * Checks whether object is of given type following the convention set by
+	 * {@link module:engine/view/node~Node#is `Node#is()`}.
+	 *
+	 *		const selection = new Selection( ... );
+	 *
+	 *		selection.is( 'selection' ); // true
+	 *		selection.is( 'node' ); // false
+	 *		selection.is( 'element' ); // false
+	 *
+	 * @param {String} type
+	 * @returns {Boolean}
+	 */
+	is( type ) {
+		return type == 'selection';
+	}
+
+	/**
 	 * Replaces all ranges that were added to the selection with given array of ranges. Last range of the array
 	 * is treated like the last added range and is used to set {@link #anchor anchor} and {@link #focus focus}.
 	 * Accepts a flag describing in which way the selection is made.

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -490,6 +490,24 @@ describe( 'DocumentSelection', () => {
 		} );
 	} );
 
+	describe( 'is', () => {
+		it( 'should return true for selection', () => {
+			expect( selection.is( 'selection' ) ).to.be.true;
+		} );
+
+		it( 'should return true for documentSelection', () => {
+			expect( selection.is( 'documentSelection' ) ).to.be.true;
+		} );
+
+		it( 'should return false for other values', () => {
+			expect( selection.is( 'node' ) ).to.be.false;
+			expect( selection.is( 'text' ) ).to.be.false;
+			expect( selection.is( 'textProxy' ) ).to.be.false;
+			expect( selection.is( 'element' ) ).to.be.false;
+			expect( selection.is( 'rootElement' ) ).to.be.false;
+		} );
+	} );
+
 	describe( '_setTo() - set collapsed at', () => {
 		it( 'detaches all existing ranges', () => {
 			selection._setTo( [ range, liveRange ] );

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -806,6 +806,21 @@ describe( 'Selection', () => {
 		} );
 	} );
 
+	describe( 'is', () => {
+		it( 'should return true for selection', () => {
+			expect( selection.is( 'selection' ) ).to.be.true;
+		} );
+
+		it( 'should return false for other values', () => {
+			expect( selection.is( 'documentSelection' ) ).to.be.false;
+			expect( selection.is( 'node' ) ).to.be.false;
+			expect( selection.is( 'text' ) ).to.be.false;
+			expect( selection.is( 'textProxy' ) ).to.be.false;
+			expect( selection.is( 'element' ) ).to.be.false;
+			expect( selection.is( 'rootElement' ) ).to.be.false;
+		} );
+	} );
+
 	describe( 'setTo - used to collapse at start', () => {
 		it( 'should collapse to start position and fire change event', () => {
 			selection.setTo( [ range2, range1, range3 ] );

--- a/tests/view/documentselection.js
+++ b/tests/view/documentselection.js
@@ -725,6 +725,24 @@ describe( 'DocumentSelection', () => {
 		} );
 	} );
 
+	describe( 'is', () => {
+		it( 'should return true for selection', () => {
+			expect( documentSelection.is( 'selection' ) ).to.be.true;
+		} );
+
+		it( 'should return true for documentSelection', () => {
+			expect( documentSelection.is( 'documentSelection' ) ).to.be.true;
+		} );
+
+		it( 'should return false for other values', () => {
+			expect( documentSelection.is( 'node' ) ).to.be.false;
+			expect( documentSelection.is( 'text' ) ).to.be.false;
+			expect( documentSelection.is( 'textProxy' ) ).to.be.false;
+			expect( documentSelection.is( 'element' ) ).to.be.false;
+			expect( documentSelection.is( 'rootElement' ) ).to.be.false;
+		} );
+	} );
+
 	describe( '_setTo()', () => {
 		describe( 'simple scenarios', () => {
 			it( 'should set selection ranges from the given selection', () => {

--- a/tests/view/selection.js
+++ b/tests/view/selection.js
@@ -599,6 +599,21 @@ describe( 'Selection', () => {
 		} );
 	} );
 
+	describe( 'is', () => {
+		it( 'should return true for selection', () => {
+			expect( selection.is( 'selection' ) ).to.be.true;
+		} );
+
+		it( 'should return false for other values', () => {
+			expect( selection.is( 'documentSelection' ) ).to.be.false;
+			expect( selection.is( 'node' ) ).to.be.false;
+			expect( selection.is( 'text' ) ).to.be.false;
+			expect( selection.is( 'textProxy' ) ).to.be.false;
+			expect( selection.is( 'element' ) ).to.be.false;
+			expect( selection.is( 'rootElement' ) ).to.be.false;
+		} );
+	} );
+
 	describe( 'setTo()', () => {
 		describe( 'simple scenarios', () => {
 			it( 'should set selection ranges from the given selection', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Implemented `Selection#is()` and `DocumentSelection#is()` methods in both the model and the view. Closes #1663.

---

A piece of https://github.com/ckeditor/ckeditor5-engine/issues/1667. To get rid of `instanceof` checks we must implement `is()` in other classes too.