### PR TITLE
Model#deleteContent will not throw anymore if the passed selection is in the graveyard root

### DIFF
--- a/src/model/utils/deletecontent.js
+++ b/src/model/utils/deletecontent.js
@@ -63,6 +63,13 @@ export default function deleteContent( model, selection, options = {} ) {
 	const schema = model.schema;
 
 	model.change( writer => {
+		const selRange = selection.getFirstRange();
+
+		// If the selection is already removed, don't do anything.
+		if ( selRange.root.rootName == '$graveyard' ) {
+			return;
+		}
+
 		// 1. Replace the entire content with paragraph.
 		// See: https://github.com/ckeditor/ckeditor5-engine/issues/1012#issuecomment-315017594.
 		if ( !options.doNotResetEntireContent && shouldEntireContentBeReplacedWithParagraph( schema, selection ) ) {
@@ -71,7 +78,6 @@ export default function deleteContent( model, selection, options = {} ) {
 			return;
 		}
 
-		const selRange = selection.getFirstRange();
 		const startPos = selRange.start;
 		const endPos = LivePosition.fromPosition( selRange.end, 'toNext' );
 

--- a/src/model/utils/deletecontent.js
+++ b/src/model/utils/deletecontent.js
@@ -60,16 +60,16 @@ export default function deleteContent( model, selection, options = {} ) {
 		return;
 	}
 
+	const selRange = selection.getFirstRange();
+
+	// If the selection is already removed, don't do anything.
+	if ( selRange.root.rootName == '$graveyard' ) {
+		return;
+	}
+
 	const schema = model.schema;
 
 	model.change( writer => {
-		const selRange = selection.getFirstRange();
-
-		// If the selection is already removed, don't do anything.
-		if ( selRange.root.rootName == '$graveyard' ) {
-			return;
-		}
-
 		// 1. Replace the entire content with paragraph.
 		// See: https://github.com/ckeditor/ckeditor5-engine/issues/1012#issuecomment-315017594.
 		if ( !options.doNotResetEntireContent && shouldEntireContentBeReplacedWithParagraph( schema, selection ) ) {

--- a/tests/model/utils/deletecontent.js
+++ b/tests/model/utils/deletecontent.js
@@ -29,6 +29,29 @@ describe( 'DataController utils', () => {
 			} );
 		} );
 
+		it( 'should not do anything if the selection is already in graveyard', () => {
+			model = new Model();
+			doc = model.document;
+
+			const gy = model.document.graveyard;
+
+			gy._appendChild( new Element( 'paragraph' ) );
+
+			const baseVersion = model.document.baseVersion;
+
+			model.change( writer => {
+				sinon.spy( writer, 'remove' );
+
+				const selection = writer.createSelection( writer.createRangeIn( gy ) );
+
+				deleteContent( model, selection );
+
+				expect( writer.remove.called ).to.be.false;
+			} );
+
+			expect( model.document.baseVersion ).to.equal( baseVersion );
+		} );
+
 		describe( 'in simple scenarios', () => {
 			beforeEach( () => {
 				model = new Model();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `Model#deleteContent` will not throw anymore if the passed selection is in the graveyard root. Closes #1706.