### PR TITLE
Introduce readonly View#isRenderingInProgress flag to check if view is in the rendering phase

### DIFF
--- a/src/view/view.js
+++ b/src/view/view.js
@@ -89,6 +89,14 @@ export default class View {
 		this.domRoots = new Map();
 
 		/**
+		 * Used to prevent calling {@link #forceRender} and {@link #change} during rendering view to the DOM.
+		 *
+		 * @readonly
+		 * @member {Boolean} #isRenderingInProgress
+		 */
+		this.set( 'isRenderingInProgress', false );
+
+		/**
 		 * Instance of the {@link module:engine/view/renderer~Renderer renderer}.
 		 *
 		 * @protected
@@ -123,14 +131,6 @@ export default class View {
 		 * @type {Boolean}
 		 */
 		this._ongoingChange = false;
-
-		/**
-		 * Used to prevent calling {@link #forceRender} and {@link #change} during rendering view to the DOM.
-		 *
-		 * @private
-		 * @type {Boolean}
-		 */
-		this._renderingInProgress = false;
 
 		/**
 		 * Used to prevent calling {@link #forceRender} and {@link #change} during rendering view to the DOM.
@@ -434,7 +434,7 @@ export default class View {
 	 * @returns {*} Value returned by the callback.
 	 */
 	change( callback ) {
-		if ( this._renderingInProgress || this._postFixersInProgress ) {
+		if ( this.isRenderingInProgress || this._postFixersInProgress ) {
 			/**
 			 * Thrown when there is an attempt to make changes to the view tree when it is in incorrect state. This may
 			 * cause some unexpected behaviour and inconsistency between the DOM and the view.
@@ -668,11 +668,11 @@ export default class View {
 	 * @private
 	 */
 	_render() {
-		this._renderingInProgress = true;
+		this.isRenderingInProgress = true;
 		this.disableObservers();
 		this._renderer.render();
 		this.enableObservers();
-		this._renderingInProgress = false;
+		this.isRenderingInProgress = false;
 	}
 
 	/**

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -487,6 +487,22 @@ describe( 'view', () => {
 		} );
 	} );
 
+	describe( 'isRenderingInProgress', () => {
+		it( 'should be true while rendering is in progress', () => {
+			expect( view.isRenderingInProgress ).to.equal( false );
+
+			const spy = sinon.spy();
+
+			view.on( 'change:isRenderingInProgress', spy );
+
+			view.fire( 'render' );
+
+			sinon.assert.calledTwice( spy );
+			sinon.assert.calledWith( spy.firstCall, sinon.match.any, 'isRenderingInProgress', true );
+			sinon.assert.calledWith( spy.secondCall, sinon.match.any, 'isRenderingInProgress', false );
+		} );
+	} );
+
 	describe( 'forceRender()', () => {
 		it( 'disable observers, renders and enable observers', () => {
 			const observerMock = view.addObserver( ObserverMock );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduce read-only `View#isRenderingInProgress` flag to check if the document is in the rendering phase. Closes https://github.com/ckeditor/ckeditor5/issues/1530.

---

### Additional information

Related: https://github.com/ckeditor/ckeditor5-ui/pull/470.
