### PR TITLE
Fake selection container was not appended to the new fake selection editable when fake selection changes

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -707,7 +707,10 @@ export default class Renderer {
 			container.appendChild( domDocument.createTextNode( '\u00A0' ) );
 		}
 
-		// Add fake container if not already added.
+		if ( container.parentElement && container.parentElement != domRoot ) {
+			container.remove( container );
+		}
+
 		if ( !container.parentElement ) {
 			domRoot.appendChild( container );
 		}

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -707,11 +707,7 @@ export default class Renderer {
 			container.appendChild( domDocument.createTextNode( '\u00A0' ) );
 		}
 
-		if ( container.parentElement && container.parentElement != domRoot ) {
-			container.remove( container );
-		}
-
-		if ( !container.parentElement ) {
+		if ( !container.parentElement || container.parentElement != domRoot ) {
 			domRoot.appendChild( container );
 		}
 

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1935,14 +1935,14 @@ describe( 'Renderer', () => {
 
 				let container = document.getSelection().anchorNode;
 
-				expect( container.parentElement ).to.equal( domRoot );
+				expect( domRoot.contains( container ) ).to.be.true;
 
 				selection._setTo( viewEditable, 'in', { fake: true, label: 'fake selection' } );
 				renderer.render();
 
 				container = document.getSelection().anchorNode;
 
-				expect( container.parentElement ).to.equal( domEditable );
+				expect( domEditable.contains( container ) ).to.be.true;
 			} );
 
 			it( 'should bind fake selection container to view selection', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fake selection container was not appended to the new fake selection editable when the fake selection changes. Closes https://github.com/ckeditor/ckeditor5/issues/1523.