### PR TITLE
Fix `Writer` error

### DIFF
--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -177,8 +177,16 @@ export default class Writer {
 			// If it isn't the same root.
 			else {
 				if ( item.root.document ) {
-					// It is forbidden to move a node that was already in a document outside of it.
-					throw new Error( 'model-writer-insert-forbidden-move: Cannot move a node from a document to a different tree.' );
+					/**
+					 * Cannot move a node from a document to a different tree.
+					 * It is forbidden to move a node that was already in a document outside of it.
+					 *
+					 * @error model-writer-insert-forbidden-move
+					 */
+					throw new CKEditorError(
+						'model-writer-insert-forbidden-move: ' +
+						'Cannot move a node from a document to a different tree. ' +
+						'It is forbidden to move a node that was already in a document outside of it.' );
 				} else {
 					// Move between two different document fragments or from document fragment to a document is possible.
 					// In that case, remove the item from it's original parent.

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -302,7 +302,7 @@ describe( 'Writer', () => {
 
 			expect( () => {
 				insert( node, docFrag );
-			} ).to.throw();
+			} ).to.throw( CKEditorError, /^model-writer-insert-forbidden-mode/ );
 		} );
 
 		it( 'should transfer markers from given DocumentFragment', () => {
@@ -716,7 +716,7 @@ describe( 'Writer', () => {
 
 			expect( () => {
 				append( node, docFrag );
-			} ).to.throw();
+			} ).to.throw( CKEditorError, /^model-writer-insert-forbidden-mode/ );
 		} );
 	} );
 

--- a/tests/model/writer.js
+++ b/tests/model/writer.js
@@ -302,7 +302,7 @@ describe( 'Writer', () => {
 
 			expect( () => {
 				insert( node, docFrag );
-			} ).to.throw( CKEditorError, /^model-writer-insert-forbidden-mode/ );
+			} ).to.throw( CKEditorError, /^model-writer-insert-forbidden-move/ );
 		} );
 
 		it( 'should transfer markers from given DocumentFragment', () => {
@@ -716,7 +716,7 @@ describe( 'Writer', () => {
 
 			expect( () => {
 				append( node, docFrag );
-			} ).to.throw( CKEditorError, /^model-writer-insert-forbidden-mode/ );
+			} ).to.throw( CKEditorError, /^model-writer-insert-forbidden-move/ );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed `Writer` `model-writer-insert-forbidden-move` error usage. Closes #1743.

---

### Additional information

Test is missing.
