### PR TITLE
All content is properly removed after undoing paste in some scenarios

### DIFF
--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -2304,9 +2304,7 @@ function _makeMoveOperationsFromRanges( ranges, targetPosition ) {
 		const op = new MoveOperation(
 			range.start,
 			range.end.offset - range.start.offset,
-			// If the target is the end of the move range this operation doesn't really move anything.
-			// In this case, it is better for OT to use range start instead of range end.
-			targetPosition.isEqual( range.end ) ? range.start : targetPosition,
+			targetPosition,
 			0
 		);
 

--- a/tests/model/operation/transform/insert.js
+++ b/tests/model/operation/transform/insert.js
@@ -291,8 +291,7 @@ describe( 'transform', () => {
 				);
 			} );
 
-			// Incorrect result due to wrap/unwrap being represented by inserts and moves.
-			it.skip( 'element in same path #2', () => {
+			it( 'element in same path #2', () => {
 				john.setData( '<paragraph>Foo[]</paragraph>' );
 				kate.setData( '[<paragraph>Foo</paragraph>]' );
 

--- a/tests/model/operation/transform/undo.js
+++ b/tests/model/operation/transform/undo.js
@@ -5,6 +5,7 @@
 
 import { Client, expectClients, clearBuffer } from './utils.js';
 
+import DocumentFragment from '../../../../src/model/documentfragment';
 import Element from '../../../../src/model/element';
 import Text from '../../../../src/model/text';
 
@@ -610,6 +611,44 @@ describe( 'transform', () => {
 
 		function getPastedContent() {
 			return new Element( 'heading1', null, new Text( 'Foobar' ) );
+		}
+	} );
+
+	// https://github.com/ckeditor/ckeditor5/issues/1540
+	it( 'paste, select all, paste, undo, undo, redo, redo, redo', () => {
+		const model = john.editor.model;
+
+		john.setData( '<paragraph>[]</paragraph>' );
+
+		model.insertContent( getPastedContent() );
+
+		john.setSelection( [ 0, 0 ], [ 1, 3 ] );
+
+		model.insertContent( getPastedContent() );
+
+		expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+
+		john.undo();
+
+		expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+
+		john.undo();
+
+		expectClients( '<paragraph></paragraph>' );
+
+		john.redo();
+
+		expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+
+		john.redo();
+
+		expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+
+		function getPastedContent() {
+			return new DocumentFragment( [
+				new Element( 'heading1', null, new Text( 'Foo' ) ),
+				new Element( 'paragraph', null, new Text( 'Bar' ) )
+			] );
 		}
 	} );
 } );

--- a/tests/model/operation/transform/wrap.js
+++ b/tests/model/operation/transform/wrap.js
@@ -382,7 +382,7 @@ describe( 'transform', () => {
 				expectClients( '<blockQuote><paragraph>c</paragraph></blockQuote>' );
 			} );
 
-			it.skip( 'delete all wrapped content and undo', () => {
+			it( 'delete all wrapped content and undo', () => {
 				john.setData( '[<paragraph>Foo</paragraph><paragraph>Bar</paragraph><paragraph>Abc</paragraph>]' );
 				kate.setData( '<paragraph>[Foo</paragraph><paragraph>Bar</paragraph><paragraph>Ab]c</paragraph>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: All content is properly removed after undoing paste in some scenarios. Closes https://github.com/ckeditor/ckeditor5/issues/1540.