### PR TITLE
Prevent from throwing while updating empty fake selection container.

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -706,7 +706,7 @@ export default class Renderer {
 			} );
 
 			// Fill it with a text node so we can update it later.
-			container.appendChild( domDocument.createTextNode( '\u00A0' ) );
+			container.textContent = '\u00A0';
 		}
 
 		if ( !container.parentElement || container.parentElement != domRoot ) {
@@ -714,7 +714,7 @@ export default class Renderer {
 		}
 
 		// Update contents.
-		container.firstChild.data = this.selection.fakeSelectionLabel || '\u00A0';
+		container.textContent = this.selection.fakeSelectionLabel || '\u00A0';
 
 		// Update selection.
 		const domSelection = domDocument.getSelection();

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1958,6 +1958,31 @@ describe( 'Renderer', () => {
 				expect( bindSelection.isEqual( selection ) ).to.be.true;
 			} );
 
+			// https://github.com/ckeditor/ckeditor5-engine/issues/1714.
+			it( 'should handle situation when label got removed from the fake selection container', () => {
+				const label = 'fake selection label';
+				selection._setTo( selection.getRanges(), { fake: true, label } );
+				renderer.render();
+
+				expect( domRoot.childNodes.length ).to.equal( 2 );
+
+				const container = domRoot.childNodes[ 1 ];
+				expect( domConverter.mapDomToView( container ) ).to.be.undefined;
+				expect( container.childNodes.length ).to.equal( 1 );
+
+				const textNode = container.childNodes[ 0 ];
+				expect( textNode.textContent ).to.equal( label );
+
+				// Remove a text node (label) from the fake selection container.
+				// It can be done by pressing backspace while the delete command is disabled and selection is on the widget.
+				textNode.remove();
+
+				renderer.render();
+
+				const domSelection = domRoot.ownerDocument.getSelection();
+				assertDomSelectionContents( domSelection, container, /^fake selection label$/ );
+			} );
+
 			// Use a forgiving way of checking what the selection contains
 			// because Safari normalizes the selection ranges so precise checking is troublesome.
 			// Also, Edge returns a normal space instead of nbsp so we need to use even more alternatives.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevent from throwing while updating empty fake selection container. Closes https://github.com/ckeditor/ckeditor5-engine/issues/1714.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
