### PR TITLE
Model#insertContent should return range affected by the insertion

### DIFF
--- a/src/model/liveposition.js
+++ b/src/model/liveposition.js
@@ -88,6 +88,7 @@ export default class LivePosition extends Position {
 	 * @method module:engine/model/liveposition~LivePosition._createAfter
 	 * @see module:engine/model/position~Position._createAfter
 	 * @param {module:engine/model/node~Node} node
+	 * @param {module:engine/model/position~PositionStickiness} [stickiness='toNone']
 	 * @returns {module:engine/model/liveposition~LivePosition}
 	 */
 
@@ -97,6 +98,18 @@ export default class LivePosition extends Position {
 	 * @method module:engine/model/liveposition~LivePosition._createBefore
 	 * @see module:engine/model/position~Position._createBefore
 	 * @param {module:engine/model/node~Node} node
+	 * @param {module:engine/model/position~PositionStickiness} [stickiness='toNone']
+	 * @returns {module:engine/model/liveposition~LivePosition}
+	 */
+
+	/**
+	 * @static
+	 * @protected
+	 * @method module:engine/model/liveposition~LivePosition._createAt
+	 * @see module:engine/model/position~Position._createAt
+	 * @param {module:engine/model/item~Item|module:engine/model/position~Position} itemOrPosition
+	 * @param {Number|'end'|'before'|'after'} [offset]
+	 * @param {module:engine/model/position~PositionStickiness} [stickiness='toNone']
 	 * @returns {module:engine/model/liveposition~LivePosition}
 	 */
 

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -373,6 +373,18 @@ export default class Model {
 	 *
 	 * * `<paragraph>^</paragraph>` with the option disabled (`doNotResetEntireContent == false`)
 	 * * `<heading1>^</heading1>` with enabled (`doNotResetEntireContent == true`)
+	 *
+	 * @param {Boolean} [options.doNotAutoparagraph=false] Whether to create a paragraph if after content deletion selection is moved
+	 * to a place where text cannot be inserted.
+	 *
+	 * For example `<paragraph>x</paragraph>[<image src="foo.jpg"></image>]` will become:
+	 *
+	 * * `<paragraph>x</paragraph><paragraph>[]</paragraph>` with the option disabled (`doNotAutoparagraph == false`)
+	 * * `<paragraph>x[]</paragraph>` with the option enabled (`doNotAutoparagraph == true`).
+	 *
+	 * **Note:** if there is no valid position for the selection, the paragraph will always be created:
+	 *
+	 * `[<image src="foo.jpg"></image>]` -> `<paragraph>[]</paragraph>`.
 	 */
 	deleteContent( selection, options ) {
 		deleteContent( this, selection, options );

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -336,9 +336,12 @@ export default class Model {
 	 * The selection into which the content should be inserted. If not provided the current model document selection will be used.
 	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] To be used when a model item was passed as `selectable`.
 	 * This param defines a position in relation to that item.
+	 * @returns {module:engine/model/range~Range} Range which contains all the performed changes. This is a range that, if removed,
+	 * would return the model to the state before the insertion. If no changes were preformed by `insertContent`, returns a range collapsed
+	 * at the insertion position.
 	 */
 	insertContent( content, selectable, placeOrOffset ) {
-		insertContent( this, content, selectable, placeOrOffset );
+		return insertContent( this, content, selectable, placeOrOffset );
 	}
 
 	/**

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -828,11 +828,13 @@ export default class Position {
 	 * * {@link module:engine/model/position~Position._createAfter}.
 	 *
 	 * @param {module:engine/model/item~Item|module:engine/model/position~Position} itemOrPosition
-	 * @param {Number|'end'|'before'|'after'} [offset] Offset or one of the flags. Used only when
+	 * @param {Number|'end'|'before'|'after'} [offset] Offset or one of the flags. Used only when the
+	 * first parameter is a {@link module:engine/model/item~Item model item}.
+	 * @param {module:engine/model/position~PositionStickiness} [stickiness='toNone'] Position stickiness. Used only when the
 	 * first parameter is a {@link module:engine/model/item~Item model item}.
 	 * @protected
 	 */
-	static _createAt( itemOrPosition, offset ) {
+	static _createAt( itemOrPosition, offset, stickiness = 'toNone' ) {
 		if ( itemOrPosition instanceof Position ) {
 			return new Position( itemOrPosition.root, itemOrPosition.path, itemOrPosition.stickiness );
 		} else {
@@ -841,9 +843,9 @@ export default class Position {
 			if ( offset == 'end' ) {
 				offset = node.maxOffset;
 			} else if ( offset == 'before' ) {
-				return this._createBefore( node );
+				return this._createBefore( node, stickiness );
 			} else if ( offset == 'after' ) {
-				return this._createAfter( node );
+				return this._createAfter( node, stickiness );
 			} else if ( offset !== 0 && !offset ) {
 				/**
 				 * {@link module:engine/model/model~Model#createPositionAt `Model#createPositionAt()`}
@@ -869,7 +871,7 @@ export default class Position {
 
 			path.push( offset );
 
-			return new this( node.root, path );
+			return new this( node.root, path, stickiness );
 		}
 	}
 
@@ -877,10 +879,11 @@ export default class Position {
 	 * Creates a new position, after given {@link module:engine/model/item~Item model item}.
 	 *
 	 * @param {module:engine/model/item~Item} item Item after which the position should be placed.
+	 * @param {module:engine/model/position~PositionStickiness} [stickiness='toNone'] Position stickiness.
 	 * @returns {module:engine/model/position~Position}
 	 * @protected
 	 */
-	static _createAfter( item ) {
+	static _createAfter( item, stickiness ) {
 		if ( !item.parent ) {
 			/**
 			 * You can not make a position after a root element.
@@ -891,17 +894,18 @@ export default class Position {
 			throw new CKEditorError( 'model-position-after-root: You cannot make a position after root.', { root: item } );
 		}
 
-		return this._createAt( item.parent, item.endOffset );
+		return this._createAt( item.parent, item.endOffset, stickiness );
 	}
 
 	/**
 	 * Creates a new position, before the given {@link module:engine/model/item~Item model item}.
 	 *
 	 * @param {module:engine/model/item~Item} item Item before which the position should be placed.
+	 * @param {module:engine/model/position~PositionStickiness} [stickiness='toNone'] Position stickiness.
 	 * @returns {module:engine/model/position~Position}
 	 * @protected
 	 */
-	static _createBefore( item ) {
+	static _createBefore( item, stickiness ) {
 		if ( !item.parent ) {
 			/**
 			 * You can not make a position before a root element.
@@ -912,7 +916,7 @@ export default class Position {
 			throw new CKEditorError( 'model-position-before-root: You cannot make a position before root.', { root: item } );
 		}
 
-		return this._createAt( item.parent, item.startOffset );
+		return this._createAt( item.parent, item.startOffset, stickiness );
 	}
 
 	/**
@@ -943,10 +947,7 @@ export default class Position {
 			);
 		}
 
-		const pos = new Position( doc.getRoot( json.root ), json.path );
-		pos.stickiness = json.stickiness;
-
-		return pos;
+		return new Position( doc.getRoot( json.root ), json.path, json.stickiness );
 	}
 }
 

--- a/src/model/utils/insertcontent.js
+++ b/src/model/utils/insertcontent.js
@@ -349,8 +349,11 @@ class Insertion {
 	}
 
 	/**
-	 * Sets `_affectedStart` and `_affectedEnd` to the given `position`. Should be used before change is done during insertion process to
+	 * Sets `_affectedStart` and `_affectedEnd` to the given `position`. Should be used before a change is done during insertion process to
 	 * mark the affected range.
+	 *
+	 * This method is used before inserting a node or splitting a parent node. `_affectedStart` and `_affectedEnd` are also changed
+	 * during merging, but the logic there is more complicated so it is left out of this function.
 	 *
 	 * @private
 	 * @param {module:engine/model/position~Position} position
@@ -402,6 +405,9 @@ class Insertion {
 			// by hand to properly reflect affected range. (Due to `_affectedStart` and `_affectedEnd` stickiness, the "range" is
 			// shown as `][`).
 			//
+			// Example - insert `<paragraph>Abc</paragraph><paragraph>Xyz</paragraph>` at the end of `<paragraph>Foo^</paragraph>`:
+			//
+			// <paragraph>Foo</paragraph><paragraph>Bar</paragraph>   -->
 			// <paragraph>Foo</paragraph>]<paragraph>Abc</paragraph><paragraph>Xyz</paragraph>[<paragraph>Bar</paragraph>   -->
 			// <paragraph>Foo]Abc</paragraph><paragraph>Xyz</paragraph>[<paragraph>Bar</paragraph>
 			//
@@ -415,6 +421,9 @@ class Insertion {
 
 			// If only one element (the merged one) is in the "affected range", also move the affected range end appropriately.
 			//
+			// Example - insert `<paragraph>Abc</paragraph>` at the of `<paragraph>Foo^</paragraph>`:
+			//
+			// <paragraph>Foo</paragraph><paragraph>Bar</paragraph>   -->
 			// <paragraph>Foo</paragraph>]<paragraph>Abc</paragraph>[<paragraph>Bar</paragraph>   -->
 			// <paragraph>Foo]Abc</paragraph>[<paragraph>Bar</paragraph>   -->
 			// <paragraph>Foo]Abc[</paragraph><paragraph>Bar</paragraph>

--- a/tests/model/liveposition.js
+++ b/tests/model/liveposition.js
@@ -78,14 +78,23 @@ describe( 'LivePosition', () =>
 	} );
 
 	it( '_createBefore should return LivePosition', () => {
-		const position = LivePosition._createBefore( ul );
+		const position = LivePosition._createBefore( ul, 'toPrevious' );
 		expect( position ).to.be.instanceof( LivePosition );
+		expect( position.stickiness ).to.equal( 'toPrevious' );
 		position.detach();
 	} );
 
 	it( '_createAfter should return LivePosition', () => {
-		const position = LivePosition._createAfter( ul );
+		const position = LivePosition._createAfter( ul, 'toPrevious' );
 		expect( position ).to.be.instanceof( LivePosition );
+		expect( position.stickiness ).to.equal( 'toPrevious' );
+		position.detach();
+	} );
+
+	it( '_createAt should return LivePosition', () => {
+		const position = LivePosition._createAt( ul, 'end', 'toPrevious' );
+		expect( position ).to.be.instanceof( LivePosition );
+		expect( position.stickiness ).to.equal( 'toPrevious' );
 		position.detach();
 	} );
 

--- a/tests/model/position.js
+++ b/tests/model/position.js
@@ -182,6 +182,10 @@ describe( 'Position', () => {
 				expect( Position._createAt( ul, 'end' ) ).to.have.property( 'path' ).that.deep.equals( [ 1, 2 ] );
 			} );
 
+			it( 'should set stickiness (if not cloning other position)', () => {
+				expect( Position._createAt( root, 'end', 'toPrevious' ) ).to.have.property( 'stickiness' ).that.equals( 'toPrevious' );
+			} );
+
 			it( 'throws when parent is not an element', () => {
 				expect( () => {
 					Position._createAt( b, 0 );
@@ -214,6 +218,10 @@ describe( 'Position', () => {
 				expect( Position._createBefore( r ) ).to.have.property( 'path' ).that.deep.equals( [ 1, 1, 2 ] );
 			} );
 
+			it( 'should set stickiness', () => {
+				expect( Position._createBefore( p, 'toPrevious' ) ).to.have.property( 'stickiness' ).that.equals( 'toPrevious' );
+			} );
+
 			it( 'should throw error if one try to create positions before root', () => {
 				expect( () => {
 					Position._createBefore( root );
@@ -238,6 +246,10 @@ describe( 'Position', () => {
 				expect( Position._createAfter( b ) ).to.have.property( 'path' ).that.deep.equals( [ 1, 1, 1 ] );
 				expect( Position._createAfter( a ) ).to.have.property( 'path' ).that.deep.equals( [ 1, 1, 2 ] );
 				expect( Position._createAfter( r ) ).to.have.property( 'path' ).that.deep.equals( [ 1, 1, 3 ] );
+			} );
+
+			it( 'should set stickiness', () => {
+				expect( Position._createAfter( p, 'toPrevious' ) ).to.have.property( 'stickiness' ).that.equals( 'toPrevious' );
 			} );
 
 			it( 'should throw error if one try to make positions after root', () => {

--- a/tests/model/utils/deletecontent.js
+++ b/tests/model/utils/deletecontent.js
@@ -592,19 +592,6 @@ describe( 'DataController utils', () => {
 					.to.equal( 'x[]z' );
 			} );
 
-			it( 'creates a paragraph when text is not allowed (paragraph selected)', () => {
-				setData(
-					model,
-					'<paragraph>x</paragraph>[<paragraph>yyy</paragraph>]<paragraph>z</paragraph>',
-					{ rootName: 'bodyRoot' }
-				);
-
-				deleteContent( model, doc.selection );
-
-				expect( getData( model, { rootName: 'bodyRoot' } ) )
-					.to.equal( '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>z</paragraph>' );
-			} );
-
 			it( 'creates a paragraph when text is not allowed (custom selection)', () => {
 				setData(
 					model,
@@ -614,6 +601,7 @@ describe( 'DataController utils', () => {
 
 				const root = doc.getRoot( 'bodyRoot' );
 
+				// [<paragraph>yyy</paragraph>]
 				const selection = new Selection( [
 					new Range( new Position( root, [ 1 ] ), new Position( root, [ 2 ] ) )
 				] );
@@ -699,6 +687,32 @@ describe( 'DataController utils', () => {
 
 				expect( getData( model, { rootName: 'restrictedRoot' } ) )
 					.to.equal( '<blockWidget></blockWidget>[]<blockWidget></blockWidget>' );
+			} );
+
+			it( 'does not create a paragraph when doNotAutoparagraph option is set to true', () => {
+				setData(
+					model,
+					'<paragraph>x</paragraph>[<blockWidget></blockWidget>]<paragraph>z</paragraph>',
+					{ rootName: 'bodyRoot' }
+				);
+
+				deleteContent( model, doc.selection, { doNotAutoparagraph: true } );
+
+				expect( getData( model, { rootName: 'bodyRoot' } ) )
+					.to.equal( '<paragraph>x[]</paragraph><paragraph>z</paragraph>' );
+			} );
+
+			it( 'creates paragraph when after deletion there is no valid selection range', () => {
+				setData(
+					model,
+					'[<blockWidget></blockWidget>]',
+					{ rootName: 'bodyRoot' }
+				);
+
+				deleteContent( model, doc.selection, { doNotAutoparagraph: true } );
+
+				expect( getData( model, { rootName: 'bodyRoot' } ) )
+					.to.equal( '<paragraph>[]</paragraph>' );
 			} );
 		} );
 

--- a/tests/model/utils/insertcontent.js
+++ b/tests/model/utils/insertcontent.js
@@ -10,17 +10,17 @@ import Text from '../../../src/model/text';
 import Element from '../../../src/model/element';
 import Position from '../../../src/model/position';
 
-import { setData, getData, parse } from '../../../src/dev-utils/model';
+import { setData, getData, parse, stringify } from '../../../src/dev-utils/model';
 import Range from '../../../src/model/range';
 
 describe( 'DataController utils', () => {
-	let model, doc;
+	let model, doc, root;
 
 	describe( 'insertContent', () => {
 		beforeEach( () => {
 			model = new Model();
 			doc = model.document;
-			doc.createRoot();
+			root = doc.createRoot();
 		} );
 
 		it( 'should use parent batch', () => {
@@ -40,8 +40,10 @@ describe( 'DataController utils', () => {
 			const selection = model.createSelection( model.createPositionFromPath( doc.getRoot(), [ 2 ] ) );
 
 			model.change( writer => {
-				insertContent( model, writer.createText( 'x' ), selection );
+				const affectedRange = insertContent( model, writer.createText( 'x' ), selection );
+
 				expect( getData( model ) ).to.equal( 'a[]bxc' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'ab[x]c' );
 			} );
 		} );
 
@@ -71,8 +73,10 @@ describe( 'DataController utils', () => {
 			const position = new Position( doc.getRoot(), [ 2 ] );
 
 			model.change( writer => {
-				insertContent( model, writer.createText( 'x' ), position );
+				const affectedRange = insertContent( model, writer.createText( 'x' ), position );
+
 				expect( getData( model ) ).to.equal( 'a[]bxc' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'ab[x]c' );
 			} );
 		} );
 
@@ -83,8 +87,10 @@ describe( 'DataController utils', () => {
 			const range = new Range( new Position( doc.getRoot(), [ 2 ] ), new Position( doc.getRoot(), [ 3 ] ) );
 
 			model.change( writer => {
-				insertContent( model, writer.createText( 'x' ), range );
+				const affectedRange = insertContent( model, writer.createText( 'x' ), range );
+
 				expect( getData( model ) ).to.equal( 'a[]bx' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'ab[x]' );
 			} );
 		} );
 
@@ -93,8 +99,10 @@ describe( 'DataController utils', () => {
 			setData( model, 'a[]bc' );
 
 			model.change( writer => {
-				insertContent( model, writer.createText( 'x' ), model.document.selection );
+				const affectedRange = insertContent( model, writer.createText( 'x' ), model.document.selection );
+
 				expect( getData( model ) ).to.equal( 'ax[]bc' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'a[x]bc' );
 			} );
 		} );
 
@@ -103,8 +111,10 @@ describe( 'DataController utils', () => {
 			setData( model, 'a[]bc' );
 
 			model.change( writer => {
-				insertContent( model, writer.createText( 'x' ) );
+				const affectedRange = insertContent( model, writer.createText( 'x' ) );
+
 				expect( getData( model ) ).to.equal( 'ax[]bc' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'a[x]bc' );
 			} );
 		} );
 
@@ -118,9 +128,10 @@ describe( 'DataController utils', () => {
 			model.change( writer => {
 				const text = writer.createText( 'x' );
 
-				insertContent( model, text, element, 2 );
+				const affectedRange = insertContent( model, text, element, 2 );
 
 				expect( getData( model ) ).to.equal( '<paragraph>foo[]</paragraph><paragraph>baxr</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo</paragraph><paragraph>ba[x]r</paragraph>' );
 			} );
 		} );
 
@@ -134,9 +145,10 @@ describe( 'DataController utils', () => {
 			model.change( writer => {
 				const text = writer.createText( 'x' );
 
-				insertContent( model, text, element, 'in' );
+				const affectedRange = insertContent( model, text, element, 'in' );
 
 				expect( getData( model ) ).to.equal( '<paragraph>foo[]</paragraph><paragraph>x</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo</paragraph><paragraph>[x]</paragraph>' );
 			} );
 		} );
 
@@ -151,9 +163,10 @@ describe( 'DataController utils', () => {
 			model.change( writer => {
 				const insertElement = writer.createElement( 'foo' );
 
-				insertContent( model, insertElement, element, 'on' );
+				const affectedRange = insertContent( model, insertElement, element, 'on' );
 
 				expect( getData( model ) ).to.equal( '<paragraph>foo[]</paragraph><foo></foo>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo</paragraph>[<foo></foo>]' );
 			} );
 		} );
 
@@ -167,9 +180,10 @@ describe( 'DataController utils', () => {
 			model.change( writer => {
 				const text = writer.createText( 'x' );
 
-				insertContent( model, text, element, 'end' );
+				const affectedRange = insertContent( model, text, element, 'end' );
 
 				expect( getData( model ) ).to.equal( '<paragraph>foo[]</paragraph><paragraph>barx</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo</paragraph><paragraph>bar[x]</paragraph>' );
 			} );
 		} );
 
@@ -213,7 +227,7 @@ describe( 'DataController utils', () => {
 			beforeEach( () => {
 				model = new Model();
 				doc = model.document;
-				doc.createRoot();
+				root = doc.createRoot();
 
 				const schema = model.schema;
 
@@ -235,29 +249,39 @@ describe( 'DataController utils', () => {
 
 			it( 'inserts one text node', () => {
 				setData( model, 'f[]oo' );
-				insertHelper( 'xyz' );
+				const affectedRange = insertHelper( 'xyz' );
+
 				expect( getData( model ) ).to.equal( 'fxyz[]oo' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'f[xyz]oo' );
 			} );
 
 			it( 'inserts one text node (at the end)', () => {
 				setData( model, 'foo[]' );
-				insertHelper( 'xyz' );
+				const affectedRange = insertHelper( 'xyz' );
+
 				expect( getData( model ) ).to.equal( 'fooxyz[]' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'foo[xyz]' );
 			} );
 
 			it( 'inserts one text node with attribute', () => {
 				setData( model, 'f[]oo' );
-				insertHelper( '<$text bold="true">xyz</$text>' );
+				const affectedRange = insertHelper( '<$text bold="true">xyz</$text>' );
+
 				expect( getData( model ) ).to.equal( 'f<$text bold="true">xyz[]</$text>oo' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'f[<$text bold="true">xyz</$text>]oo' );
 
 				expect( doc.selection.getAttribute( 'bold' ) ).to.be.true;
 			} );
 
 			it( 'inserts one text node with attribute into text with a different attribute', () => {
 				setData( model, '<$text bold="true">f[]oo</$text>' );
-				insertHelper( '<$text italic="true">xyz</$text>' );
+				const affectedRange = insertHelper( '<$text italic="true">xyz</$text>' );
+
 				expect( getData( model ) )
 					.to.equal( '<$text bold="true">f</$text><$text italic="true">xyz[]</$text><$text bold="true">oo</$text>' );
+
+				expect( stringify( root, affectedRange ) )
+					.to.equal( '<$text bold="true">f</$text>[<$text italic="true">xyz</$text>]<$text bold="true">oo</$text>' );
 
 				expect( doc.selection.getAttribute( 'italic' ) ).to.be.true;
 				expect( doc.selection.hasAttribute( 'bold' ) ).to.be.false;
@@ -265,43 +289,54 @@ describe( 'DataController utils', () => {
 
 			it( 'inserts one text node with attribute into text with the same attribute', () => {
 				setData( model, '<$text bold="true">f[]oo</$text>' );
-				insertHelper( '<$text bold="true">xyz</$text>' );
-				expect( getData( model ) )
-					.to.equal( '<$text bold="true">fxyz[]oo</$text>' );
+				const affectedRange = insertHelper( '<$text bold="true">xyz</$text>' );
+
+				expect( getData( model ) ).to.equal( '<$text bold="true">fxyz[]oo</$text>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<$text bold="true">f[xyz]oo</$text>' );
 
 				expect( doc.selection.getAttribute( 'bold' ) ).to.be.true;
 			} );
 
 			it( 'inserts a text without attributes into a text with an attribute', () => {
 				setData( model, '<$text bold="true">f[]oo</$text>' );
-				insertHelper( 'xyz' );
+				const affectedRange = insertHelper( 'xyz' );
+
 				expect( getData( model ) ).to.equal( '<$text bold="true">f</$text>xyz[]<$text bold="true">oo</$text>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<$text bold="true">f</$text>[xyz]<$text bold="true">oo</$text>' );
 
 				expect( doc.selection.hasAttribute( 'bold' ) ).to.be.false;
 			} );
 
 			it( 'inserts an element', () => {
 				setData( model, 'f[]oo' );
-				insertHelper( '<image></image>' );
+				const affectedRange = insertHelper( '<image></image>' );
+
 				expect( getData( model ) ).to.equal( 'f<image></image>[]oo' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'f[<image></image>]oo' );
 			} );
 
 			it( 'inserts a text and an element', () => {
 				setData( model, 'f[]oo' );
-				insertHelper( 'xyz<image></image>' );
+				const affectedRange = insertHelper( 'xyz<image></image>' );
+
 				expect( getData( model ) ).to.equal( 'fxyz<image></image>[]oo' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'f[xyz<image></image>]oo' );
 			} );
 
 			it( 'strips a disallowed element', () => {
 				setData( model, 'f[]oo' );
-				insertHelper( '<disallowedElement>xyz</disallowedElement>' );
+				const affectedRange = insertHelper( '<disallowedElement>xyz</disallowedElement>' );
+
 				expect( getData( model ) ).to.equal( 'fxyz[]oo' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'f[xyz]oo' );
 			} );
 
 			it( 'deletes selection before inserting the content', () => {
 				setData( model, 'f[abc]oo' );
-				insertHelper( 'x' );
+				const affectedRange = insertHelper( 'x' );
+
 				expect( getData( model ) ).to.equal( 'fx[]oo' );
+				expect( stringify( root, affectedRange ) ).to.equal( 'f[x]oo' );
 			} );
 
 			describe( 'spaces handling', () => {
@@ -344,7 +379,7 @@ describe( 'DataController utils', () => {
 			beforeEach( () => {
 				model = new Model();
 				doc = model.document;
-				doc.createRoot();
+				root = doc.createRoot();
 
 				const schema = model.schema;
 
@@ -367,40 +402,52 @@ describe( 'DataController utils', () => {
 
 			it( 'inserts one text node', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( 'xyz' );
+				const affectedRange = insertHelper( 'xyz' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>fxyz[]oo</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[xyz]oo</paragraph>' );
 			} );
 
 			it( 'inserts one text node to fully selected paragraph', () => {
 				setData( model, '<paragraph>[foo]</paragraph>' );
-				insertHelper( 'xyz' );
+				const affectedRange = insertHelper( 'xyz' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>xyz[]</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>[xyz]</paragraph>' );
 			} );
 
 			it( 'inserts one text node to fully selected paragraphs (from outside)', () => {
 				setData( model, '[<paragraph>foo</paragraph><paragraph>bar</paragraph>]' );
-				insertHelper( 'xyz' );
+				const affectedRange = insertHelper( 'xyz' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>xyz[]</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>[xyz]</paragraph>' );
 			} );
 
 			it( 'merges two blocks before inserting content (p+p)', () => {
 				setData( model, '<paragraph>fo[o</paragraph><paragraph>b]ar</paragraph>' );
-				insertHelper( 'xyz' );
+				const affectedRange = insertHelper( 'xyz' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>foxyz[]ar</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>fo[xyz]ar</paragraph>' );
 			} );
 
 			it( 'inserts inline widget and text', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( 'xyz<inlineWidget></inlineWidget>' );
+				const affectedRange = insertHelper( 'xyz<inlineWidget></inlineWidget>' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>fxyz<inlineWidget></inlineWidget>[]oo</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[xyz<inlineWidget></inlineWidget>]oo</paragraph>' );
 			} );
 
 			// Note: In CKEditor 4 the blocks are not merged, but to KISS we're merging here
 			// because that's what deleteContent() does.
 			it( 'merges two blocks before inserting content (h+p)', () => {
 				setData( model, '<heading1>fo[o</heading1><paragraph>b]ar</paragraph>' );
-				insertHelper( 'xyz' );
+				const affectedRange = insertHelper( 'xyz' );
+
 				expect( getData( model ) ).to.equal( '<heading1>foxyz[]ar</heading1>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<heading1>fo[xyz]ar</heading1>' );
 			} );
 
 			it( 'not insert autoparagraph when paragraph is disallowed at the current position', () => {
@@ -417,107 +464,155 @@ describe( 'DataController utils', () => {
 				] );
 
 				setData( model, '[<heading2>foo</heading2>]' );
-				insertContent( model, content );
+				const affectedRange = insertContent( model, content );
+
 				expect( getData( model ) ).to.equal( '<heading1>bar[]</heading1>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '[<heading1>bar</heading1>]' );
 			} );
 
 			describe( 'block to block handling', () => {
 				it( 'inserts one paragraph', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<paragraph>xyz</paragraph>' );
+					const affectedRange = insertHelper( '<paragraph>xyz</paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fxyz[]oo</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[xyz]oo</paragraph>' );
 				} );
 
 				it( 'inserts one paragraph (at the end)', () => {
 					setData( model, '<paragraph>foo[]</paragraph>' );
-					insertHelper( '<paragraph>xyz</paragraph>' );
+					const affectedRange = insertHelper( '<paragraph>xyz</paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fooxyz[]</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo[xyz]</paragraph>' );
 				} );
 
 				it( 'inserts one paragraph into an empty paragraph', () => {
 					setData( model, '<paragraph>[]</paragraph>' );
-					insertHelper( '<paragraph>xyz</paragraph>' );
+					const affectedRange = insertHelper( '<paragraph>xyz</paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>xyz[]</paragraph>' );
+
+					// The empty paragraph gets removed and the new element is inserted instead.
+					expect( stringify( root, affectedRange ) ).to.equal( '[<paragraph>xyz</paragraph>]' );
 				} );
 
 				it( 'inserts one empty paragraph', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<paragraph></paragraph>' );
+					const affectedRange = insertHelper( '<paragraph></paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>f[]oo</paragraph>' );
+
+					// Nothing is inserted so the `affectedRange` is collapsed at insertion position.
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[]oo</paragraph>' );
 				} );
 
 				it( 'inserts one block into a fully selected content', () => {
 					setData( model, '<heading1>[foo</heading1><paragraph>bar]</paragraph>' );
-					insertHelper( '<heading2>xyz</heading2>' );
+					const affectedRange = insertHelper( '<heading2>xyz</heading2>' );
+
 					expect( getData( model ) ).to.equal( '<heading2>xyz[]</heading2>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '[<heading2>xyz</heading2>]' );
 				} );
 
 				it( 'inserts one heading', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<heading1>xyz</heading1>' );
+					const affectedRange = insertHelper( '<heading1>xyz</heading1>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fxyz[]oo</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[xyz]oo</paragraph>' );
 				} );
 
 				it( 'inserts two headings', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<heading1>xxx</heading1><heading1>yyy</heading1>' );
+					const affectedRange = insertHelper( '<heading1>xxx</heading1><heading1>yyy</heading1>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fxxx</paragraph><heading1>yyy[]oo</heading1>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[xxx</paragraph><heading1>yyy]oo</heading1>' );
 				} );
 
 				it( 'inserts one object', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<blockWidget></blockWidget>' );
-					expect( getData( model ) ).to.equal( '<paragraph>f</paragraph>[<blockWidget></blockWidget>]<paragraph>oo</paragraph>' );
+					const affectedRange = insertHelper( '<blockWidget></blockWidget>' );
+
+					expect( getData( model ) )
+						.to.equal( '<paragraph>f</paragraph>[<blockWidget></blockWidget>]<paragraph>oo</paragraph>' );
+
+					expect( stringify( root, affectedRange ) )
+						.to.equal( '<paragraph>f[</paragraph><blockWidget></blockWidget><paragraph>]oo</paragraph>' );
 				} );
 
 				it( 'inserts one object (at the end)', () => {
 					setData( model, '<paragraph>foo[]</paragraph>' );
-					insertHelper( '<blockWidget></blockWidget>' );
+					const affectedRange = insertHelper( '<blockWidget></blockWidget>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>foo</paragraph>[<blockWidget></blockWidget>]' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo</paragraph>[<blockWidget></blockWidget>]' );
 				} );
 
 				it( 'inserts one object (at the beginning)', () => {
 					setData( model, '<paragraph>[]bar</paragraph>' );
-					insertHelper( '<blockWidget></blockWidget>' );
+					const affectedRange = insertHelper( '<blockWidget></blockWidget>' );
+
 					expect( getData( model ) ).to.equal( '[<blockWidget></blockWidget>]<paragraph>bar</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '[<blockWidget></blockWidget>]<paragraph>bar</paragraph>' );
 				} );
 
 				it( 'inserts one list item', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<listItem listIndent="0" listType="bulleted">xyz</listItem>' );
+					const affectedRange = insertHelper( '<listItem listIndent="0" listType="bulleted">xyz</listItem>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fxyz[]oo</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[xyz]oo</paragraph>' );
 				} );
 
 				it( 'inserts list item to empty element', () => {
 					setData( model, '<paragraph>[]</paragraph>' );
-					insertHelper( '<listItem listIndent="0" listType="bulleted">xyz</listItem>' );
+					const affectedRange = insertHelper( '<listItem listIndent="0" listType="bulleted">xyz</listItem>' );
+
 					expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">xyz[]</listItem>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '[<listItem listIndent="0" listType="bulleted">xyz</listItem>]' );
 				} );
 
 				it( 'inserts three list items at the end of paragraph', () => {
 					setData( model, '<paragraph>foo[]</paragraph>' );
-					insertHelper(
+					const affectedRange = insertHelper(
 						'<listItem listIndent="0" listType="bulleted">xxx</listItem>' +
 						'<listItem listIndent="0" listType="bulleted">yyy</listItem>' +
 						'<listItem listIndent="0" listType="bulleted">zzz</listItem>'
 					);
+
 					expect( getData( model ) ).to.equal(
 						'<paragraph>fooxxx</paragraph>' +
 						'<listItem listIndent="0" listType="bulleted">yyy</listItem>' +
 						'<listItem listIndent="0" listType="bulleted">zzz[]</listItem>'
 					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>foo[xxx</paragraph>' +
+						'<listItem listIndent="0" listType="bulleted">yyy</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">zzz</listItem>]'
+					);
 				} );
 
 				it( 'inserts two list items to an empty paragraph', () => {
 					setData( model, '<paragraph>a</paragraph><paragraph>[]</paragraph><paragraph>b</paragraph>' );
-					insertHelper(
+					const affectedRange = insertHelper(
 						'<listItem listIndent="0" listType="bulleted">xxx</listItem>' +
 						'<listItem listIndent="0" listType="bulleted">yyy</listItem>'
 					);
+
 					expect( getData( model ) ).to.equal(
 						'<paragraph>a</paragraph>' +
 						'<listItem listIndent="0" listType="bulleted">xxx</listItem>' +
 						'<listItem listIndent="0" listType="bulleted">yyy[]</listItem>' +
+						'<paragraph>b</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>a</paragraph>' +
+						'[<listItem listIndent="0" listType="bulleted">xxx</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">yyy</listItem>]' +
 						'<paragraph>b</paragraph>'
 					);
 				} );
@@ -530,14 +625,22 @@ describe( 'DataController utils', () => {
 
 					setData( model, '<listItem>fo[]o</listItem>' );
 
-					insertHelper( '<blockQuote><paragraph>xxx</paragraph></blockQuote><heading1>yyy</heading1>' );
+					const affectedRange = insertHelper( '<blockQuote><paragraph>xxx</paragraph></blockQuote><heading1>yyy</heading1>' );
 
 					expect( getData( model ) ).to.equal(
 						'<listItem>fo</listItem>' +
 						'<blockQuote>' +
-						'<paragraph>xxx</paragraph>' +
+							'<paragraph>xxx</paragraph>' +
 						'</blockQuote>' +
 						'<heading1>yyy[]o</heading1>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<listItem>fo[</listItem>' +
+						'<blockQuote>' +
+							'<paragraph>xxx</paragraph>' +
+						'</blockQuote>' +
+						'<heading1>yyy]o</heading1>'
 					);
 				} );
 
@@ -549,14 +652,22 @@ describe( 'DataController utils', () => {
 
 					setData( model, '<listItem>fo[]o</listItem>' );
 
-					insertHelper( '<heading1>yyy</heading1><blockQuote><paragraph>xxx</paragraph></blockQuote>' );
+					const affectedRange = insertHelper( '<heading1>yyy</heading1><blockQuote><paragraph>xxx</paragraph></blockQuote>' );
 
 					expect( getData( model ) ).to.equal(
 						'<listItem>foyyy</listItem>' +
 						'<blockQuote>' +
-						'<paragraph>xxx</paragraph>' +
+							'<paragraph>xxx</paragraph>' +
 						'</blockQuote>' +
 						'<listItem>[]o</listItem>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<listItem>fo[yyy</listItem>' +
+						'<blockQuote>' +
+							'<paragraph>xxx</paragraph>' +
+						'</blockQuote>' +
+						'<listItem>]o</listItem>'
 					);
 				} );
 
@@ -568,14 +679,22 @@ describe( 'DataController utils', () => {
 
 					setData( model, '<listItem>fo[]o</listItem>' );
 
-					insertHelper( '<blockQuote><paragraph>xxx</paragraph></blockQuote>' );
+					const affectedRange = insertHelper( '<blockQuote><paragraph>xxx</paragraph></blockQuote>' );
 
 					expect( getData( model ) ).to.equal(
 						'<listItem>fo</listItem>' +
 						'<blockQuote>' +
-						'<paragraph>xxx</paragraph>' +
+							'<paragraph>xxx</paragraph>' +
 						'</blockQuote>' +
 						'<listItem>[]o</listItem>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<listItem>fo[</listItem>' +
+						'<blockQuote>' +
+							'<paragraph>xxx</paragraph>' +
+						'</blockQuote>' +
+						'<listItem>]o</listItem>'
 					);
 				} );
 			} );
@@ -583,34 +702,47 @@ describe( 'DataController utils', () => {
 			describe( 'mixed content to block', () => {
 				it( 'inserts text + paragraph', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( 'xxx<paragraph>yyy</paragraph>' );
+					const affectedRange = insertHelper( 'xxx<paragraph>yyy</paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fxxx</paragraph><paragraph>yyy[]oo</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[xxx</paragraph><paragraph>yyy]oo</paragraph>' );
 				} );
 
 				it( 'inserts text + inlineWidget + text + paragraph', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( 'xxx<inlineWidget></inlineWidget>yyy<paragraph>zzz</paragraph>' );
+					const affectedRange = insertHelper( 'xxx<inlineWidget></inlineWidget>yyy<paragraph>zzz</paragraph>' );
+
 					expect( getData( model ) ).to.equal(
 						'<paragraph>fxxx<inlineWidget></inlineWidget>yyy</paragraph><paragraph>zzz[]oo</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>f[xxx<inlineWidget></inlineWidget>yyy</paragraph><paragraph>zzz]oo</paragraph>'
 					);
 				} );
 
 				it( 'inserts text + paragraph (at the beginning)', () => {
 					setData( model, '<paragraph>[]foo</paragraph>' );
-					insertHelper( 'xxx<paragraph>yyy</paragraph>' );
+					const affectedRange = insertHelper( 'xxx<paragraph>yyy</paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>xxx</paragraph><paragraph>yyy[]foo</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>[xxx</paragraph><paragraph>yyy]foo</paragraph>' );
 				} );
 
 				it( 'inserts text + paragraph (at the end)', () => {
 					setData( model, '<paragraph>foo[]</paragraph>' );
-					insertHelper( 'xxx<paragraph>yyy</paragraph>' );
+					const affectedRange = insertHelper( 'xxx<paragraph>yyy</paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fooxxx</paragraph><paragraph>yyy[]</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo[xxx</paragraph><paragraph>yyy</paragraph>]' );
 				} );
 
 				it( 'inserts paragraph + text', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<paragraph>yyy</paragraph>xxx' );
+					const affectedRange = insertHelper( '<paragraph>yyy</paragraph>xxx' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fyyy</paragraph><paragraph>xxx[]oo</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[yyy</paragraph><paragraph>xxx]oo</paragraph>' );
 				} );
 
 				// This is the expected result, but it was so hard to achieve at this stage that I
@@ -625,53 +757,133 @@ describe( 'DataController utils', () => {
 				// See the comment above.
 				it( 'inserts paragraph + text + inlineWidget + text', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<paragraph>yyy</paragraph>xxx<inlineWidget></inlineWidget>zzz' );
+					const affectedRange = insertHelper( '<paragraph>yyy</paragraph>xxx<inlineWidget></inlineWidget>zzz' );
+
 					expect( getData( model ) ).to.equal(
 						'<paragraph>fyyy</paragraph><paragraph>xxx</paragraph>' +
 						'<paragraph><inlineWidget></inlineWidget></paragraph>' +
 						'<paragraph>zzz[]oo</paragraph>'
 					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>f[yyy</paragraph><paragraph>xxx</paragraph>' +
+						'<paragraph><inlineWidget></inlineWidget></paragraph>' +
+						'<paragraph>zzz]oo</paragraph>'
+					);
 				} );
 
 				it( 'inserts paragraph + text + paragraph', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<paragraph>yyy</paragraph>xxx<paragraph>zzz</paragraph>' );
+					const affectedRange = insertHelper( '<paragraph>yyy</paragraph>xxx<paragraph>zzz</paragraph>' );
+
 					expect( getData( model ) ).to.equal(
 						'<paragraph>fyyy</paragraph><paragraph>xxx</paragraph><paragraph>zzz[]oo</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>f[yyy</paragraph><paragraph>xxx</paragraph><paragraph>zzz]oo</paragraph>'
 					);
 				} );
 
 				it( 'inserts paragraph + text (at the beginning)', () => {
 					setData( model, '<paragraph>[]foo</paragraph>' );
-					insertHelper( '<paragraph>yyy</paragraph>xxx' );
+					const affectedRange = insertHelper( '<paragraph>yyy</paragraph>xxx' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>yyy</paragraph><paragraph>xxx[]foo</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '[<paragraph>yyy</paragraph><paragraph>xxx]foo</paragraph>' );
 				} );
 
 				it( 'inserts paragraph + text (at the end)', () => {
 					setData( model, '<paragraph>foo[]</paragraph>' );
-					insertHelper( '<paragraph>yyy</paragraph>xxx' );
+					const affectedRange = insertHelper( '<paragraph>yyy</paragraph>xxx' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fooyyy</paragraph><paragraph>xxx[]</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo[yyy</paragraph><paragraph>xxx</paragraph>]' );
 				} );
 
 				it( 'inserts text + heading', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( 'xxx<heading1>yyy</heading1>' );
+					const affectedRange = insertHelper( 'xxx<heading1>yyy</heading1>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fxxx</paragraph><heading1>yyy[]oo</heading1>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[xxx</paragraph><heading1>yyy]oo</heading1>' );
 				} );
 
 				it( 'inserts paragraph + object', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<paragraph>xxx</paragraph><blockWidget></blockWidget>' );
+					const affectedRange = insertHelper( '<paragraph>xxx</paragraph><blockWidget></blockWidget>' );
+
 					expect( getData( model ) ).to.equal(
 						'<paragraph>fxxx</paragraph>[<blockWidget></blockWidget>]<paragraph>oo</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>f[xxx</paragraph><blockWidget></blockWidget><paragraph>]oo</paragraph>'
 					);
 				} );
 
 				it( 'inserts object + paragraph', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
-					insertHelper( '<blockWidget></blockWidget><paragraph>xxx</paragraph>' );
+					const affectedRange = insertHelper( '<blockWidget></blockWidget><paragraph>xxx</paragraph>' );
+
 					expect( getData( model ) ).to.equal(
 						'<paragraph>f</paragraph><blockWidget></blockWidget><paragraph>xxx[]oo</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>f[</paragraph><blockWidget></blockWidget><paragraph>xxx]oo</paragraph>'
+					);
+				} );
+
+				it( 'inserts object + text', () => {
+					setData( model, '<paragraph>f[]oo</paragraph>' );
+					const affectedRange = insertHelper( '<blockWidget></blockWidget>xxx' );
+
+					expect( getData( model ) ).to.equal(
+						'<paragraph>f</paragraph><blockWidget></blockWidget><paragraph>xxx[]oo</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>f[</paragraph><blockWidget></blockWidget><paragraph>xxx]oo</paragraph>'
+					);
+				} );
+
+				it( 'inserts object + text (at the beginning)', () => {
+					setData( model, '<paragraph>[]foo</paragraph>' );
+					const affectedRange = insertHelper( '<blockWidget></blockWidget>xxx' );
+
+					expect( getData( model ) ).to.equal(
+						'<blockWidget></blockWidget><paragraph>xxx[]foo</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'[<blockWidget></blockWidget><paragraph>xxx]foo</paragraph>'
+					);
+				} );
+
+				it( 'inserts object + text (at the end)', () => {
+					setData( model, '<paragraph>foo[]</paragraph>' );
+					const affectedRange = insertHelper( '<blockWidget></blockWidget>xxx' );
+
+					expect( getData( model ) ).to.equal(
+						'<paragraph>foo</paragraph><blockWidget></blockWidget><paragraph>xxx[]</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>foo</paragraph>[<blockWidget></blockWidget><paragraph>xxx</paragraph>]'
+					);
+				} );
+
+				it( 'inserts text + object (at the end)', () => {
+					setData( model, '<paragraph>foo[]</paragraph>' );
+					const affectedRange = insertHelper( 'xxx<blockWidget></blockWidget>' );
+
+					expect( getData( model ) ).to.equal(
+						'<paragraph>fooxxx</paragraph>[<blockWidget></blockWidget>]'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>foo[xxx</paragraph><blockWidget></blockWidget>]'
 					);
 				} );
 			} );
@@ -679,92 +891,133 @@ describe( 'DataController utils', () => {
 			describe( 'content over a block object', () => {
 				it( 'inserts text', () => {
 					setData( model, '<paragraph>foo</paragraph>[<blockWidget></blockWidget>]<paragraph>bar</paragraph>' );
-					insertHelper( 'xxx' );
+					const affectedRange = insertHelper( 'xxx' );
+
 					expect( getData( model ) ).to.equal(
 						'<paragraph>foo</paragraph><paragraph>xxx[]</paragraph><paragraph>bar</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>foo</paragraph>[<paragraph>xxx</paragraph>]<paragraph>bar</paragraph>'
 					);
 				} );
 
 				it( 'inserts paragraph', () => {
 					setData( model, '<paragraph>foo</paragraph>[<blockWidget></blockWidget>]<paragraph>bar</paragraph>' );
-					insertHelper( '<paragraph>xxx</paragraph>' );
+					const affectedRange = insertHelper( '<paragraph>xxx</paragraph>' );
+
 					expect( getData( model ) )
 						.to.equal( '<paragraph>foo</paragraph><paragraph>xxx[]</paragraph><paragraph>bar</paragraph>' );
+
+					expect( stringify( root, affectedRange ) )
+						.to.equal( '<paragraph>foo</paragraph>[<paragraph>xxx</paragraph>]<paragraph>bar</paragraph>' );
 				} );
 
 				it( 'inserts text + paragraph', () => {
 					setData( model, '<paragraph>foo</paragraph>[<blockWidget></blockWidget>]<paragraph>bar</paragraph>' );
-					insertHelper( 'yyy<paragraph>xxx</paragraph>' );
-					expect( getData( model ) )
-						.to.equal(
-							'<paragraph>foo</paragraph><paragraph>yyy</paragraph><paragraph>xxx[]</paragraph><paragraph>bar</paragraph>'
-						);
+					const affectedRange = insertHelper( 'yyy<paragraph>xxx</paragraph>' );
+
+					expect( getData( model ) ).to.equal(
+						'<paragraph>foo</paragraph><paragraph>yyy</paragraph><paragraph>xxx[]</paragraph><paragraph>bar</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>foo</paragraph>[<paragraph>yyy</paragraph><paragraph>xxx</paragraph>]<paragraph>bar</paragraph>'
+					);
 				} );
 
 				it( 'inserts two blocks', () => {
 					setData( model, '<paragraph>foo</paragraph>[<blockWidget></blockWidget>]<paragraph>bar</paragraph>' );
-					insertHelper( '<heading1>xxx</heading1><paragraph>yyy</paragraph>' );
-					expect( getData( model ) )
-						.to.equal(
-							'<paragraph>foo</paragraph><heading1>xxx</heading1><paragraph>yyy[]</paragraph><paragraph>bar</paragraph>'
-						);
+					const affectedRange = insertHelper( '<heading1>xxx</heading1><paragraph>yyy</paragraph>' );
+
+					expect( getData( model ) ).to.equal(
+						'<paragraph>foo</paragraph><heading1>xxx</heading1><paragraph>yyy[]</paragraph><paragraph>bar</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>foo</paragraph>[<heading1>xxx</heading1><paragraph>yyy</paragraph>]<paragraph>bar</paragraph>'
+					);
 				} );
 
 				it( 'inserts block object', () => {
 					setData( model, '<paragraph>foo</paragraph>[<blockWidget></blockWidget>]<paragraph>bar</paragraph>' );
-					insertHelper( '<blockWidget></blockWidget>' );
+					const affectedRange = insertHelper( '<blockWidget></blockWidget>' );
+
 					// It's enough, don't worry.
 					expect( getData( model ) ).to.equal(
+						'<paragraph>foo</paragraph>[<blockWidget></blockWidget>]<paragraph>bar</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
 						'<paragraph>foo</paragraph>[<blockWidget></blockWidget>]<paragraph>bar</paragraph>'
 					);
 				} );
 
 				it( 'inserts inline object', () => {
 					setData( model, '<paragraph>foo</paragraph>[<blockWidget></blockWidget>]<paragraph>bar</paragraph>' );
-					insertHelper( '<inlineWidget></inlineWidget>' );
-					expect( getData( model ) )
-						.to.equal(
-							'<paragraph>foo</paragraph><paragraph><inlineWidget></inlineWidget>[]</paragraph><paragraph>bar</paragraph>'
-						);
+					const affectedRange = insertHelper( '<inlineWidget></inlineWidget>' );
+
+					expect( getData( model ) ).to.equal(
+						'<paragraph>foo</paragraph><paragraph><inlineWidget></inlineWidget>[]</paragraph><paragraph>bar</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>foo</paragraph>[<paragraph><inlineWidget></inlineWidget></paragraph>]<paragraph>bar</paragraph>'
+					);
 				} );
 			} );
 
 			describe( 'content over an inline object', () => {
 				it( 'inserts text', () => {
 					setData( model, '<paragraph>foo[<inlineWidget></inlineWidget>]bar</paragraph>' );
-					insertHelper( 'xxx' );
+					const affectedRange = insertHelper( 'xxx' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fooxxx[]bar</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo[xxx]bar</paragraph>' );
 				} );
 
 				it( 'inserts paragraph', () => {
 					setData( model, '<paragraph>foo[<inlineWidget></inlineWidget>]bar</paragraph>' );
-					insertHelper( '<paragraph>xxx</paragraph>' );
+					const affectedRange = insertHelper( '<paragraph>xxx</paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fooxxx[]bar</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo[xxx]bar</paragraph>' );
 				} );
 
 				it( 'inserts text + paragraph', () => {
 					setData( model, '<paragraph>foo[<inlineWidget></inlineWidget>]bar</paragraph>' );
-					insertHelper( 'yyy<paragraph>xxx</paragraph>' );
+					const affectedRange = insertHelper( 'yyy<paragraph>xxx</paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fooyyy</paragraph><paragraph>xxx[]bar</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo[yyy</paragraph><paragraph>xxx]bar</paragraph>' );
 				} );
 
 				it( 'inserts two blocks', () => {
 					setData( model, '<paragraph>foo[<inlineWidget></inlineWidget>]bar</paragraph>' );
-					insertHelper( '<heading1>xxx</heading1><paragraph>yyy</paragraph>' );
+					const affectedRange = insertHelper( '<heading1>xxx</heading1><paragraph>yyy</paragraph>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>fooxxx</paragraph><paragraph>yyy[]bar</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo[xxx</paragraph><paragraph>yyy]bar</paragraph>' );
 				} );
 
 				it( 'inserts inline object', () => {
 					setData( model, '<paragraph>foo[<inlineWidget></inlineWidget>]bar</paragraph>' );
-					insertHelper( '<inlineWidget></inlineWidget>' );
+					const affectedRange = insertHelper( '<inlineWidget></inlineWidget>' );
+
 					expect( getData( model ) ).to.equal( '<paragraph>foo<inlineWidget></inlineWidget>[]bar</paragraph>' );
+					expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo[<inlineWidget></inlineWidget>]bar</paragraph>' );
 				} );
 
 				it( 'inserts block object', () => {
 					setData( model, '<paragraph>foo[<inlineWidget></inlineWidget>]bar</paragraph>' );
-					insertHelper( '<blockWidget></blockWidget>' );
+					const affectedRange = insertHelper( '<blockWidget></blockWidget>' );
+
 					expect( getData( model ) ).to.equal(
 						'<paragraph>foo</paragraph>[<blockWidget></blockWidget>]<paragraph>bar</paragraph>'
+					);
+
+					expect( stringify( root, affectedRange ) ).to.equal(
+						'<paragraph>foo[</paragraph><blockWidget></blockWidget><paragraph>]bar</paragraph>'
 					);
 				} );
 			} );
@@ -774,7 +1027,7 @@ describe( 'DataController utils', () => {
 			beforeEach( () => {
 				model = new Model();
 				doc = model.document;
-				doc.createRoot();
+				root = doc.createRoot();
 
 				const schema = model.schema;
 
@@ -827,69 +1080,106 @@ describe( 'DataController utils', () => {
 
 			it( 'filters out disallowed elements and leaves out the text', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( '<table><td>xxx</td><td>yyy</td></table>' );
+				const affectedRange = insertHelper( '<table><td>xxx</td><td>yyy</td></table>' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>fxxxyyy[]oo</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[xxxyyy]oo</paragraph>' );
 			} );
 
 			it( 'filters out disallowed elements and leaves out the paragraphs', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( '<table><td><paragraph>xxx</paragraph><paragraph>yyy</paragraph><paragraph>zzz</paragraph></td></table>' );
+				const affectedRange = insertHelper(
+					'<table><td><paragraph>xxx</paragraph><paragraph>yyy</paragraph><paragraph>zzz</paragraph></td></table>'
+				);
+
 				expect( getData( model ) )
 					.to.equal( '<paragraph>fxxx</paragraph><paragraph>yyy</paragraph><paragraph>zzz[]oo</paragraph>' );
+
+				expect( stringify( root, affectedRange ) )
+					.to.equal( '<paragraph>f[xxx</paragraph><paragraph>yyy</paragraph><paragraph>zzz]oo</paragraph>' );
 			} );
 
 			it( 'filters out disallowed objects', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( '<disallowedWidget>xxx</disallowedWidget>' );
+				const affectedRange = insertHelper( '<disallowedWidget>xxx</disallowedWidget>' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>f[]oo</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[]oo</paragraph>' );
 			} );
 
 			it( 'filters out disallowed attributes when inserting text', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( 'x<$text a="1" b="1">x</$text>xy<$text a="1">y</$text>y' );
+				const affectedRange = insertHelper( 'x<$text a="1" b="1">x</$text>xy<$text a="1">y</$text>y' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>fx<$text b="1">x</$text>xyyy[]oo</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[x<$text b="1">x</$text>xyyy]oo</paragraph>' );
 			} );
 
 			it( 'filters out disallowed attributes when inserting nested elements', () => {
 				setData( model, '<element>[]</element>' );
-				insertHelper( '<table><td>f<$text a="1" b="1" c="1">o</$text>o</td></table>' );
-				expect( getData( model ) ).to.equal( '<element><table><td>f<$text b="1">o</$text>o</td></table>[]</element>' );
+				const affectedRange = insertHelper( '<table><td>f<$text a="1" b="1" c="1">o</$text>o</td></table>' );
+
+				expect( getData( model ) )
+					.to.equal( '<element><table><td>f<$text b="1">o</$text>o</td></table>[]</element>' );
+
+				expect( stringify( root, affectedRange ) )
+					.to.equal( '<element>[<table><td>f<$text b="1">o</$text>o</td></table>]</element>' );
 			} );
 
 			it( 'filters out disallowed attributes when inserting text in disallowed elements', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( '<table><td>x<$text a="1" b="1">x</$text>x</td><td>y<$text a="1">y</$text>y</td></table>' );
+				const affectedRange = insertHelper(
+					'<table><td>x<$text a="1" b="1">x</$text>x</td><td>y<$text a="1">y</$text>y</td></table>'
+				);
+
 				expect( getData( model ) ).to.equal( '<paragraph>fx<$text b="1">x</$text>xyyy[]oo</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[x<$text b="1">x</$text>xyyy]oo</paragraph>' );
 			} );
 
 			it( 'filters out disallowed attributes when merging #1', () => {
 				setData( model, '<paragraph>[]foo</paragraph>' );
-				insertHelper( '<paragraph>x<$text a="1" b="1">x</$text>x</paragraph>' );
+				const affectedRange = insertHelper( '<paragraph>x<$text a="1" b="1">x</$text>x</paragraph>' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>x<$text b="1">x</$text>x[]foo</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>[x<$text b="1">x</$text>x]foo</paragraph>' );
 			} );
 
 			it( 'filters out disallowed attributes when merging #2', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( '<paragraph>x<$text a="1" b="1">x</$text>x</paragraph>' );
+				const affectedRange = insertHelper( '<paragraph>x<$text a="1" b="1">x</$text>x</paragraph>' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>fx<$text b="1">x</$text>x[]oo</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>f[x<$text b="1">x</$text>x]oo</paragraph>' );
 			} );
 
 			it( 'filters out disallowed attributes when merging #3', () => {
 				setData( model, '<paragraph>foo[]</paragraph>' );
-				insertHelper( '<paragraph>x<$text a="1" b="1">x</$text>x</paragraph>' );
+				const affectedRange = insertHelper( '<paragraph>x<$text a="1" b="1">x</$text>x</paragraph>' );
+
 				expect( getData( model ) ).to.equal( '<paragraph>foox<$text b="1">x</$text>x[]</paragraph>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<paragraph>foo[x<$text b="1">x</$text>x]</paragraph>' );
 			} );
 
 			it( 'filters out disallowed attributes from nested nodes when merging', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( '<heading1>x<element>b<$text a="1" b="1">a</$text>r</element>x</heading1>' );
-				expect( getData( model ) ).to.equal( '<paragraph>fx<element>b<$text b="1">a</$text>r</element>x[]oo</paragraph>' );
+				const affectedRange = insertHelper( '<heading1>x<element>b<$text a="1" b="1">a</$text>r</element>x</heading1>' );
+
+				expect( getData( model ) )
+					.to.equal( '<paragraph>fx<element>b<$text b="1">a</$text>r</element>x[]oo</paragraph>' );
+
+				expect( stringify( root, affectedRange ) )
+					.to.equal( '<paragraph>f[x<element>b<$text b="1">a</$text>r</element>x]oo</paragraph>' );
 			} );
 
 			it( 'filters out disallowed attributes when autoparagraphing', () => {
 				setData( model, '<paragraph>f[]oo</paragraph>' );
-				insertHelper( '<paragraph>xxx</paragraph><$text a="1" b="1">yyy</$text>' );
-				expect( getData( model ) ).to.equal( '<paragraph>fxxx</paragraph><paragraph><$text b="1">yyy[]</$text>oo</paragraph>' );
+				const affectedRange = insertHelper( '<paragraph>xxx</paragraph><$text a="1" b="1">yyy</$text>' );
+
+				expect( getData( model ) )
+					.to.equal( '<paragraph>fxxx</paragraph><paragraph><$text b="1">yyy[]</$text>oo</paragraph>' );
+
+				expect( stringify( root, affectedRange ) )
+					.to.equal( '<paragraph>f[xxx</paragraph><paragraph><$text b="1">yyy</$text>]oo</paragraph>' );
 			} );
 		} );
 	} );
@@ -898,7 +1188,7 @@ describe( 'DataController utils', () => {
 		beforeEach( () => {
 			model = new Model();
 			doc = model.document;
-			doc.createRoot();
+			root = doc.createRoot();
 
 			const schema = model.schema;
 
@@ -915,52 +1205,61 @@ describe( 'DataController utils', () => {
 		} );
 
 		it( 'should insert limit element', () => {
-			insertHelper( '<limit></limit>' );
+			const affectedRange = insertHelper( '<limit></limit>' );
 
 			expect( getData( model ) ).to.equal( '<limit>[]</limit>' );
+			expect( stringify( root, affectedRange ) ).to.equal( '[<limit></limit>]' );
 		} );
 
 		it( 'should insert text into limit element', () => {
 			setData( model, '<limit>[]</limit>' );
-			insertHelper( 'foo bar' );
+			const affectedRange = insertHelper( 'foo bar' );
 
 			expect( getData( model ) ).to.equal( '<limit>foo bar[]</limit>' );
+			expect( stringify( root, affectedRange ) ).to.equal( '<limit>[foo bar]</limit>' );
 		} );
 
 		it( 'should insert text into limit element when selection spans over many limit elements', () => {
+			let affectedRange;
+
 			model.enqueueChange( 'transparent', () => {
 				setData( model, '<limit>foo[</limit><limit>]bar</limit>' );
-				insertHelper( 'baz' );
+				affectedRange = insertHelper( 'baz' );
 			} );
 
 			expect( getData( model ) ).to.equal( '<limit>foobaz[]</limit><limit>bar</limit>' );
+			expect( stringify( root, affectedRange ) ).to.equal( '<limit>foo[baz]</limit><limit>bar</limit>' );
 		} );
 
 		it( 'should not insert disallowed elements inside limit elements', () => {
 			setData( model, '<limit>[]</limit>' );
-			insertHelper( '<disallowedElement></disallowedElement>' );
+			const affectedRange = insertHelper( '<disallowedElement></disallowedElement>' );
 
 			expect( getData( model ) ).to.equal( '<limit>[]</limit>' );
+			expect( stringify( root, affectedRange ) ).to.equal( '<limit>[]</limit>' );
 		} );
 
 		it( 'should not leave the limit element when inserting at the end', () => {
 			setData( model, '<limit>foo[]</limit>' );
-			insertHelper( '<paragraph>a</paragraph><paragraph>b</paragraph>' );
+			const affectedRange = insertHelper( '<paragraph>a</paragraph><paragraph>b</paragraph>' );
 
 			expect( getData( model ) ).to.equal( '<limit>fooab[]</limit>' );
+			expect( stringify( root, affectedRange ) ).to.equal( '<limit>foo[ab]</limit>' );
 		} );
 
 		it( 'should not leave the limit element when inserting at the beginning', () => {
 			setData( model, '<limit>[]foo</limit>' );
-			insertHelper( '<paragraph>a</paragraph><paragraph>b</paragraph>' );
+			const affectedRange = insertHelper( '<paragraph>a</paragraph><paragraph>b</paragraph>' );
 
 			expect( getData( model ) ).to.equal( '<limit>ab[]foo</limit>' );
+			expect( stringify( root, affectedRange ) ).to.equal( '<limit>[ab]foo</limit>' );
 		} );
 	} );
 
 	// Helper function that parses given content and inserts it at the cursor position.
 	//
 	// @param {module:engine/model/item~Item|String} content
+	// @returns {module:engine/model/range~Range} range
 	function insertHelper( content ) {
 		if ( typeof content == 'string' ) {
 			content = parse( content, model.schema, {
@@ -968,6 +1267,6 @@ describe( 'DataController utils', () => {
 			} );
 		}
 
-		insertContent( model, content );
+		return insertContent( model, content );
 	}
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `Model#insertContent()` will return a range affected by the insertion.

In `Model#deleteContent()`, added `doNotAutoparagraph` flag to `options`.

`Position` and `LivePosition` static creators should handle `stickiness` param.

Closes #1689. Closes #1688.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
