### PR TITLE
Return original operations map in transformSets

### DIFF
--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -390,6 +390,13 @@ class ContextFactory {
 	// @param {Boolean} [forceWeakRemove=false] If set to `false`, remove operation will be always stronger than move operation,
 	// so the removed nodes won't end up back in the document root. When set to `true`, context data will be used.
 	constructor( document, useRelations, forceWeakRemove = false ) {
+		// For each operation that is created during transformation process, we keep a reference to the original operation
+		// which it comes from. The original operation works as a kind of "identifier". Every contextual information
+		// gathered during transformation that we want to save for given operation, is actually saved for the original operation.
+		// This way no matter if operation `a` is cloned, then transformed, even breaks, we still have access to the previously
+		// gathered data through original operation reference.
+		this.originalOperations = new Map();
+
 		// `model.History` instance which information about undone operations will be taken from.
 		this._history = document.history;
 
@@ -397,13 +404,6 @@ class ContextFactory {
 		this._useRelations = useRelations;
 
 		this._forceWeakRemove = !!forceWeakRemove;
-
-		// For each operation that is created during transformation process, we keep a reference to the original operation
-		// which it comes from. The original operation works as a kind of "identifier". Every contextual information
-		// gathered during transformation that we want to save for given operation, is actually saved for the original operation.
-		// This way no matter if operation `a` is cloned, then transformed, even breaks, we still have access to the previously
-		// gathered data through original operation reference.
-		this.originalOperations = new Map();
 
 		// Relations is a double-map structure (maps in map) where for two operations we store how those operations were related
 		// to each other. Those relations are evaluated during transformation process. For every transformated pair of operations

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -158,9 +158,8 @@ export function transformSets( operationsA, operationsB, options ) {
 	// If one of sets is empty there is simply nothing to transform, so return sets as they are.
 	if ( operationsA.length == 0 || operationsB.length == 0 ) {
 		const originalOperations = new Map();
-		const receivedOperations = operationsA.concat( operationsB );
 
-		for ( const operation of receivedOperations ) {
+		for ( const operation of operationsA.concat( operationsB ) ) {
 			originalOperations.set( operation, operation );
 		}
 

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -155,9 +155,18 @@ export function transformSets( operationsA, operationsB, options ) {
 	operationsA = operationsA.slice();
 	operationsB = operationsB.slice();
 
+	const originalOperations = new Map();
+	const receivedOperations = operationsA.concat( operationsB );
+
+	for ( const operation of receivedOperations ) {
+		const originalOperation = this._originalOperations.get( operation );
+
+		originalOperations.set( operation, originalOperation );
+	}
+
 	// If one of sets is empty there is simply nothing to transform, so return sets as they are.
 	if ( operationsA.length == 0 || operationsB.length == 0 ) {
-		return { operationsA, operationsB };
+		return { operationsA, operationsB, originalOperations };
 	}
 	//
 	// Following is a description of transformation process:
@@ -374,7 +383,7 @@ export function transformSets( operationsA, operationsB, options ) {
 	updateBaseVersions( operationsA, data.nextBaseVersionB );
 	updateBaseVersions( operationsB, data.nextBaseVersionA );
 
-	return { operationsA, operationsB };
+	return { operationsA, operationsB, originalOperations };
 }
 
 // Gathers additional data about operations processed during transformation. Can be used to obtain contextual information

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -148,6 +148,8 @@ export function transform( a, b, context = {} ) {
  * @returns {Object} Transformation result.
  * @returns {Array.<module:engine/model/operation/operation~Operation>} return.operationsA Transformed `operationsA`.
  * @returns {Array.<module:engine/model/operation/operation~Operation>} return.operationsB Transformed `operationsB`.
+ * @returns {Map} return.originalOperations A map that links transformed operations to original operations. The keys are the transformed
+ * operations and the values are the original operations from the input (`operationsA` and `operationsB`).
  */
 export function transformSets( operationsA, operationsB, options ) {
 	// Create new arrays so the originally passed arguments are not changed.

--- a/src/model/operation/transform.js
+++ b/src/model/operation/transform.js
@@ -155,14 +155,14 @@ export function transformSets( operationsA, operationsB, options ) {
 	operationsA = operationsA.slice();
 	operationsB = operationsB.slice();
 
+	const contextFactory = new ContextFactory( options.document, options.useRelations, options.forceWeakRemove );
+	contextFactory.setOriginalOperations( operationsA );
+	contextFactory.setOriginalOperations( operationsB );
+
+	const originalOperations = contextFactory.originalOperations;
+
 	// If one of sets is empty there is simply nothing to transform, so return sets as they are.
 	if ( operationsA.length == 0 || operationsB.length == 0 ) {
-		const originalOperations = new Map();
-
-		for ( const operation of operationsA.concat( operationsB ) ) {
-			originalOperations.set( operation, operation );
-		}
-
 		return { operationsA, operationsB, originalOperations };
 	}
 	//
@@ -311,10 +311,6 @@ export function transformSets( operationsA, operationsB, options ) {
 		originalOperationsBCount: operationsB.length
 	};
 
-	const contextFactory = new ContextFactory( options.document, options.useRelations, options.forceWeakRemove );
-	contextFactory.setOriginalOperations( operationsA );
-	contextFactory.setOriginalOperations( operationsB );
-
 	// Index of currently transformed operation `a`.
 	let i = 0;
 
@@ -375,8 +371,6 @@ export function transformSets( operationsA, operationsB, options ) {
 		padWithNoOps( operationsA, brokenOperationsBCount - brokenOperationsACount );
 		padWithNoOps( operationsB, brokenOperationsACount - brokenOperationsBCount );
 	}
-
-	const originalOperations = contextFactory.originalOperations;
 
 	// Finally, update base versions of transformed operations.
 	updateBaseVersions( operationsA, data.nextBaseVersionB );

--- a/tests/model/operation/transform.js
+++ b/tests/model/operation/transform.js
@@ -4,6 +4,7 @@
  */
 
 import { transform } from '../../../src/model/operation/transform';
+import { transformSets } from '@ckeditor/ckeditor5-engine/src/model/operation/transform';
 
 import Model from '../../../src/model/model';
 import RootElement from '../../../src/model/rootelement';
@@ -2605,5 +2606,71 @@ describe( 'transform', () => {
 				expectOperation( transOp[ 0 ], expected );
 			} );
 		} );
+	} );
+} );
+
+describe( 'transformSets', () => {
+	let model, doc, root, node;
+
+	beforeEach( () => {
+		model = new Model();
+		doc = model.document;
+		root = doc.createRoot();
+
+		node = new Node();
+	} );
+
+	it( 'originalOperations should correctly link transformed operations with original operations #1', () => {
+		const position = new Position( root, [ 0 ] );
+
+		const a = new InsertOperation( position, [ node ], 0 );
+
+		const { operationsA, originalOperations } = transformSets( [ a ], [], {
+			document: doc,
+			useRelations: false,
+			padWithNoOps: false
+		} );
+
+		expect( originalOperations.get( operationsA[ 0 ] ) ).to.equal( a );
+	} );
+
+	it( 'originalOperations should correctly link transformed operations with original operations #2', () => {
+		const position = new Position( root, [ 0 ] );
+
+		const b = new InsertOperation( position, [ node ], 0 );
+
+		const { operationsB, originalOperations } = transformSets( [], [ b ], {
+			document: doc,
+			useRelations: false,
+			padWithNoOps: false
+		} );
+
+		expect( originalOperations.get( operationsB[ 0 ] ) ).to.equal( b );
+	} );
+
+	it( 'originalOperations should correctly link transformed operations with original operations #3', () => {
+		const position = new Position( root, [ 4 ] );
+
+		const a = new InsertOperation( position, [ node ], 0 );
+		const b = new AttributeOperation(
+			new Range(
+				new Position( root, [ 2 ] ),
+				new Position( root, [ 11 ] )
+			),
+			'foo',
+			'bar',
+			'xyz',
+			0
+		);
+
+		const { operationsA, operationsB, originalOperations } = transformSets( [ a ], [ b ], {
+			document: doc,
+			useRelations: false,
+			padWithNoOps: false
+		} );
+
+		expect( originalOperations.get( operationsA[ 0 ] ) ).to.equal( a );
+		expect( originalOperations.get( operationsB[ 0 ] ) ).to.equal( b );
+		expect( originalOperations.get( operationsB[ 1 ] ) ).to.equal( b );
 	} );
 } );

--- a/tests/model/operation/transform.js
+++ b/tests/model/operation/transform.js
@@ -3,8 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import { transform } from '../../../src/model/operation/transform';
-import { transformSets } from '@ckeditor/ckeditor5-engine/src/model/operation/transform';
+import { transform, transformSets } from '../../../src/model/operation/transform';
 
 import Model from '../../../src/model/model';
 import RootElement from '../../../src/model/rootelement';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Return original operations map in transformSets. Closes #1767 .

---

### Additional information

Related tickets: 
https://github.com/cksource/cloud-features/issues/2753
https://github.com/cksource/ckeditor5-real-time-collaboration/pull/363
