### PR TITLE
Fix: Prevented from losing selection attributes between operations - IME.

### DIFF
--- a/src/model/document.js
+++ b/src/model/document.js
@@ -396,6 +396,10 @@ export default class Document {
 			for ( const callback of this._postFixers ) {
 				// Ensure selection attributes are up to date before each post-fixer.
 				// https://github.com/ckeditor/ckeditor5-engine/issues/1673.
+				//
+				// It might be good to refresh the selection after each operation but at the moment it leads
+				// to losing attributes for composition or and spell checking
+				// https://github.com/ckeditor/ckeditor5-typing/issues/188
 				this.selection.refresh();
 
 				wasFixed = callback( writer );

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -307,14 +307,14 @@ export default class Document {
 		if ( this._hasDocumentChangedFromTheLastChangeBlock() ) {
 			this._callPostFixers( writer );
 
+			// Refresh selection attributes according to the final position in the model after the change.
+			this.selection.refreshAttributes();
+
 			if ( this.differ.hasDataChanges() ) {
 				this.fire( 'change:data', writer.batch );
 			} else {
 				this.fire( 'change', writer.batch );
 			}
-
-			// Refresh selection attributes according to the final position in the model after the change.
-			this.selection.refreshAttributes();
 
 			this.differ.reset();
 		}

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -313,6 +313,9 @@ export default class Document {
 				this.fire( 'change', writer.batch );
 			}
 
+			// Refresh selection attributes according to the final position in the model after the change.
+			this.selection.refreshAttributes();
+
 			this.differ.reset();
 		}
 
@@ -391,6 +394,10 @@ export default class Document {
 
 		do {
 			for ( const callback of this._postFixers ) {
+				// Ensure selection attributes are up to date before each post-fixer.
+				// https://github.com/ckeditor/ckeditor5-engine/issues/1673.
+				this.selection.refreshAttributes();
+
 				wasFixed = callback( writer );
 
 				if ( wasFixed ) {

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -308,7 +308,7 @@ export default class Document {
 			this._callPostFixers( writer );
 
 			// Refresh selection attributes according to the final position in the model after the change.
-			this.selection.refreshAttributes();
+			this.selection.refresh();
 
 			if ( this.differ.hasDataChanges() ) {
 				this.fire( 'change:data', writer.batch );
@@ -396,7 +396,7 @@ export default class Document {
 			for ( const callback of this._postFixers ) {
 				// Ensure selection attributes are up to date before each post-fixer.
 				// https://github.com/ckeditor/ckeditor5-engine/issues/1673.
-				this.selection.refreshAttributes();
+				this.selection.refresh();
 
 				wasFixed = callback( writer );
 

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -316,6 +316,10 @@ export default class Document {
 				this.fire( 'change', writer.batch );
 			}
 
+			// Theoretically, it is not necessary to refresh selection after change event because
+			// post-fixers are the last who should change the model, but just in case...
+			this.selection.refresh();
+
 			this.differ.reset();
 		}
 

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -360,6 +360,14 @@ export default class DocumentSelection {
 	}
 
 	/**
+	 * Refreshes selection attributes and markers according to the current position in the model.
+	 */
+	refreshAttributes() {
+		this._selection._updateMarkers();
+		this._selection._updateAttributes( false );
+	}
+
+	/**
 	 * Checks whether object is of given type following the convention set by
 	 * {@link module:engine/model/node~Node#is `Node#is()`}.
 	 *
@@ -598,32 +606,7 @@ class LiveSelection extends Selection {
 		// @type {Set}
 		this._overriddenGravityRegister = new Set();
 
-		// Ensure selection is correct and up to date after each range change.
-		this.on( 'change:range', () => {
-			for ( const range of this.getRanges() ) {
-				if ( !this._document._validateSelectionRange( range ) ) {
-					/**
-					 * Range from {@link module:engine/model/documentselection~DocumentSelection document selection}
-					 * starts or ends at incorrect position.
-					 *
-					 * @error document-selection-wrong-position
-					 * @param {module:engine/model/range~Range} range
-					 */
-					throw new CKEditorError(
-						'document-selection-wrong-position: Range from document selection starts or ends at incorrect position.',
-						{ range }
-					);
-				}
-			}
-
-			this._updateMarkers();
-			this._updateAttributes( false );
-		} );
-
-		// Update markers data stored by the selection after each marker change.
-		this.listenTo( this._model.markers, 'update', () => this._updateMarkers() );
-
-		// Ensure selection is correct and up to date after each operation.
+		// Ensure selection is correct after each operation.
 		this.listenTo( this._model, 'applyOperation', ( evt, args ) => {
 			const operation = args[ 0 ];
 
@@ -641,12 +624,31 @@ class LiveSelection extends Selection {
 				this._hasChangedRange = false;
 				this.fire( 'change:range', { directChange: false } );
 			}
-
-			this._updateMarkers();
-			this._updateAttributes( false );
 		}, { priority: 'lowest' } );
 
-		// Clear selection attributes from element if no longer empty.
+		// Ensure selection is correct and up to date after each range change.
+		this.on( 'change:range', () => {
+			for ( const range of this.getRanges() ) {
+				if ( !this._document._validateSelectionRange( range ) ) {
+					/**
+					 * Range from {@link module:engine/model/documentselection~DocumentSelection document selection}
+					 * starts or ends at incorrect position.
+					 *
+					 * @error document-selection-wrong-position
+					 * @param {module:engine/model/range~Range} range
+					 */
+					throw new CKEditorError(
+						'document-selection-wrong-position: Range from document selection starts or ends at incorrect position.',
+						{ range }
+					);
+				}
+			}
+		} );
+
+		// Update markers data stored by the selection after each marker change.
+		this.listenTo( this._model.markers, 'update', () => this._updateMarkers() );
+
+		// Ensure selection is up to date after each change block.
 		this.listenTo( this._document, 'change', ( evt, batch ) => {
 			clearAttributesStoredInElement( this._model, batch );
 		} );
@@ -715,12 +717,12 @@ class LiveSelection extends Selection {
 
 	setTo( selectable, optionsOrPlaceOrOffset, options ) {
 		super.setTo( selectable, optionsOrPlaceOrOffset, options );
-		this._refreshAttributes();
+		this._updateAttributes( true );
 	}
 
 	setFocus( itemOrPosition, offset ) {
 		super.setFocus( itemOrPosition, offset );
-		this._refreshAttributes();
+		this._updateAttributes( true );
 	}
 
 	setAttribute( key, value ) {
@@ -747,7 +749,7 @@ class LiveSelection extends Selection {
 		this._overriddenGravityRegister.add( overrideUid );
 
 		if ( this._overriddenGravityRegister.size === 1 ) {
-			this._refreshAttributes();
+			this._updateAttributes( true );
 		}
 
 		return overrideUid;
@@ -773,13 +775,8 @@ class LiveSelection extends Selection {
 
 		// Restore gravity only when all overriding have been restored.
 		if ( !this.isGravityOverridden ) {
-			this._refreshAttributes();
+			this._updateAttributes( true );
 		}
-	}
-
-	// Removes all attributes from the selection and sets attributes according to the surrounding nodes.
-	_refreshAttributes() {
-		this._updateAttributes( true );
 	}
 
 	_popRange() {

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -362,7 +362,7 @@ export default class DocumentSelection {
 	/**
 	 * Refreshes selection attributes and markers according to the current position in the model.
 	 */
-	refreshAttributes() {
+	refresh() {
 		this._selection._updateMarkers();
 		this._selection._updateAttributes( false );
 	}

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -1205,10 +1205,16 @@ describe( 'DocumentSelection', () => {
 			} );
 		} );
 
-		it( 'should be up to date after post fixers', () => {
+		it( 'should be up to date after post fixers (on `change` event)', done => {
 			model.schema.extend( '$text', { allowAttributes: 'foo' } );
 
 			const p = doc.getRoot().getChild( 0 );
+
+			doc.on( 'change', () => {
+				expect( model.document.selection.getAttribute( 'foo' ) ).to.equal( 'biz' );
+				expect( Array.from( model.document.selection.markers, m => m.name ) ).to.deep.equal( [ 'marker-2' ] );
+				done();
+			} );
 
 			doc.registerPostFixer( writer => {
 				writer.setAttribute( 'foo', 'biz', p.getChild( 0 ) );
@@ -1235,9 +1241,6 @@ describe( 'DocumentSelection', () => {
 
 				writer.setSelection( writer.createPositionFromPath( p, [ 3 ] ) );
 			} );
-
-			expect( model.document.selection.getAttribute( 'foo' ) ).to.equal( 'biz' );
-			expect( Array.from( model.document.selection.markers, m => m.name ) ).to.deep.equal( [ 'marker-2' ] );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevented from losing selection attributes between operations - IME. Closes https://github.com/ckeditor/ckeditor5-typing/issues/188.

---

### Additional information

Related https://github.com/ckeditor/ckeditor5-typing/pull/189.
