### PR TITLE
Introduced schema#setAttributeProperties() and schema#getAttributeProperties() methods

### DIFF
--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -498,7 +498,8 @@ export default class Schema {
 	 *			isFormatting: false
 	 *		} );
 	 *
-	 * You can also use custom properties:
+	 * Properties are not limited to members defined in the
+	 * {@link module:engine/model/schema~AttributeProperties `AttributeProperties` type} and you can also use custom properties:
 	 *
 	 *		schema.setAttributeProperties( 'blockQuote', {
 	 *			customProperty: 'value'

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -149,70 +149,6 @@ export default class Schema {
 	}
 
 	/**
-	 * Registers custom properties to a given attribute.
-	 *
-	 * It can be used to mark the attributes relation and handle them in a common way.
-	 *
-	 *		// Mark blockQuote as a formatting attribute.
-	 *		schema.setAttributeProperties( 'blockQuote', {
-	 *			isFormatting: true
-	 *		} );
-	 *
-	 *		// Override code not to be considered a formatting markup.
-	 *		schema.setAttributeProperties( 'code', {
-	 *			isFormatting: false
-	 *		} );
-	 *
-	 * You can also use custom attributes:
-	 *
-	 *		schema.setAttributeProperties( 'blockQuote', {
-	 *			customAttribute: 'value'
-	 *		} );
-	 *
-	 * Subsequent calls to the same attributes will add up the value:
-	 *
-	 *		schema.setAttributeProperties( 'blockQuote', {
-	 *			one: 1
-	 *		} );
-	 *
-	 *		schema.setAttributeProperties( 'blockQuote', {
-	 *			two: 2
-	 *		} );
-	 *
-	 *		console.log( schema.getAttributeProperties( 'blockQuote' ) );
-	 *		// Logs: {one: 1, two: 2}
-	 *
-	 * @param {String} attributeName Name of the attribute to receive properties.
-	 * @param {module:engine/model/schema~AttributeProperties} properties A dictionary of properties.
-	 */
-	setAttributeProperties( attributeName, properties ) {
-		this._attributeProperties[ attributeName ] = Object.assign( this._attributeProperties[ attributeName ] || {}, properties );
-	}
-
-	/**
-	 * Returns properties assigned to a given attribute.
-	 *
-	 * @param {String} attributeName Name of the attribute.
-	 * @returns {module:engine/model/schema~AttributeProperties}
-	 */
-	getAttributeProperties( attributeName ) {
-		return this._attributeProperties[ attributeName ];
-	}
-
-	/**
-	 * Returns all registered items.
-	 *
-	 * @returns {Object.<String,module:engine/model/schema~SchemaCompiledItemDefinition>}
-	 */
-	getDefinitions() {
-		if ( !this._compiledDefinitions ) {
-			this._compile();
-		}
-
-		return this._compiledDefinitions;
-	}
-
-	/**
 	 * Returns a definition of the given item or `undefined` if item is not registered.
 	 *
 	 * @param {module:engine/model/item~Item|module:engine/model/schema~SchemaContextItem|String} item
@@ -532,6 +468,70 @@ export default class Schema {
 				evt.return = retValue;
 			}
 		}, { priority: 'high' } );
+	}
+
+	/**
+	 * Registers custom properties to a given attribute.
+	 *
+	 * It can be used to mark the attributes relation and handle them in a common way.
+	 *
+	 *		// Mark blockQuote as a formatting attribute.
+	 *		schema.setAttributeProperties( 'blockQuote', {
+	 *			isFormatting: true
+	 *		} );
+	 *
+	 *		// Override code not to be considered a formatting markup.
+	 *		schema.setAttributeProperties( 'code', {
+	 *			isFormatting: false
+	 *		} );
+	 *
+	 * You can also use custom attributes:
+	 *
+	 *		schema.setAttributeProperties( 'blockQuote', {
+	 *			customAttribute: 'value'
+	 *		} );
+	 *
+	 * Subsequent calls to the same attributes will add up the value:
+	 *
+	 *		schema.setAttributeProperties( 'blockQuote', {
+	 *			one: 1
+	 *		} );
+	 *
+	 *		schema.setAttributeProperties( 'blockQuote', {
+	 *			two: 2
+	 *		} );
+	 *
+	 *		console.log( schema.getAttributeProperties( 'blockQuote' ) );
+	 *		// Logs: {one: 1, two: 2}
+	 *
+	 * @param {String} attributeName Name of the attribute to receive properties.
+	 * @param {module:engine/model/schema~AttributeProperties} properties A dictionary of properties.
+	 */
+	setAttributeProperties( attributeName, properties ) {
+		this._attributeProperties[ attributeName ] = Object.assign( this._attributeProperties[ attributeName ] || {}, properties );
+	}
+
+	/**
+	 * Returns properties assigned to a given attribute.
+	 *
+	 * @param {String} attributeName Name of the attribute.
+	 * @returns {module:engine/model/schema~AttributeProperties}
+	 */
+	getAttributeProperties( attributeName ) {
+		return this._attributeProperties[ attributeName ];
+	}
+
+	/**
+	 * Returns all registered items.
+	 *
+	 * @returns {Object.<String,module:engine/model/schema~SchemaCompiledItemDefinition>}
+	 */
+	getDefinitions() {
+		if ( !this._compiledDefinitions ) {
+			this._compile();
+		}
+
+		return this._compiledDefinitions;
 	}
 
 	/**

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -149,6 +149,19 @@ export default class Schema {
 	}
 
 	/**
+	 * Returns all registered items.
+	 *
+	 * @returns {Object.<String,module:engine/model/schema~SchemaCompiledItemDefinition>}
+	 */
+	getDefinitions() {
+		if ( !this._compiledDefinitions ) {
+			this._compile();
+		}
+
+		return this._compiledDefinitions;
+	}
+
+	/**
 	 * Returns a definition of the given item or `undefined` if item is not registered.
 	 *
 	 * @param {module:engine/model/item~Item|module:engine/model/schema~SchemaContextItem|String} item
@@ -519,19 +532,6 @@ export default class Schema {
 	 */
 	getAttributeProperties( attributeName ) {
 		return this._attributeProperties[ attributeName ];
-	}
-
-	/**
-	 * Returns all registered items.
-	 *
-	 * @returns {Object.<String,module:engine/model/schema~SchemaCompiledItemDefinition>}
-	 */
-	getDefinitions() {
-		if ( !this._compiledDefinitions ) {
-			this._compile();
-		}
-
-		return this._compiledDefinitions;
 	}
 
 	/**

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -40,10 +40,10 @@ export default class Schema {
 		this._sourceDefinitions = {};
 
 		/**
-		 * A map containing attribute's properties.
+		 * A dictionary containing attribute properties.
 		 *
 		 * @private
-		 * @member {Map.<String,String>}
+		 * @member {Object.<String,String>}
 		 */
 		this._attributeProperties = {};
 
@@ -471,12 +471,12 @@ export default class Schema {
 	}
 
 	/**
-	 * Registers custom properties to a given attribute.
+	 * This method allows assigning additional metadata to the model attributes. For example,
+	 * {@link module:engine/model/schema~AttributeProperties `AttributeProperties#isFormatting` property} is
+	 * used to mark formatting attributes (like `bold` or `italic`).
 	 *
-	 * It can be used to mark the attributes relation and handle them in a common way.
-	 *
-	 *		// Mark blockQuote as a formatting attribute.
-	 *		schema.setAttributeProperties( 'blockQuote', {
+	 *		// Mark bold as a formatting attribute.
+	 *		schema.setAttributeProperties( 'bold', {
 	 *			isFormatting: true
 	 *		} );
 	 *
@@ -485,13 +485,13 @@ export default class Schema {
 	 *			isFormatting: false
 	 *		} );
 	 *
-	 * You can also use custom attributes:
+	 * You can also use custom properties:
 	 *
 	 *		schema.setAttributeProperties( 'blockQuote', {
-	 *			customAttribute: 'value'
+	 *			customProperty: 'value'
 	 *		} );
 	 *
-	 * Subsequent calls to the same attributes will add up the value:
+	 * Subsequent calls with the same attribute will extend its custom properties:
 	 *
 	 *		schema.setAttributeProperties( 'blockQuote', {
 	 *			one: 1
@@ -502,19 +502,19 @@ export default class Schema {
 	 *		} );
 	 *
 	 *		console.log( schema.getAttributeProperties( 'blockQuote' ) );
-	 *		// Logs: {one: 1, two: 2}
+	 *		// Logs: { one: 1, two: 2 }
 	 *
-	 * @param {String} attributeName Name of the attribute to receive properties.
+	 * @param {String} attributeName A name of the attribute to receive the properties.
 	 * @param {module:engine/model/schema~AttributeProperties} properties A dictionary of properties.
 	 */
 	setAttributeProperties( attributeName, properties ) {
-		this._attributeProperties[ attributeName ] = Object.assign( this._attributeProperties[ attributeName ] || {}, properties );
+		this._attributeProperties[ attributeName ] = Object.assign( this.getAttributeProperties( attributeName ) || {}, properties );
 	}
 
 	/**
-	 * Returns properties assigned to a given attribute.
+	 * Returns properties associated with a given model attribute. See {@link #setAttributeProperties `setAttributeProperties()`}.
 	 *
-	 * @param {String} attributeName Name of the attribute.
+	 * @param {String} attributeName A name of the attribute.
 	 * @returns {module:engine/model/schema~AttributeProperties}
 	 */
 	getAttributeProperties( attributeName ) {
@@ -1350,7 +1350,8 @@ export class SchemaContext {
  * See {@link module:engine/model/schema~Schema#setAttributeProperties `Schema#setAttributeProperties()`} for usage examples.
  *
  * @typedef {Object} module:engine/model/schema~AttributeProperties
- * @property {Boolean} [isFormatting] Indicates that the attribute should be considered as a visual formatting.
+ * @property {Boolean} [isFormatting] Indicates that the attribute should be considered as a visual formatting, like `bold`, `italic` or
+ * `fontSize` rather than semantic attribute (such as `src`, `listType`, etc.). For example, it is used by the "Remove format" feature.
  */
 
 function compileBaseItemRule( sourceItemRules, itemName ) {

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -39,6 +39,14 @@ export default class Schema {
 	constructor() {
 		this._sourceDefinitions = {};
 
+		/**
+		 * A map containing attribute's properties.
+		 *
+		 * @private
+		 * @member {Map.<String,String>}
+		 */
+		this._attributeProperties = {};
+
 		this.decorate( 'checkChild' );
 		this.decorate( 'checkAttribute' );
 
@@ -138,6 +146,36 @@ export default class Schema {
 		this._sourceDefinitions[ itemName ].push( Object.assign( {}, definition ) );
 
 		this._clearCache();
+	}
+
+	/**
+	 * Registers custom properties to a given attribute.
+	 *
+	 *		// Mark blockQuote as a formatting attribute.
+	 *		schema.setAttributeProperties( 'blockQuote', {
+	 *			isFormatting: true
+	 *		} );
+	 *
+	 *		// Override code not to be considered a formatting markup.
+	 *		schema.setAttributeProperties( 'code', {
+	 *			isFormatting: false
+	 *		} );
+	 *
+	 * @param {String} attributeName Name of the attribute to receive properties.
+	 * @param {Map.<String,String>} properties Dictionary of properties.
+	 */
+	setAttributeProperties( attributeName, properties ) {
+		this._attributeProperties[ attributeName ] = Object.assign( this._attributeProperties[ attributeName ] || {}, properties );
+	}
+
+	/**
+	 * Returns properties assigned to a given attribute.
+	 *
+	 * @param {String} attributeName Name of the attribute.
+	 * @returns {Map.<String,String>}
+	 */
+	getAttributeProperties( attributeName ) {
+		return this._attributeProperties[ attributeName ];
 	}
 
 	/**

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -151,6 +151,8 @@ export default class Schema {
 	/**
 	 * Registers custom properties to a given attribute.
 	 *
+	 * It can be used to mark the attributes relation and handle them in a common way.
+	 *
 	 *		// Mark blockQuote as a formatting attribute.
 	 *		schema.setAttributeProperties( 'blockQuote', {
 	 *			isFormatting: true
@@ -161,8 +163,27 @@ export default class Schema {
 	 *			isFormatting: false
 	 *		} );
 	 *
+	 * You can also use custom attributes:
+	 *
+	 *		schema.setAttributeProperties( 'blockQuote', {
+	 *			customAttribute: 'value'
+	 *		} );
+	 *
+	 * Subsequent calls to the same attributes will add up the value:
+	 *
+	 *		schema.setAttributeProperties( 'blockQuote', {
+	 *			one: 1
+	 *		} );
+	 *
+	 *		schema.setAttributeProperties( 'blockQuote', {
+	 *			two: 2
+	 *		} );
+	 *
+	 *		console.log( schema.getAttributeProperties( 'blockQuote' ) );
+	 *		// Logs: {one: 1, two: 2}
+	 *
 	 * @param {String} attributeName Name of the attribute to receive properties.
-	 * @param {Map.<String,String>} properties Dictionary of properties.
+	 * @param {module:engine/model/schema~AttributeProperties} properties A dictionary of properties.
 	 */
 	setAttributeProperties( attributeName, properties ) {
 		this._attributeProperties[ attributeName ] = Object.assign( this._attributeProperties[ attributeName ] || {}, properties );
@@ -172,7 +193,7 @@ export default class Schema {
 	 * Returns properties assigned to a given attribute.
 	 *
 	 * @param {String} attributeName Name of the attribute.
-	 * @returns {Map.<String,String>}
+	 * @returns {module:engine/model/schema~AttributeProperties}
 	 */
 	getAttributeProperties( attributeName ) {
 		return this._attributeProperties[ attributeName ];
@@ -1321,6 +1342,15 @@ export class SchemaContext {
  *		} );
  *
  * @typedef {Object} module:engine/model/schema~SchemaContextItem
+ */
+
+/**
+ * A structure containing additional metadata describing the attribute.
+ *
+ * See {@link module:engine/schema~setAttributeProperties} for usage examples.
+ *
+ * @typedef {Object} module:engine/model/schema~AttributeProperties
+ * @property {Boolean} [isFormatting] Indicates that the attribute should be considered as a visual formatting.
  */
 
 function compileBaseItemRule( sourceItemRules, itemName ) {

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -1347,7 +1347,7 @@ export class SchemaContext {
 /**
  * A structure containing additional metadata describing the attribute.
  *
- * See {@link module:engine/schema~setAttributeProperties} for usage examples.
+ * See {@link module:engine/model/schema~Schema#setAttributeProperties `Schema#setAttributeProperties()`} for usage examples.
  *
  * @typedef {Object} module:engine/model/schema~AttributeProperties
  * @property {Boolean} [isFormatting] Indicates that the attribute should be considered as a visual formatting.

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -96,6 +96,49 @@ describe( 'Schema', () => {
 		} );
 	} );
 
+	describe( 'setAttributeProperties()', () => {
+		beforeEach( () => {
+			schema.register( '$root' );
+			schema.register( 'paragraph', {
+				allowIn: '$root'
+			} );
+			schema.register( '$text', {
+				allowIn: 'paragraph'
+			} );
+		} );
+
+		it( 'allows registering new properties', () => {
+			schema.extend( '$text', { allowAttributes: 'testAttribute' } );
+
+			schema.setAttributeProperties( 'testAttribute', {
+				foo: 'bar',
+				baz: 'bom'
+			} );
+
+			expect( schema.getAttributeProperties( 'testAttribute' ) ).to.deep.equal( {
+				foo: 'bar',
+				baz: 'bom'
+			} );
+		} );
+
+		it( 'support adding properties in subsequent calls', () => {
+			schema.extend( '$text', { allowAttributes: 'testAttribute' } );
+
+			schema.setAttributeProperties( 'testAttribute', {
+				first: 'foo'
+			} );
+
+			schema.setAttributeProperties( 'testAttribute', {
+				second: 'bar'
+			} );
+
+			expect( schema.getAttributeProperties( 'testAttribute' ) ).to.deep.equal( {
+				first: 'foo',
+				second: 'bar'
+			} );
+		} );
+	} );
+
 	describe( 'getDefinitions()', () => {
 		it( 'returns compiled definitions', () => {
 			schema.register( '$root' );

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -105,11 +105,10 @@ describe( 'Schema', () => {
 			schema.register( '$text', {
 				allowIn: 'paragraph'
 			} );
+			schema.extend( '$text', { allowAttributes: 'testAttribute' } );
 		} );
 
 		it( 'allows registering new properties', () => {
-			schema.extend( '$text', { allowAttributes: 'testAttribute' } );
-
 			schema.setAttributeProperties( 'testAttribute', {
 				foo: 'bar',
 				baz: 'bom'
@@ -122,8 +121,6 @@ describe( 'Schema', () => {
 		} );
 
 		it( 'support adding properties in subsequent calls', () => {
-			schema.extend( '$text', { allowAttributes: 'testAttribute' } );
-
 			schema.setAttributeProperties( 'testAttribute', {
 				first: 'foo'
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `schema#setAttributeProperties()` and `schema#getAttributeProperties()` methods. Closes ckeditor/ckeditor5#1659.

---

## Followups

- [ ] - implement it in our formatting plugins
	- [ ] - bold, italic, underline, strikethrough, code, subscript, superscript
	- [ ] - fontSize, fontFamily
	- [ ] - alignment
	- [ ] - highlight
- [ ] - integrate it with remove formatting plugin
- [ ] - integrate it in CKE5 inspector