### PR TITLE
Introduced UpcastConversionApi#getSplitParts

### DIFF
--- a/src/conversion/upcastdispatcher.js
+++ b/src/conversion/upcastdispatcher.js
@@ -573,16 +573,12 @@ function createContextTree( contextDefinition, writer ) {
  * Example of a usage in a converter code:
  *
  *		const myElement = conversionApi.writer.createElement( 'myElement' );
- *		// ...
+ *
+ *		// Children conversion may split `myElement`.
  *		conversionApi.convertChildren( myElement, modelCursor );
- *		// ...
+ *
  *		const splitParts = conversionApi.getSplitParts( myElement );
  *		const lastSplitPart = splitParts[ splitParts.length - 1 ];
- *
- *		// Additional processing on all the parts after the children are converted and the original element might be split.
- *		for ( const element of splitParts ) {
- *			// ...
- *		}
  *
  *		// Setting `data.modelRange` basing on split parts:
  *		data.modelRange = conversionApi.writer.createRange(

--- a/src/conversion/upcastdispatcher.js
+++ b/src/conversion/upcastdispatcher.js
@@ -283,14 +283,15 @@ export default class UpcastDispatcher {
 		// Split element to allowed parent.
 		const splitResult = this.conversionApi.writer.split( modelCursor, allowedParent );
 
-		// Using the range returned by `model.Writer#split`, pair original elements with their split parts.
-		// The range returned from the writer spans "between" the split or precisely saying, from the end of the split element
-		// to the beginning of the other part of the split element:
+		// Using the range returned by `model.Writer#split`, we will pair original elements with their split parts.
+		//
+		// The range returned from the writer spans "over the split" or, precisely saying, from the end of the original (split) element
+		// to the beginning of the other (new) part of that element:
 		//
 		// <limit><a><b><c>X[]Y</c></b><a></limit> ->
 		// <limit><a><b><c>X[</c></b></a><a><b><c>]Y</c></b></a>
 		//
-		// After the split no meaningful content can be between the positions in `splitRange` - they have to be touching.
+		// After the split there cannot be any full node between the positions in `splitRange`. The positions are touching.
 		// Also, because of how splitting works, it is easy to notice, that "closing tags" are in the reverse order than "opening tags".
 		// Also, since we split all those elements, each of them has to have the other part.
 		//

--- a/src/conversion/upcastdispatcher.js
+++ b/src/conversion/upcastdispatcher.js
@@ -285,8 +285,8 @@ export default class UpcastDispatcher {
 
 		// Using the range returned by `model.Writer#split`, we will pair original elements with their split parts.
 		//
-		// The range returned from the writer spans "over the split" or, precisely saying, from the end of the original (split) element
-		// to the beginning of the other (new) part of that element:
+		// The range returned from the writer spans "over the split" or, precisely saying, from the end of the original element (the one
+		// that got split) to the beginning of the other part of that element:
 		//
 		// <limit><a><b><c>X[]Y</c></b><a></limit> ->
 		// <limit><a><b><c>X[</c></b></a><a><b><c>]Y</c></b></a>

--- a/src/conversion/upcastdispatcher.js
+++ b/src/conversion/upcastdispatcher.js
@@ -349,8 +349,6 @@ export default class UpcastDispatcher {
 			parts = this._splitParts.get( element );
 		}
 
-		parts.last = parts[ parts.length - 1 ];
-
 		return parts;
 	}
 
@@ -569,8 +567,6 @@ function createContextTree( contextDefinition, writer ) {
  * For a reference to any of above paragraphs, the function will return all three paragraphs (the original element included),
  * sorted in the order of their creation (the original element is the first one).
  *
- * The function returns `Array` with elements. Additionally, `.last` property is set on the array for an easy access to the last split part.
- *
  * If given `element` was not split, an array with single element is returned.
  *
  * Example of a usage in a converter code:
@@ -580,6 +576,7 @@ function createContextTree( contextDefinition, writer ) {
  *		conversionApi.convertChildren( myElement, modelCursor );
  *		// ...
  *		const splitParts = conversionApi.getSplitParts( myElement );
+ *		const lastSplitPart = splitParts[ splitParts.length - 1 ];
  *
  *		// Additional processing on all the parts after the children are converted and the original element might be split.
  *		for ( const element of splitParts ) {
@@ -589,11 +586,11 @@ function createContextTree( contextDefinition, writer ) {
  *		// Setting `data.modelRange` basing on split parts:
  *		data.modelRange = conversionApi.writer.createRange(
  *			conversionApi.writer.createPositionBefore( myElement ),
- *			conversionApi.writer.createPositionAfter( splitParts.last )
+ *			conversionApi.writer.createPositionAfter( lastSplitPart )
  *		);
  *
  *		// Setting `data.modelCursor` to continue after the last split element:
- *		data.modelCursor = conversionApi.writer.createPositionAfter( splitParts.last );
+ *		data.modelCursor = conversionApi.writer.createPositionAfter( lastSplitPart );
  *
  * **Tip:** if you are unable to get a reference to the original element (for example because the code is split into multiple converters
  * or even classes) but it was already converted, you might want to check first element in `data.modelRange`. This is a common situation

--- a/src/conversion/upcastdispatcher.js
+++ b/src/conversion/upcastdispatcher.js
@@ -303,10 +303,10 @@ export default class UpcastDispatcher {
 				stack.push( treeWalkerValue.item );
 			} else {
 				// There should not be any text nodes after the element is split, so the only other value is `elementStart`.
-				const originalElement = stack.pop();
-				const splitElement = treeWalkerValue.item;
+				const originalPart = stack.pop();
+				const splitPart = treeWalkerValue.item;
 
-				this._registerSplitPair( originalElement, splitElement );
+				this._registerSplitPair( originalPart, splitPart );
 			}
 		}
 
@@ -317,23 +317,23 @@ export default class UpcastDispatcher {
 	}
 
 	/**
-	 * Registers that `split` element is a split part of the `original` element.
+	 * Registers that `splitPart` element is a split part of the `originalPart` element.
 	 *
-	 * Data set by this method is then used by {@link #_getSplitParts} and {@link #_removeEmptyElements}
+	 * Data set by this method is used by {@link #_getSplitParts} and {@link #_removeEmptyElements}.
 	 *
 	 * @private
-	 * @param {module:engine/model/element~Element} original The original element.
-	 * @param {module:engine/model/element~Element} split The split part element.
+	 * @param {module:engine/model/element~Element} originalPart
+	 * @param {module:engine/model/element~Element} splitPart
 	 */
-	_registerSplitPair( original, split ) {
-		if ( !this._splitParts.has( original ) ) {
-			this._splitParts.set( original, [ original ] );
+	_registerSplitPair( originalPart, splitPart ) {
+		if ( !this._splitParts.has( originalPart ) ) {
+			this._splitParts.set( originalPart, [ originalPart ] );
 		}
 
-		const list = this._splitParts.get( original );
+		const list = this._splitParts.get( originalPart );
 
-		this._splitParts.set( split, list );
-		list.push( split );
+		this._splitParts.set( splitPart, list );
+		list.push( splitPart );
 	}
 
 	/**

--- a/src/conversion/upcasthelpers.js
+++ b/src/conversion/upcasthelpers.js
@@ -570,7 +570,7 @@ function prepareToElementConverter( config ) {
 		// Set conversion result range.
 		data.modelRange = new ModelRange(
 			conversionApi.writer.createPositionBefore( modelElement ),
-			conversionApi.writer.createPositionAfter( parts.last )
+			conversionApi.writer.createPositionAfter( parts[ parts.length - 1 ] )
 		);
 
 		// Now we need to check where the `modelCursor` should be.

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -717,8 +717,8 @@ export default class Writer {
 	 * @param {module:engine/model/position~Position} position Position of split.
 	 * @param {module:engine/model/node~Node} [limitElement] Stop splitting when this element will be reached.
 	 * @returns {Object} result Split result.
-	 * @returns {module:engine/model/position~Position} result.position between split elements.
-	 * @returns {module:engine/model/range~Range} result.range Range that stars from the end of the first split element and ands
+	 * @returns {module:engine/model/position~Position} result.position Position between split elements.
+	 * @returns {module:engine/model/range~Range} result.range Range that stars from the end of the first split element and ends
 	 * at the beginning of the first copy element.
 	 */
 	split( position, limitElement ) {

--- a/tests/conversion/upcastdispatcher.js
+++ b/tests/conversion/upcastdispatcher.js
@@ -626,7 +626,6 @@ describe( 'UpcastDispatcher', () => {
 					const parts = conversionApi.getSplitParts( modelElement );
 
 					expect( parts ).to.deep.equal( [ modelElement ] );
-					expect( parts.last ).to.equal( modelElement );
 
 					spy();
 
@@ -689,7 +688,6 @@ describe( 'UpcastDispatcher', () => {
 					expect( parts[ 2 ].getChild( 0 ).data ).to.equal( 'xyz' );
 
 					expect( parts[ 0 ] ).to.equal( modelElement );
-					expect( parts.last ).to.equal( parts[ 2 ] );
 
 					spy();
 

--- a/tests/conversion/upcastdispatcher.js
+++ b/tests/conversion/upcastdispatcher.js
@@ -5,6 +5,7 @@
 
 import UpcastDispatcher from '../../src/conversion/upcastdispatcher';
 import ViewContainerElement from '../../src/view/containerelement';
+import ViewElement from '../../src/view/element';
 import ViewDocumentFragment from '../../src/view/documentfragment';
 import ViewText from '../../src/view/text';
 
@@ -38,10 +39,12 @@ describe( 'UpcastDispatcher', () => {
 			expect( dispatcher.conversionApi ).to.have.property( 'splitToAllowedParent' ).that.is.instanceof( Function );
 		} );
 
-		it( 'should have properties', () => {
+		it( 'should not crash if no additional api is passed', () => {
 			const dispatcher = new UpcastDispatcher();
 
-			expect( dispatcher._removeIfEmpty ).to.instanceof( Set );
+			expect( dispatcher.conversionApi ).to.have.property( 'convertItem' ).that.is.instanceof( Function );
+			expect( dispatcher.conversionApi ).to.have.property( 'convertChildren' ).that.is.instanceof( Function );
+			expect( dispatcher.conversionApi ).to.have.property( 'splitToAllowedParent' ).that.is.instanceof( Function );
 		} );
 	} );
 
@@ -49,10 +52,10 @@ describe( 'UpcastDispatcher', () => {
 		let dispatcher;
 
 		beforeEach( () => {
-			dispatcher = new UpcastDispatcher();
+			dispatcher = new UpcastDispatcher( { schema: model.schema } );
 		} );
 
-		it( 'should create api for current conversion process', () => {
+		it( 'should create api for a conversion process', () => {
 			const viewElement = new ViewContainerElement( 'p', null, new ViewText( 'foobar' ) );
 
 			// To be sure that both converters was called.
@@ -64,22 +67,17 @@ describe( 'UpcastDispatcher', () => {
 			// Conversion process properties should be undefined/empty before conversion.
 			expect( dispatcher.conversionApi.writer ).to.not.ok;
 			expect( dispatcher.conversionApi.store ).to.not.ok;
-			expect( dispatcher._removeIfEmpty.size ).to.equal( 0 );
 
 			dispatcher.on( 'element', ( evt, data, conversionApi ) => {
 				// Check conversion api params.
 				expect( conversionApi.writer ).to.instanceof( ModelWriter );
 				expect( conversionApi.store ).to.deep.equal( {} );
-				expect( dispatcher._removeIfEmpty.size ).to.equal( 0 );
 
 				// Remember writer to check in next converter that is exactly the same instance (the same undo step).
 				writer = conversionApi.writer;
 
 				// Add some data to conversion storage to verify them in next converter.
 				conversionApi.store.foo = 'bar';
-
-				// Add empty element and mark as a split result to check in next converter.
-				dispatcher._removeIfEmpty.add( conversionApi.writer.createElement( 'paragraph' ) );
 
 				// Convert children - this will call second converter.
 				conversionApi.convertChildren( data.viewItem, data.modelCursor );
@@ -94,9 +92,6 @@ describe( 'UpcastDispatcher', () => {
 				// Data set by previous converter are remembered.
 				expect( conversionApi.store ).to.deep.equal( { foo: 'bar' } );
 
-				// Split element is remembered as well.
-				expect( dispatcher._removeIfEmpty.size ).to.equal( 1 );
-
 				spy();
 			} );
 
@@ -108,7 +103,6 @@ describe( 'UpcastDispatcher', () => {
 			// Conversion process properties should be cleared after conversion.
 			expect( dispatcher.conversionApi.writer ).to.not.ok;
 			expect( dispatcher.conversionApi.store ).to.not.ok;
-			expect( dispatcher._removeIfEmpty.size ).to.equal( 0 );
 		} );
 
 		it( 'should fire viewCleanup event on converted view part', () => {
@@ -248,58 +242,50 @@ describe( 'UpcastDispatcher', () => {
 		} );
 
 		it( 'should remove empty elements that was created as a result of split', () => {
-			const viewElement = new ViewContainerElement( 'p' );
+			const viewElement = new ViewElement( 'div', null, [
+				new ViewElement( 'p', null, [
+					new ViewElement( 'img' )
+				] )
+			] );
 
-			// To be sure that converter was called.
-			const spy = sinon.spy();
+			model.schema.register( 'div', { allowIn: '$root' } );
+			model.schema.register( 'p', { allowIn: 'div' } );
+			model.schema.register( 'image', { allowIn: '$root' } );
+
+			dispatcher.on( 'element:img', ( evt, data, conversionApi ) => {
+				const writer = conversionApi.writer;
+
+				const modelElement = writer.createElement( 'image' );
+				const splitResult = conversionApi.splitToAllowedParent( modelElement, data.modelCursor );
+				writer.insert( modelElement, splitResult.position );
+
+				data.modelRange = writer.createRangeOn( modelElement );
+				data.modelCursor = writer.createPositionAt( splitResult.cursorParent, 0 );
+
+				// Prevent below converter to fire.
+				evt.stop();
+			}, { priority: 'high' } );
 
 			dispatcher.on( 'element', ( evt, data, conversionApi ) => {
-				// First let's convert target element.
-				const paragraph = conversionApi.writer.createElement( 'paragraph' );
-				conversionApi.writer.insert( paragraph, data.modelCursor );
+				const writer = conversionApi.writer;
 
-				// Then add some elements and mark as split.
+				const modelElement = writer.createElement( data.viewItem.name );
+				writer.insert( modelElement, data.modelCursor );
 
-				// Create and insert empty split element before target element.
-				const emptySplit = conversionApi.writer.createElement( 'paragraph' );
-				conversionApi.writer.insert( emptySplit, ModelPosition._createAfter( paragraph ) );
+				const result = conversionApi.convertChildren( data.viewItem, writer.createPositionAt( modelElement, 0 ) );
 
-				// Create and insert not empty split after target element.
-				const notEmptySplit = conversionApi.writer.createElement( 'paragraph' );
-				conversionApi.writer.appendText( 'foo', notEmptySplit );
-				conversionApi.writer.insert( notEmptySplit, ModelPosition._createAfter( emptySplit ) );
-
-				// Create and insert split with other split inside (both should be removed)
-				const outerSplit = conversionApi.writer.createElement( 'paragraph' );
-				const innerSplit = conversionApi.writer.createElement( 'paragraph' );
-				conversionApi.writer.append( innerSplit, outerSplit );
-				conversionApi.writer.insert( outerSplit, ModelPosition._createBefore( paragraph ) );
-
-				dispatcher._removeIfEmpty.add( emptySplit );
-				dispatcher._removeIfEmpty.add( notEmptySplit );
-				dispatcher._removeIfEmpty.add( outerSplit );
-				dispatcher._removeIfEmpty.add( innerSplit );
-
-				data.modelRange = ModelRange._createOn( paragraph );
+				data.modelRange = writer.createRange(
+					writer.createPositionBefore( modelElement ),
+					conversionApi.writer.createPositionAfter( result.modelCursor.parent )
+				);
 				data.modelCursor = data.modelRange.end;
-
-				// We have the following result:
-				// <p><p></p></p>[<p></p>]<p></p><p>foo</p>
-				// Everything out of selected range is a result of the split.
-
-				spy();
 			} );
 
 			const result = model.change( writer => dispatcher.convert( viewElement, writer ) );
 
-			// Empty split elements should be removed and we should have the following result:
-			// [<p></p>]<p>foo</p>
-			expect( result.childCount ).to.equal( 2 );
-			expect( result.getChild( 0 ).name ).to.equal( 'paragraph' );
-			expect( result.getChild( 0 ).childCount ).to.equal( 0 );
-			expect( result.getChild( 1 ).name ).to.equal( 'paragraph' );
-			expect( result.getChild( 1 ).childCount ).to.equal( 1 );
-			expect( result.getChild( 1 ).getChild( 0 ).data ).to.equal( 'foo' );
+			// After splits `div` and `p` are empty so they should be removed.
+			expect( result.childCount ).to.equal( 1 );
+			expect( result.getChild( 0 ).name ).to.equal( 'image' );
 		} );
 
 		it( 'should extract temporary markers elements from converter element and create static markers list', () => {
@@ -626,6 +612,102 @@ describe( 'UpcastDispatcher', () => {
 
 				model.change( writer => dispatcher.convert( new ViewDocumentFragment(), writer, [ '$root', 'paragraph' ] ) );
 				sinon.assert.calledOnce( spy );
+			} );
+		} );
+
+		describe( 'getSplitParts()', () => {
+			it( 'should return an array containing only passed element if the element has not been split', () => {
+				model.schema.register( 'paragraph', { allowIn: '$root' } );
+
+				const spy = sinon.spy();
+
+				dispatcher.on( 'element', ( evt, data, conversionApi ) => {
+					const modelElement = conversionApi.writer.createElement( 'paragraph' );
+					const parts = conversionApi.getSplitParts( modelElement );
+
+					expect( parts ).to.deep.equal( [ modelElement ] );
+					expect( parts.last ).to.equal( modelElement );
+
+					spy();
+
+					// Overwrite converters specified in `beforeEach`.
+					evt.stop();
+				}, { priority: 'high' } );
+
+				const viewElement = new ViewElement( 'p' );
+
+				model.change( writer => dispatcher.convert( viewElement, writer ) );
+
+				expect( spy.called ).to.be.true;
+			} );
+
+			it( 'should return all parts of the split element', () => {
+				model.schema.register( 'paragraph', { allowIn: '$root' } );
+				model.schema.register( 'text', { allowIn: 'paragraph' } );
+				model.schema.register( 'image', { allowIn: '$root' } );
+
+				dispatcher.on( 'text', ( evt, data, conversionApi ) => {
+					const modelText = conversionApi.writer.createText( data.viewItem.data );
+
+					conversionApi.writer.insert( modelText, data.modelCursor );
+
+					data.modelRange = conversionApi.writer.createRangeOn( modelText );
+					data.modelCursor = data.modelRange.end;
+
+					// Overwrite converters specified in `beforeEach`.
+					evt.stop();
+				}, { priority: 'high' } );
+
+				dispatcher.on( 'element:image', ( evt, data, conversionApi ) => {
+					const modelElement = conversionApi.writer.createElement( 'image' );
+
+					const splitResult = conversionApi.splitToAllowedParent( modelElement, data.modelCursor );
+
+					conversionApi.writer.insert( modelElement, splitResult.position );
+
+					data.modelRange = conversionApi.writer.createRangeOn( modelElement );
+					data.modelCursor = conversionApi.writer.createPositionAt( splitResult.cursorParent, 0 );
+
+					// Overwrite converters specified in `beforeEach`.
+					evt.stop();
+				}, { priority: 'high' } );
+
+				const spy = sinon.spy();
+
+				dispatcher.on( 'element:p', ( evt, data, conversionApi ) => {
+					const modelElement = conversionApi.writer.createElement( 'paragraph' );
+
+					conversionApi.writer.insert( modelElement, data.modelCursor );
+					conversionApi.convertChildren( data.viewItem, conversionApi.writer.createPositionAt( modelElement, 0 ) );
+
+					const parts = conversionApi.getSplitParts( modelElement );
+
+					expect( parts.length ).to.equal( 3 );
+
+					expect( parts[ 0 ].getChild( 0 ).data ).to.equal( 'foo' );
+					expect( parts[ 1 ].getChild( 0 ).data ).to.equal( 'bar' );
+					expect( parts[ 2 ].getChild( 0 ).data ).to.equal( 'xyz' );
+
+					expect( parts[ 0 ] ).to.equal( modelElement );
+					expect( parts.last ).to.equal( parts[ 2 ] );
+
+					spy();
+
+					// Overwrite converters specified in `beforeEach`.
+					evt.stop();
+				}, { priority: 'high' } );
+
+				const viewElement = new ViewElement( 'p', null, [
+					new ViewText( 'foo' ),
+					new ViewElement( 'image' ),
+					new ViewText( 'bar' ),
+					new ViewElement( 'image' ),
+					new ViewText( 'xyz' )
+				] );
+
+				model.change( writer => dispatcher.convert( viewElement, writer, [ '$root' ] ) );
+
+				expect( spy.called ).to.be.true;
 			} );
 		} );
 	} );

--- a/tests/conversion/upcasthelpers.js
+++ b/tests/conversion/upcasthelpers.js
@@ -112,6 +112,15 @@ describe( 'UpcastHelpers', () => {
 			expectResult( new ViewContainerElement( 'p', { 'data-level': 2 } ), '' );
 		} );
 
+		it( 'config.view is not set - should fire conversion for every element', () => {
+			upcastHelpers.elementToElement( {
+				model: 'paragraph'
+			} );
+
+			expectResult( new ViewContainerElement( 'p' ), '<paragraph></paragraph>' );
+			expectResult( new ViewContainerElement( 'foo' ), '<paragraph></paragraph>' );
+		} );
+
 		it( 'should fire conversion of the element children', () => {
 			upcastHelpers.elementToElement( { view: 'p', model: 'paragraph' } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `UpcastConversionApi#getSplitParts`. Also, provided a way to set upcast conversion helper fired for every view element. Closes https://github.com/ckeditor/ckeditor5/issues/1580. Closes https://github.com/ckeditor/ckeditor5/issues/1581.

------

### Additional information

I added a possibility to specify conversion from any view element to model element by not setting `view` property in upcast helper configuration:

```js
conversion.for( 'upcast' ).elementToElement( { model: 'paragraph' } );
```

Will convert any non-converted element to a `paragraph` model element.