### PR TITLE
t/1680: Enabled the .ck-read-only class support on view root element

### DIFF
--- a/src/view/view.js
+++ b/src/view/view.js
@@ -240,6 +240,12 @@ export default class View {
 
 		const updateContenteditableAttribute = () => {
 			this._writer.setAttribute( 'contenteditable', !viewRoot.isReadOnly, viewRoot );
+
+			if ( viewRoot.isReadOnly ) {
+				this._writer.addClass( 'ck-read-only', viewRoot );
+			} else {
+				this._writer.removeClass( 'ck-read-only', viewRoot );
+			}
 		};
 
 		// Set initial value.

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -132,6 +132,19 @@ describe( 'view', () => {
 			expect( viewRoot.getAttribute( 'contenteditable' ) ).to.equal( 'false' );
 		} );
 
+		it( 'should handle the ".ck-read-only" class management on #isReadOnly change', () => {
+			const domDiv = document.createElement( 'div' );
+			const viewRoot = createViewRoot( viewDocument, 'div', 'main' );
+
+			view.attachDomRoot( domDiv );
+
+			viewRoot.isReadOnly = false;
+			expect( viewRoot.hasClass( 'ck-read-only' ) ).to.be.false;
+
+			viewRoot.isReadOnly = true;
+			expect( viewRoot.hasClass( 'ck-read-only' ) ).to.be.true;
+		} );
+
 		it( 'should call observe on each observer', () => {
 			// The variable will be overwritten.
 			view.destroy();
@@ -219,6 +232,23 @@ describe( 'view', () => {
 			view.detachDomRoot( 'main' );
 
 			expect( domDiv.hasAttribute( 'contenteditable' ) ).to.be.false;
+
+			domDiv.remove();
+		} );
+
+		it( 'should remove the ".ck-read-only" class from the DOM root', () => {
+			const domDiv = document.createElement( 'div' );
+			const viewRoot = createViewRoot( viewDocument, 'div', 'main' );
+
+			view.attachDomRoot( domDiv );
+			view.forceRender();
+
+			viewRoot.isReadOnly = true;
+			expect( domDiv.classList.contains( 'ck-read-only' ) ).to.be.true;
+
+			view.detachDomRoot( 'main' );
+
+			expect( domDiv.classList.contains( 'ck-read-only' ) ).to.be.false;
 
 			domDiv.remove();
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Enabled the .ck-read-only class support on view root element. Originally introduced in ckeditor/ckeditor5-ui#453 but forgotten in ckeditor/ckeditor5-ui#463 refactoring. Closes #1680.