### PR TITLE
Undo and redo no longer crashes in scenarios featuring pasting content into earlier pasted content

### DIFF
--- a/tests/model/operation/transform/undo.js
+++ b/tests/model/operation/transform/undo.js
@@ -5,6 +5,9 @@
 
 import { Client, expectClients, clearBuffer } from './utils.js';
 
+import Element from '../../../../src/model/element';
+import Text from '../../../../src/model/text';
+
 describe( 'transform', () => {
 	let john;
 
@@ -573,5 +576,40 @@ describe( 'transform', () => {
 		john.undo();
 
 		expectClients( '<paragraph>XY</paragraph>' );
+	} );
+
+	// https://github.com/ckeditor/ckeditor5/issues/1385
+	it( 'paste inside paste + undo, undo + redo, redo', () => {
+		const model = john.editor.model;
+
+		john.setData( '<paragraph>[]</paragraph>' );
+
+		model.insertContent( getPastedContent() );
+
+		john.setSelection( [ 0, 3 ] );
+
+		model.insertContent( getPastedContent() );
+
+		expectClients( '<heading1>FooFoobarbar</heading1>' );
+
+		john.undo();
+
+		expectClients( '<heading1>Foobar</heading1>' );
+
+		john.undo();
+
+		expectClients( '<paragraph></paragraph>' );
+
+		john.redo();
+
+		expectClients( '<heading1>Foobar</heading1>' );
+
+		john.redo();
+
+		expectClients( '<heading1>FooFoobarbar</heading1>' );
+
+		function getPastedContent() {
+			return new Element( 'heading1', null, new Text( 'Foobar' ) );
+		}
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Undo and redo no longer crashes in scenarios featuring pasting content into earlier pasted content. Closes https://github.com/ckeditor/ckeditor5/issues/1385.

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-undo/pull/96/files

I had to re-introduce `forceWeakRemove` flag. This mechanism/flag was used before when we had deltas. I figured it was no longer needed after the refactorings we had. It wasn't needed for long, however, unfortunately, those cases need it. They can't be solved in a way other than explicitly saying: "this is undo, do (not) do this or that".

@Mgsy please test *extensively* undo after this PR as it touches multiple scenarios. Please test scenarios with merges, splits and removes. All unit tests were fine, though.