### PR TITLE
Make sure that schema#getAttributeProperties() always return an object

### DIFF
--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -532,7 +532,7 @@ export default class Schema {
 	 * @returns {module:engine/model/schema~AttributeProperties}
 	 */
 	getAttributeProperties( attributeName ) {
-		return this._attributeProperties[ attributeName ];
+		return this._attributeProperties[ attributeName ] || {};
 	}
 
 	/**

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -522,7 +522,7 @@ export default class Schema {
 	 * @param {module:engine/model/schema~AttributeProperties} properties A dictionary of properties.
 	 */
 	setAttributeProperties( attributeName, properties ) {
-		this._attributeProperties[ attributeName ] = Object.assign( this.getAttributeProperties( attributeName ) || {}, properties );
+		this._attributeProperties[ attributeName ] = Object.assign( this.getAttributeProperties( attributeName ), properties );
 	}
 
 	/**

--- a/tests/model/schema.js
+++ b/tests/model/schema.js
@@ -96,7 +96,7 @@ describe( 'Schema', () => {
 		} );
 	} );
 
-	describe( 'setAttributeProperties()', () => {
+	describe( 'attribute properties', () => {
 		beforeEach( () => {
 			schema.register( '$root' );
 			schema.register( 'paragraph', {
@@ -105,33 +105,45 @@ describe( 'Schema', () => {
 			schema.register( '$text', {
 				allowIn: 'paragraph'
 			} );
-			schema.extend( '$text', { allowAttributes: 'testAttribute' } );
+			schema.extend( '$text', { allowAttributes: [ 'testAttribute', 'noPropertiesAttribute' ] } );
 		} );
 
-		it( 'allows registering new properties', () => {
-			schema.setAttributeProperties( 'testAttribute', {
-				foo: 'bar',
-				baz: 'bom'
+		describe( 'setAttributeProperties()', () => {
+			it( 'allows registering new properties', () => {
+				schema.setAttributeProperties( 'testAttribute', {
+					foo: 'bar',
+					baz: 'bom'
+				} );
+
+				expect( schema.getAttributeProperties( 'testAttribute' ) ).to.deep.equal( {
+					foo: 'bar',
+					baz: 'bom'
+				} );
 			} );
 
-			expect( schema.getAttributeProperties( 'testAttribute' ) ).to.deep.equal( {
-				foo: 'bar',
-				baz: 'bom'
+			it( 'support adding properties in subsequent calls', () => {
+				schema.setAttributeProperties( 'testAttribute', {
+					first: 'foo'
+				} );
+
+				schema.setAttributeProperties( 'testAttribute', {
+					second: 'bar'
+				} );
+
+				expect( schema.getAttributeProperties( 'testAttribute' ) ).to.deep.equal( {
+					first: 'foo',
+					second: 'bar'
+				} );
 			} );
 		} );
 
-		it( 'support adding properties in subsequent calls', () => {
-			schema.setAttributeProperties( 'testAttribute', {
-				first: 'foo'
+		describe( 'getAttributeProperties()', () => {
+			it( 'it returns a proper value if the attribute has no properties', () => {
+				expect( schema.getAttributeProperties( 'noPropertiesAttribute' ) ).to.deep.equal( {} );
 			} );
 
-			schema.setAttributeProperties( 'testAttribute', {
-				second: 'bar'
-			} );
-
-			expect( schema.getAttributeProperties( 'testAttribute' ) ).to.deep.equal( {
-				first: 'foo',
-				second: 'bar'
+			it( 'it returns a proper value for unknown attribute', () => {
+				expect( schema.getAttributeProperties( 'unregistered-attribute' ) ).to.deep.equal( {} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Make sure that `schema#getAttributeProperties()` always return an object. Closes #1717.

---

### Additional information

This fixes a behavior that has not been officially released yet, so it might be reasonable to skip this in the changelog.

Without this there's a potential for making references to `undefined` value.