### PR TITLE
Remove fake selection container before inspecting changed child nodes in Renderer.render().

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -171,6 +171,10 @@ export default class Renderer {
 	render() {
 		let inlineFillerPosition;
 
+		// Remove unneeded fake selection container from the DOM so it will not affect the DOM nodes diffing.
+		// It will be re-added if needed when rendering the selection.
+		this._removeFakeSelection();
+
 		// Refresh mappings.
 		for ( const element of this.markedChildren ) {
 			this._updateChildrenMappings( element );
@@ -660,7 +664,6 @@ export default class Renderer {
 		// If there is no selection - remove DOM and fake selections.
 		if ( this.selection.rangeCount === 0 ) {
 			this._removeDomSelection();
-			this._removeFakeSelection();
 
 			return;
 		}
@@ -676,7 +679,6 @@ export default class Renderer {
 		if ( this.selection.isFake ) {
 			this._updateFakeSelection( domRoot );
 		} else {
-			this._removeFakeSelection();
 			this._updateDomSelection( domRoot );
 		}
 	}

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -172,8 +172,9 @@ export default class Renderer {
 		let inlineFillerPosition;
 
 		// Remove unneeded fake selection container from the DOM so it will not affect the DOM nodes diffing.
-		// It will be re-added if needed when rendering the selection.
-		this._removeFakeSelection();
+		if ( !this.selection.isFake && isInDom( this._fakeSelectionContainer ) ) {
+			this._removeFakeSelection();
+		}
 
 		// Refresh mappings.
 		for ( const element of this.markedChildren ) {
@@ -956,4 +957,8 @@ function fixGeckoSelectionAfterBr( focus, domSelection ) {
 	if ( childAtOffset && childAtOffset.tagName == 'BR' ) {
 		domSelection.addRange( domSelection.getRangeAt( 0 ) );
 	}
+}
+
+function isInDom( fakeSelectionContainer ) {
+	return fakeSelectionContainer && fakeSelectionContainer.parentElement;
 }

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -3320,6 +3320,31 @@ describe( 'Renderer', () => {
 				return viewData.repeat( repeat );
 			}
 		} );
+
+		it( 'should work with fake selection container', () => {
+			let viewString = '';
+
+			for ( let i = 0; i < 151; i++ ) {
+				viewString += '<container:p>foo</container:p>';
+			}
+
+			viewRoot._appendChild( parse( viewString ) );
+
+			// Set fake selection
+			selection._setTo( viewRoot.getChild( 1 ), 'on', { fake: true } );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			viewRoot._removeChildren( 1, 1 );
+			selection._setTo( viewRoot.getChild( 0 ), 'in' );
+
+			renderer.markToSync( 'children', viewRoot );
+
+			expect( () => {
+				renderer.render();
+			} ).to.not.throw();
+		} );
 	} );
 
 	describe( '#922', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Remove fake selection container before inspecting changed child nodes in Renderer.render().. Closes ckeditor/ckeditor5#1578.

---

### Additional information

* WiP: working solution - beautifying it
