### PR TITLE
allow upcast model key value to be function

### DIFF
--- a/src/conversion/upcasthelpers.js
+++ b/src/conversion/upcasthelpers.js
@@ -676,7 +676,7 @@ function prepareToAttributeConverter( config, shallow ) {
 			return;
 		}
 
-		const modelKey = config.model.key;
+		const modelKey = typeof config.model.key == 'function' ? config.model.key(data.viewItem) : config.model.key;
 		const modelValue = typeof config.model.value == 'function' ? config.model.value( data.viewItem ) : config.model.value;
 
 		// Do not convert if attribute building function returned falsy value.


### PR DESCRIPTION
Allow model key value in upcast (upcasthelpers.js) elementToAttribute to be function to set the value dynamically

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #000.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
