### PR TITLE
Feature: Introduced `Writer#refreshMarker` method.

### DIFF
--- a/src/model/markercollection.js
+++ b/src/model/markercollection.js
@@ -167,7 +167,7 @@ export default class MarkerCollection {
 		const marker = this._markers.get( markerName );
 
 		if ( !marker ) {
-			throw new CKEditorError( 'markers-refresh-marker-not-exists: Marker with provided name does not exists.' );
+			throw new CKEditorError( 'markercollection-refresh-marker-not-exists: Marker with provided name does not exists.' );
 		}
 
 		const range = marker.getRange();

--- a/src/model/markercollection.js
+++ b/src/model/markercollection.js
@@ -154,6 +154,27 @@ export default class MarkerCollection {
 	}
 
 	/**
+	 * Fires an {@link module:engine/model/markercollection~MarkerCollection#event:update} event for the given {@link ~Marker marker}
+	 * but does not change the marker. Useful to force {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher downcast
+	 * conversion} for the marker.
+	 *
+	 * @protected
+	 * @fires module:engine/model/markercollection~MarkerCollection#event:update
+	 * @param {String} markerOrName Marker or name of a marker to refresh.
+	 */
+	_refresh( markerOrName ) {
+		const markerName = markerOrName instanceof Marker ? markerOrName.name : markerOrName;
+		const marker = this._markers.get( markerName );
+
+		if ( !marker ) {
+			throw new CKEditorError( 'markers-refresh-marker-not-exists: Marker with provided name does not exists.' );
+		}
+
+		const range = marker.getRange();
+		this.fire( 'update:' + markerName, marker, range, range, marker.managedUsingOperations, marker.affectsData );
+	}
+
+	/**
 	 * Returns iterator that iterates over all markers, which ranges contain given {@link module:engine/model/position~Position position}.
 	 *
 	 * @param {module:engine/model/position~Position} position

--- a/src/model/markercollection.js
+++ b/src/model/markercollection.js
@@ -171,6 +171,7 @@ export default class MarkerCollection {
 		}
 
 		const range = marker.getRange();
+
 		this.fire( 'update:' + markerName, marker, range, range, marker.managedUsingOperations, marker.affectsData );
 	}
 

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -939,14 +939,14 @@ export default class Writer {
 	}
 
 	/**
-	 * Adds updates or refreshes a {@link module:engine/model/markercollection~Marker marker}. Marker is a named range, which tracks
+	 * Adds, updates or refreshes a {@link module:engine/model/markercollection~Marker marker}. Marker is a named range, which tracks
 	 * changes in the document and updates its range automatically, when model tree changes. Still, it is possible to change the
 	 * marker's range directly using this method.
 	 *
 	 * As the first parameter you can set marker name or instance. If none of them is provided, new marker, with a unique
 	 * name is created and returned.
 	 *
-	 * As the second parameter you can set the new marker data or leave this parameter as empty what will only refresh
+	 * As the second parameter you can set the new marker data or leave this parameter as empty which will just refresh
 	 * the marker by triggering downcast conversion for it. Refreshing the marker is useful when you want to change
 	 * the marker {@link module:engine/view/element~Element view element} without changing any marker data.
 	 *

--- a/tests/model/markercollection.js
+++ b/tests/model/markercollection.js
@@ -195,6 +195,24 @@ describe( 'MarkerCollection', () => {
 		} );
 	} );
 
+	describe( '_refresh()', () => {
+		it( 'should fire update:<markerName> event', () => {
+			const marker = markers._set( 'name', range );
+
+			sinon.spy( markers, 'fire' );
+
+			markers._refresh( 'name' );
+
+			sinon.assert.calledWithExactly( markers.fire, 'update:name', marker, range, range, false, false );
+		} );
+
+		it( 'should throw if marker does not exist', () => {
+			expect( () => {
+				markers._refresh( 'name' );
+			} ).to.throw( CKEditorError, 'markers-refresh-marker-not-exists: Marker with provided name does not exists.' );
+		} );
+	} );
+
 	describe( 'getMarkersGroup', () => {
 		it( 'returns all markers which names start on given prefix', () => {
 			const markerFooA = markers._set( 'foo:a', range );

--- a/tests/model/markercollection.js
+++ b/tests/model/markercollection.js
@@ -209,7 +209,7 @@ describe( 'MarkerCollection', () => {
 		it( 'should throw if marker does not exist', () => {
 			expect( () => {
 				markers._refresh( 'name' );
-			} ).to.throw( CKEditorError, 'markers-refresh-marker-not-exists: Marker with provided name does not exists.' );
+			} ).to.throw( CKEditorError, 'markercollection-refresh-marker-not-exists: Marker with provided name does not exists.' );
 		} );
 	} );
 

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -2402,7 +2402,7 @@ describe( 'Writer', () => {
 		it( 'should throw when range and usingOperations were not provided', () => {
 			expect( () => {
 				addMarker( 'name', { range, usingOperation: false } );
-				updateMarker( 'name' );
+				updateMarker( 'name', {} );
 			} ).to.throw( CKEditorError, /^writer-updateMarker-wrong-options/ );
 		} );
 
@@ -2410,6 +2410,21 @@ describe( 'Writer', () => {
 			expect( () => {
 				updateMarker( 'name', { usingOperation: false } );
 			} ).to.throw( CKEditorError, /^writer-updateMarker-marker-not-exists/ );
+		} );
+
+		it( 'should only refresh the marker when there is no provided options to update', () => {
+			const marker = addMarker( 'name', { range, usingOperation: true } );
+			const spy = sinon.spy( model.markers, '_refresh' );
+
+			updateMarker( marker );
+
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, marker );
+
+			updateMarker( 'name' );
+
+			sinon.assert.calledTwice( spy );
+			sinon.assert.calledWithExactly( spy.secondCall, marker );
 		} );
 
 		it( 'should throw when trying to use detached writer', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added possibility to refresh the marker with no changes through `Writer#updateMarker()` method. Closes #1649.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
