### PR TITLE
Correct moving selection during invalid copy-paste

### DIFF
--- a/src/model/utils/insertcontent.js
+++ b/src/model/utils/insertcontent.js
@@ -562,7 +562,7 @@ class Insertion {
 
 				// Special case – parent is empty (<p>^</p>).
 				// We can remove the element after moving insertion position out of it.
-				if ( parent.isEmpty ) {
+				if ( parent.isEmpty && parent.parent === allowedIn ) {
 					this.writer.remove( parent );
 				}
 			} else if ( this.position.isAtEnd ) {

--- a/src/model/utils/insertcontent.js
+++ b/src/model/utils/insertcontent.js
@@ -561,7 +561,14 @@ class Insertion {
 				this.position = this.writer.createPositionBefore( parent );
 
 				// Special case – parent is empty (<p>^</p>).
+				//
+				// 1. parent.isEmpty
 				// We can remove the element after moving insertion position out of it.
+				//
+				// 2. parent.parent === allowedIn
+				// However parent should remain in place when allowed element is above limit element in document tree.
+				// For example there shouldn't be allowed to remove empty paragraph from tableCell, when is pasted
+				// content allowed in $root.
 				if ( parent.isEmpty && parent.parent === allowedIn ) {
 					this.writer.remove( parent );
 				}

--- a/tests/model/utils/insertcontent.js
+++ b/tests/model/utils/insertcontent.js
@@ -1255,7 +1255,7 @@ describe( 'DataController utils', () => {
 			expect( stringify( root, affectedRange ) ).to.equal( '<limit>[ab]foo</limit>' );
 		} );
 
-		describe( 'when allowed elements is somewhere above limit', () => {
+		describe( 'when allowed element is above limit element in document tree', () => {
 			// $root > table > tableRow > tableCell > paragraph
 			// After inserting new table ( allowed in root ), empty paragraph shouldn't be removed from current tableCell.
 			beforeEach( () => {

--- a/tests/model/utils/insertcontent.js
+++ b/tests/model/utils/insertcontent.js
@@ -1254,6 +1254,43 @@ describe( 'DataController utils', () => {
 			expect( getData( model ) ).to.equal( '<limit>ab[]foo</limit>' );
 			expect( stringify( root, affectedRange ) ).to.equal( '<limit>[ab]foo</limit>' );
 		} );
+
+		describe( 'when allowed elements is somewhere above limit', () => {
+			// $root > table > tableRow > tableCell > paragraph
+			// After inserting new table ( allowed in root ), empty paragraph shouldn't be removed from current tableCell.
+			beforeEach( () => {
+				const schema = model.schema;
+
+				schema.register( 'wrapper', {
+					isLimit: true,
+					isBlock: true,
+					isObject: true,
+					allowWhere: '$block'
+				} );
+
+				schema.extend( 'paragraph', { allowIn: 'limit' } );
+				schema.extend( 'limit', { allowIn: 'wrapper' } );
+			} );
+
+			it( 'should not remove empty elements when not-allowed element is paste', () => {
+				setData( model, '<wrapper><limit><paragraph>[]</paragraph></limit></wrapper>' );
+
+				// pasted content is forbidden in current selection
+				const affectedRange = insertHelper( '<wrapper><limit><paragraph>foo</paragraph></limit></wrapper>' );
+
+				expect( getData( model ) ).to.equal( '<wrapper><limit>[]<paragraph></paragraph></limit></wrapper>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<wrapper><limit><paragraph>[]</paragraph></limit></wrapper>' );
+			} );
+
+			it( 'should correctly paste allowed nodes', () => {
+				setData( model, '<wrapper><limit><paragraph>[]</paragraph></limit></wrapper>' );
+
+				const affectedRange = insertHelper( '<paragraph>foo</paragraph>' );
+
+				expect( getData( model ) ).to.equal( '<wrapper><limit><paragraph>foo</paragraph>[]</limit></wrapper>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<wrapper><limit>[<paragraph>foo</paragraph>]</limit></wrapper>' );
+			} );
+		} );
 	} );
 
 	// Helper function that parses given content and inserts it at the cursor position.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Moving selection during forbidden copy-paste operation (pasting table into empty table cell). Closes ckeditor/ckeditor5#1380.
