### PR TITLE
T/ckeditor5 widget/95: Remove the getTopMostBlocks() method

### DIFF
--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -233,14 +233,14 @@ export default class DocumentSelection {
 	}
 
 	/**
-	 * Gets elements of type "block" touched by the selection.
+	 * Gets elements of type {@link module:engine/model/schema~Schema#isBlock "block"} touched by the selection.
 	 *
 	 * This method's result can be used for example to apply block styling to all blocks covered by this selection.
 	 *
 	 * **Note:** `getSelectedBlocks()` returns blocks that are nested in other non-block elements
 	 * but will not return blocks nested in other blocks.
 	 *
-	 * In this case the function will return exactly all 3 paragraphs:
+	 * In this case the function will return exactly all 3 paragraphs (note: `<blockQuote>` is not a block itself):
 	 *
 	 *		<paragraph>[a</paragraph>
 	 *		<blockQuote>
@@ -252,7 +252,7 @@ export default class DocumentSelection {
 	 *
 	 *		<paragraph>[]a</paragraph>
 	 *
-	 *	In such scenario however, only blocks A, B & E will be returned as blocks C & D are nested in block B:
+	 * In such a scenario, however, only blocks A, B & E will be returned as blocks C & D are nested in block B:
 	 *
 	 *		[<blockA></blockA>
 	 *		<blockB>
@@ -261,7 +261,7 @@ export default class DocumentSelection {
 	 *		</blockB>
 	 *		<blockE></blockE>]
 	 *
-	 *	If the selection is inside a block all the inner blocks (A & B) are returned:
+	 * If the selection is inside a block all the inner blocks (A & B) are returned:
 	 *
 	 * 		<block>
 	 *			<blockA>[a</blockA>

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -233,9 +233,26 @@ export default class DocumentSelection {
 	}
 
 	/**
-	 * Returns blocks that aren't nested in other selected blocks.
+	 * Gets elements of type "block" touched by the selection.
 	 *
-	 * In this case the method will return blocks A, B and E because C & D are children of block B:
+	 * This method's result can be used for example to apply block styling to all blocks covered by this selection.
+	 *
+	 * **Note:** `getSelectedBlocks()` returns blocks that are nested in other non-block elements
+	 * but will not return blocks nested in other blocks.
+	 *
+	 * In this case the function will return exactly all 3 paragraphs:
+	 *
+	 *		<paragraph>[a</paragraph>
+	 *		<quote>
+	 *			<paragraph>b</paragraph>
+	 *		</quote>
+	 *		<paragraph>c]d</paragraph>
+	 *
+	 * In this case the paragraph will also be returned, despite the collapsed selection:
+	 *
+	 *		<paragraph>[]a</paragraph>
+	 *
+	 *	In such scenario however, only blocks A, B & E will be returned:
 	 *
 	 *		[<blockA></blockA>
 	 *		<blockB>
@@ -244,7 +261,12 @@ export default class DocumentSelection {
 	 *		</blockB>
 	 *		<blockE></blockE>]
 	 *
-	 * **Note:** To get all selected blocks use {@link #getSelectedBlocks `getSelectedBlocks()`}.
+	 * **Special case**: If a selection ends at the beginning of a block, that block is not returned as from user perspective
+	 * this block wasn't selected. See [#984](https://github.com/ckeditor/ckeditor5-engine/issues/984) for more details.
+	 *
+	 *		<paragraph>[a</paragraph>
+	 *		<paragraph>b</paragraph>
+	 *		<paragraph>]c</paragraph> // this block will not be returned
 	 *
 	 * @returns {Iterable.<module:engine/model/element~Element>}
 	 */

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -243,16 +243,16 @@ export default class DocumentSelection {
 	 * In this case the function will return exactly all 3 paragraphs:
 	 *
 	 *		<paragraph>[a</paragraph>
-	 *		<quote>
+	 *		<blockQuote>
 	 *			<paragraph>b</paragraph>
-	 *		</quote>
+	 *		</blockQuote>
 	 *		<paragraph>c]d</paragraph>
 	 *
 	 * In this case the paragraph will also be returned, despite the collapsed selection:
 	 *
 	 *		<paragraph>[]a</paragraph>
 	 *
-	 *	In such scenario however, only blocks A, B & E will be returned:
+	 *	In such scenario however, only blocks A, B & E will be returned as blocks C & D are nested in block B:
 	 *
 	 *		[<blockA></blockA>
 	 *		<blockB>
@@ -260,6 +260,13 @@ export default class DocumentSelection {
 	 *			<blockD></blockD>
 	 *		</blockB>
 	 *		<blockE></blockE>]
+	 *
+	 *	If the selection is inside a block all the inner blocks (A & B) are returned:
+	 *
+	 * 		<block>
+	 *			<blockA>[a</blockA>
+	 * 			<blockB>b]</blockB>
+	 * 		</block>
 	 *
 	 * **Special case**: If a selection ends at the beginning of a block, that block is not returned as from user perspective
 	 * this block wasn't selected. See [#984](https://github.com/ckeditor/ckeditor5-engine/issues/984) for more details.

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -277,8 +277,8 @@ export default class DocumentSelection {
 	 *
 	 * @returns {Iterable.<module:engine/model/element~Element>}
 	 */
-	getSelectedBlocks( config ) {
-		return this._selection.getSelectedBlocks( config );
+	getSelectedBlocks() {
+		return this._selection.getSelectedBlocks();
 	}
 
 	/**

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -233,38 +233,6 @@ export default class DocumentSelection {
 	}
 
 	/**
-	 * Gets elements of type "block" touched by the selection.
-	 *
-	 * This method's result can be used for example to apply block styling to all blocks covered by this selection.
-	 *
-	 * **Note:** `getSelectedBlocks()` always returns the deepest block.
-	 *
-	 * In this case the function will return exactly all 3 paragraphs:
-	 *
-	 *		<paragraph>[a</paragraph>
-	 *		<quote>
-	 *			<paragraph>b</paragraph>
-	 *		</quote>
-	 *		<paragraph>c]d</paragraph>
-	 *
-	 * In this case the paragraph will also be returned, despite the collapsed selection:
-	 *
-	 *		<paragraph>[]a</paragraph>
-	 *
-	 * **Special case**: If a selection ends at the beginning of a block, that block is not returned as from user perspective
-	 * this block wasn't selected. See [#984](https://github.com/ckeditor/ckeditor5-engine/issues/984) for more details.
-	 *
-	 *		<paragraph>[a</paragraph>
-	 *		<paragraph>b</paragraph>
-	 *		<paragraph>]c</paragraph> // this block will not be returned
-	 *
-	 * @returns {Iterable.<module:engine/model/element~Element>}
-	 */
-	getSelectedBlocks() {
-		return this._selection.getSelectedBlocks();
-	}
-
-	/**
 	 * Returns blocks that aren't nested in other selected blocks.
 	 *
 	 * In this case the method will return blocks A, B and E because C & D are children of block B:
@@ -280,8 +248,8 @@ export default class DocumentSelection {
 	 *
 	 * @returns {Iterable.<module:engine/model/element~Element>}
 	 */
-	getTopMostBlocks() {
-		return this._selection.getTopMostBlocks();
+	getSelectedBlocks( config ) {
+		return this._selection.getSelectedBlocks( config );
 	}
 
 	/**

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -641,14 +641,14 @@ export default class Selection {
 	}
 
 	/**
-	 * Gets elements of type "block" touched by the selection.
+	 * Gets elements of type {@link module:engine/model/schema~Schema#isBlock "block"} touched by the selection.
 	 *
 	 * This method's result can be used for example to apply block styling to all blocks covered by this selection.
 	 *
 	 * **Note:** `getSelectedBlocks()` returns blocks that are nested in other non-block elements
 	 * but will not return blocks nested in other blocks.
 	 *
-	 * In this case the function will return exactly all 3 paragraphs:
+	 * In this case the function will return exactly all 3 paragraphs (note: `<blockQuote>` is not a block itself):
 	 *
 	 *		<paragraph>[a</paragraph>
 	 *		<blockQuote>
@@ -660,7 +660,7 @@ export default class Selection {
 	 *
 	 *		<paragraph>[]a</paragraph>
 	 *
-	 *	In such scenario however, only blocks A, B & E will be returned as blocks C & D are nested in block B:
+	 * In such a scenario, however, only blocks A, B & E will be returned as blocks C & D are nested in block B:
 	 *
 	 *		[<blockA></blockA>
 	 *		<blockB>
@@ -669,7 +669,7 @@ export default class Selection {
 	 *		</blockB>
 	 *		<blockE></blockE>]
 	 *
-	 *	If the selection is inside a block all the inner blocks (A & B) are returned:
+	 * If the selection is inside a block all the inner blocks (A & B) are returned:
 	 *
 	 * 		<block>
 	 *			<blockA>[a</blockA>

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -667,7 +667,7 @@ export default class Selection {
 	 *
 	 * @returns {Iterable.<module:engine/model/element~Element>}
 	 */
-	* getSelectedBlocks() {
+	* getBlocks() {
 		const visited = new WeakSet();
 
 		for ( const range of this.getRanges() ) {
@@ -708,14 +708,15 @@ export default class Selection {
 	 *
 	 * @returns {Iterable.<module:engine/model/element~Element>}
 	 */
-	* getTopMostBlocks() {
-		const selected = Array.from( this.getSelectedBlocks() );
+	* getSelectedBlocks( config = { deep: false } ) {
+		const selected = Array.from( this.getBlocks() );
+		const { deep } = config;
 
 		for ( const block of selected ) {
 			const parentBlock = findAncestorBlock( block );
 
 			// Filter out blocks that are nested in other selected blocks (like paragraphs in tables).
-			if ( !parentBlock || !selected.includes( parentBlock ) ) {
+			if ( deep || ( !parentBlock || !selected.includes( parentBlock ) ) ) {
 				yield block;
 			}
 		}

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -644,7 +644,8 @@ export default class Selection {
 	 *
 	 * This method's result can be used for example to apply block styling to all blocks covered by this selection.
 	 *
-	 * **Note:** `getSelectedBlocks()` always returns the deepest block.
+	 * **Note:** `getSelectedBlocks()` returns blocks that are nested in other non-block elements
+	 * but will not return blocks nested in other blocks.
 	 *
 	 * In this case the function will return exactly all 3 paragraphs:
 	 *
@@ -657,6 +658,15 @@ export default class Selection {
 	 * In this case the paragraph will also be returned, despite the collapsed selection:
 	 *
 	 *		<paragraph>[]a</paragraph>
+	 *
+	 *	In such scenario however, only blocks A, B & E will be returned:
+	 *
+	 *		[<blockA></blockA>
+	 *		<blockB>
+	 *			<blockC></blockC>
+	 *			<blockD></blockD>
+	 *		</blockB>
+	 *		<blockE></blockE>]
 	 *
 	 * **Special case**: If a selection ends at the beginning of a block, that block is not returned as from user perspective
 	 * this block wasn't selected. See [#984](https://github.com/ckeditor/ckeditor5-engine/issues/984) for more details.
@@ -693,23 +703,6 @@ export default class Selection {
 			}
 		}
 	}
-
-	/**
-	 * Returns blocks that aren't nested in other selected blocks.
-	 *
-	 * In this case the method will return blocks A, B and E because C & D are children of block B:
-	 *
-	 *		[<blockA></blockA>
-	 *		<blockB>
-	 *			<blockC></blockC>
-	 *			<blockD></blockD>
-	 *		</blockB>
-	 *		<blockE></blockE>]
-	 *
-	 * **Note:** To get all selected blocks use {@link #getSelectedBlocks `getSelectedBlocks()`}.
-	 *
-	 * @returns {Iterable.<module:engine/model/element~Element>}
-	 */
 
 	/**
 	 * Checks whether the selection contains the entire content of the given element. This means that selection must start

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -650,16 +650,16 @@ export default class Selection {
 	 * In this case the function will return exactly all 3 paragraphs:
 	 *
 	 *		<paragraph>[a</paragraph>
-	 *		<quote>
+	 *		<blockQuote>
 	 *			<paragraph>b</paragraph>
-	 *		</quote>
+	 *		</blockQuote>
 	 *		<paragraph>c]d</paragraph>
 	 *
 	 * In this case the paragraph will also be returned, despite the collapsed selection:
 	 *
 	 *		<paragraph>[]a</paragraph>
 	 *
-	 *	In such scenario however, only blocks A, B & E will be returned:
+	 *	In such scenario however, only blocks A, B & E will be returned as blocks C & D are nested in block B:
 	 *
 	 *		[<blockA></blockA>
 	 *		<blockB>
@@ -667,6 +667,13 @@ export default class Selection {
 	 *			<blockD></blockD>
 	 *		</blockB>
 	 *		<blockE></blockE>]
+	 *
+	 *	If the selection is inside a block all the inner blocks (A & B) are returned:
+	 *
+	 * 		<block>
+	 *			<blockA>[a</blockA>
+	 * 			<blockB>b]</blockB>
+	 * 		</block>
 	 *
 	 * **Special case**: If a selection ends at the beginning of a block, that block is not returned as from user perspective
 	 * this block wasn't selected. See [#984](https://github.com/ckeditor/ckeditor5-engine/issues/984) for more details.
@@ -681,6 +688,7 @@ export default class Selection {
 		const visited = new WeakSet();
 
 		for ( const range of this.getRanges() ) {
+			// Get start block of range in case of a collapsed range.
 			const startBlock = getParentBlock( range.start, visited );
 
 			if ( startBlock && isTopBlockInRange( startBlock, range ) ) {

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -904,5 +904,8 @@ function checkBlock( block, range ) {
 	}
 
 	// Check if element is nested in other block from a range.
-	return !range.containsRange( Range._createOn( parent ) );
+	const parentRange = Range._createOn( parent );
+	const isParentSomething = !( range.containsRange( parentRange ) || range.isEqual( parentRange ) );
+
+	return isParentSomething;
 }

--- a/src/view/downcastwriter.js
+++ b/src/view/downcastwriter.js
@@ -788,26 +788,26 @@ export default class DowncastWriter {
 	}
 
 	/**
-     * Wraps elements within range with provided {@link module:engine/view/attributeelement~AttributeElement AttributeElement}.
-     * If a collapsed range is provided, it will be wrapped only if it is equal to view selection.
-     *
-     * If a collapsed range was passed and is same as selection, the selection
-     * will be moved to the inside of the wrapped attribute element.
-     *
-     * Throws {@link module:utils/ckeditorerror~CKEditorError} `view-writer-invalid-range-container`
-     * when {@link module:engine/view/range~Range#start}
-     * and {@link module:engine/view/range~Range#end} positions are not placed inside same parent container.
-     *
-     * Throws {@link module:utils/ckeditorerror~CKEditorError} `view-writer-wrap-invalid-attribute` when passed attribute element is not
-     * an instance of {@link module:engine/view/attributeelement~AttributeElement AttributeElement}.
-     *
-     * Throws {@link module:utils/ckeditorerror~CKEditorError} `view-writer-wrap-nonselection-collapsed-range` when passed range
-     * is collapsed and different than view selection.
-     *
-     * @param {module:engine/view/range~Range} range Range to wrap.
-     * @param {module:engine/view/attributeelement~AttributeElement} attribute Attribute element to use as wrapper.
-     * @returns {module:engine/view/range~Range} range Range after wrapping, spanning over wrapping attribute element.
-    */
+	 * Wraps elements within range with provided {@link module:engine/view/attributeelement~AttributeElement AttributeElement}.
+	 * If a collapsed range is provided, it will be wrapped only if it is equal to view selection.
+	 *
+	 * If a collapsed range was passed and is same as selection, the selection
+	 * will be moved to the inside of the wrapped attribute element.
+	 *
+	 * Throws {@link module:utils/ckeditorerror~CKEditorError} `view-writer-invalid-range-container`
+	 * when {@link module:engine/view/range~Range#start}
+	 * and {@link module:engine/view/range~Range#end} positions are not placed inside same parent container.
+	 *
+	 * Throws {@link module:utils/ckeditorerror~CKEditorError} `view-writer-wrap-invalid-attribute` when passed attribute element is not
+	 * an instance of {@link module:engine/view/attributeelement~AttributeElement AttributeElement}.
+	 *
+	 * Throws {@link module:utils/ckeditorerror~CKEditorError} `view-writer-wrap-nonselection-collapsed-range` when passed range
+	 * is collapsed and different than view selection.
+	 *
+	 * @param {module:engine/view/range~Range} range Range to wrap.
+	 * @param {module:engine/view/attributeelement~AttributeElement} attribute Attribute element to use as wrapper.
+	 * @returns {module:engine/view/range~Range} range Range after wrapping, spanning over wrapping attribute element.
+	*/
 	wrap( range, attribute ) {
 		if ( !( attribute instanceof AttributeElement ) ) {
 			throw new CKEditorError( 'view-writer-wrap-invalid-attribute', this.document );

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -950,6 +950,12 @@ describe( 'Selection', () => {
 			// Special block which can contain another blocks.
 			model.schema.register( 'nestedBlock', { inheritAllFrom: '$block' } );
 			model.schema.extend( 'nestedBlock', { allowIn: '$block' } );
+
+			model.schema.register( 'table', { isBlock: true, isLimit: true, isObject: true, allowIn: '$root' } );
+			model.schema.register( 'tableRow', { allowIn: 'table', isLimit: true } );
+			model.schema.register( 'tableCell', { allowIn: 'tableRow', isObject: true } );
+
+			model.schema.extend( 'p', { allowIn: 'tableCell' } );
 		} );
 
 		it( 'returns an iterator', () => {
@@ -961,7 +967,7 @@ describe( 'Selection', () => {
 		it( 'returns block for a collapsed selection', () => {
 			setData( model, '<p>a</p><p>[]b</p><p>c</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'b' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#b' ] );
 		} );
 
 		it( 'returns block for a collapsed selection (empty block)', () => {
@@ -976,86 +982,89 @@ describe( 'Selection', () => {
 		it( 'returns block for a non collapsed selection', () => {
 			setData( model, '<p>a</p><p>[b]</p><p>c</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'b' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#b' ] );
 		} );
 
 		it( 'returns two blocks for a non collapsed selection', () => {
 			setData( model, '<p>a</p><h>[b</h><p>c]</p><p>d</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'b', 'c' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'h#b', 'p#c' ] );
 		} );
 
 		it( 'returns two blocks for a non collapsed selection (starts at block end)', () => {
 			setData( model, '<p>a</p><h>b[</h><p>c]</p><p>d</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'b', 'c' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'h#b', 'p#c' ] );
 		} );
 
 		it( 'returns proper block for a multi-range selection', () => {
 			setData( model, '<p>a</p><h>[b</h><p>c]</p><p>d</p><p>[e]</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'b', 'c', 'e' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'h#b', 'p#c', 'p#e' ] );
 		} );
 
 		it( 'does not return a block twice if two ranges are anchored in it', () => {
 			setData( model, '<p>[a]b[c]</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'abc' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#abc' ] );
 		} );
 
 		it( 'returns only blocks', () => {
 			setData( model, '<p>[a</p><image>b</image><p>c]</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'a', 'c' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#a', 'p#c' ] );
 		} );
 
 		it( 'gets deeper into the tree', () => {
 			setData( model, '<p>[a</p><blockquote><p>b</p><p>c</p></blockquote><p>d]</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'a', 'b', 'c', 'd' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) )
+				.to.deep.equal( [ 'p#a', 'p#b', 'p#c', 'p#d' ] );
 		} );
 
 		it( 'gets deeper into the tree (end deeper)', () => {
 			setData( model, '<p>[a</p><blockquote><p>b]</p><p>c</p></blockquote><p>d</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'a', 'b' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) )
+				.to.deep.equal( [ 'p#a', 'p#b' ] );
 		} );
 
 		it( 'gets deeper into the tree (start deeper)', () => {
 			setData( model, '<p>a</p><blockquote><p>b</p><p>[c</p></blockquote><p>d]</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'c', 'd' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) )
+				.to.deep.equal( [ 'p#c', 'p#d' ] );
 		} );
 
 		it( 'returns an empty array if none of the selected elements is a block', () => {
 			setData( model, '<p>a</p><image>[a</image><image>b]</image><p>b</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.be.empty;
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.be.empty;
 		} );
 
 		it( 'returns an empty array if the selected element is not a block', () => {
 			setData( model, '<p>a</p><image>[]a</image><p>b</p>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.be.empty;
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.be.empty;
 		} );
 
 		// Super edge case – should not happen (blocks should never be nested),
 		// but since the code handles it already it's worth testing.
-		it( 'returns only the lowest block if blocks are nested', () => {
+		it( 'returns only the lowest block if blocks are nested (case #1)', () => {
 			setData( model, '<nestedBlock>a<nestedBlock>[]b</nestedBlock></nestedBlock>' );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'b' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'nestedBlock#b' ] );
 		} );
 
 		// Like above but trickier.
-		it( 'returns only the lowest block if blocks are nested', () => {
+		it( 'returns only the lowest block if blocks are nested (case #2)', () => {
 			setData(
 				model,
 				'<nestedBlock>a<nestedBlock>[b</nestedBlock></nestedBlock>' +
 				'<nestedBlock>c<nestedBlock>d]</nestedBlock></nestedBlock>'
 			);
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'b', 'd' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'nestedBlock#b', 'nestedBlock#d' ] );
 		} );
 
 		it( 'returns nothing if directly in a root', () => {
@@ -1063,26 +1072,26 @@ describe( 'Selection', () => {
 
 			setData( model, 'a[b]c', { rootName: 'inlineOnlyRoot' } );
 
-			expect( toText( doc.selection.getSelectedBlocks() ) ).to.be.empty;
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.be.empty;
 		} );
 
 		describe( '#984', () => {
 			it( 'does not return the last block if none of its content is selected', () => {
 				setData( model, '<p>[a</p><p>b</p><p>]c</p>' );
 
-				expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'a', 'b' ] );
+				expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#a', 'p#b' ] );
 			} );
 
 			it( 'returns only the first block for a non collapsed selection if only end of selection is touching a block', () => {
 				setData( model, '<p>a</p><h>b[</h><p>]c</p><p>d</p>' );
 
-				expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'b' ] );
+				expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'h#b' ] );
 			} );
 
 			it( 'does not return the last block if none of its content is selected (nested case)', () => {
 				setData( model, '<p>[a</p><nestedBlock><nestedBlock>]b</nestedBlock></nestedBlock>' );
 
-				expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'a' ] );
+				expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#a' ] );
 			} );
 
 			// Like a super edge case, we can live with this behavior as I don't even know what we could expect here
@@ -1090,20 +1099,20 @@ describe( 'Selection', () => {
 			it( 'does not return the last block if none of its content is selected (nested case, wrapper with a content)', () => {
 				setData( model, '<p>[a</p><nestedBlock>b<nestedBlock>]c</nestedBlock></nestedBlock>' );
 
-				expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'a' ] );
+				expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#a' ] );
 			} );
 
 			it( 'returns the last block if at least one of its child nodes is selected', () => {
 				setData( model, '<p>[a</p><p>b</p><p><image></image>]c</p>' );
 
-				expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'a', 'b', 'c' ] );
+				expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#a', 'p#b', 'p#c' ] );
 			} );
 
 			// I needed these last 2 cases to justify the use of isTouching() instead of simple `offset == 0` check.
 			it( 'returns the last block if at least one of its child nodes is selected (end in an inline element)', () => {
 				setData( model, '<p>[a</p><p>b</p><p><image>x]</image>c</p>' );
 
-				expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'a', 'b', 'c' ] );
+				expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#a', 'p#b', 'p#c' ] );
 			} );
 
 			it(
@@ -1112,86 +1121,29 @@ describe( 'Selection', () => {
 				() => {
 					setData( model, '<p>[a</p><p>b</p><p><image>]x</image>c</p>' );
 
-					expect( toText( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'a', 'b' ] );
+					expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#a', 'p#b' ] );
 				}
 			);
 		} );
 
-		it( 'does not go beyond limit elements', () => {
-			model.schema.register( 'table', { isBlock: true, isLimit: true, isObject: true, allowIn: '$root' } );
-			model.schema.register( 'tableRow', { allowIn: 'table', isLimit: true } );
-			model.schema.register( 'tableCell', { allowIn: 'tableRow', isObject: true } );
-
+		it( 'does not go cross limit elements', () => {
 			model.schema.register( 'blk', { allowIn: [ '$root', 'tableCell' ], isObject: true, isBlock: true } );
-
-			model.schema.extend( 'p', { allowIn: 'tableCell' } );
 
 			setData( model, '<table><tableRow><tableCell><p>foo</p>[<blk></blk><p>bar]</p></tableCell></tableRow></table>' );
 
-			expect( stringifyBlocks( doc.selection.getTopMostBlocks() ) ).to.deep.equal( [ 'blk', 'p#bar' ] );
-		} );
-
-		// Map all elements to data of its first child text node.
-		function toText( elements ) {
-			return Array.from( elements ).map( el => {
-				return Array.from( el.getChildren() ).find( child => child.data ).data;
-			} );
-		}
-	} );
-
-	describe( 'getTopMostBlocks()', () => {
-		beforeEach( () => {
-			model.schema.register( 'p', { inheritAllFrom: '$block' } );
-			model.schema.register( 'table', { isBlock: true, isLimit: true, isObject: true, allowIn: '$root' } );
-			model.schema.register( 'tableRow', { allowIn: 'table', isLimit: true } );
-			model.schema.register( 'tableCell', { allowIn: 'tableRow', isObject: true } );
-
-			model.schema.extend( 'p', { allowIn: 'tableCell' } );
-		} );
-
-		it( 'returns an iterator', () => {
-			setData( model, '<p>a</p><p>[]b</p><p>c</p>' );
-
-			expect( doc.selection.getTopMostBlocks().next ).to.be.a( 'function' );
-		} );
-
-		it( 'returns block for a collapsed selection', () => {
-			setData( model, '<p>a</p><p>[]b</p><p>c</p>' );
-
-			expect( stringifyBlocks( doc.selection.getTopMostBlocks() ) ).to.deep.equal( [ 'p#b' ] );
-		} );
-
-		it( 'returns block for a collapsed selection (empty block)', () => {
-			setData( model, '<p>a</p><p>[]</p><p>c</p>' );
-
-			const blocks = Array.from( doc.selection.getTopMostBlocks() );
-
-			expect( blocks ).to.have.length( 1 );
-			expect( blocks[ 0 ].childCount ).to.equal( 0 );
-		} );
-
-		it( 'returns block for a non collapsed selection', () => {
-			setData( model, '<p>a</p><p>[b]</p><p>c</p>' );
-
-			expect( stringifyBlocks( doc.selection.getTopMostBlocks() ) ).to.deep.equal( [ 'p#b' ] );
-		} );
-
-		it( 'returns two blocks for a non collapsed selection', () => {
-			setData( model, '<p>a</p><p>[b</p><p>c]</p><p>d</p>' );
-
-			expect( stringifyBlocks( doc.selection.getTopMostBlocks() ) ).to.deep.equal( [ 'p#b', 'p#c' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'blk', 'p#bar' ] );
 		} );
 
 		it( 'returns only top most blocks', () => {
-			setData( model, '[<p>foo</p><table><tableRow><tableCell><p>bar</p></tableCell></tableRow></table><p>baz</p>]' );
+			setData( model, '<p>[foo</p><table><tableRow><tableCell><p>bar</p></tableCell></tableRow></table><p>baz]</p>' );
 
-			expect( stringifyBlocks( doc.selection.getTopMostBlocks() ) ).to.deep.equal( [ 'p#foo', 'table', 'p#baz' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#foo', 'table', 'p#baz' ] );
 		} );
 
 		it( 'returns only selected blocks even if nested in other blocks', () => {
 			setData( model, '<p>foo</p><table><tableRow><tableCell><p>[b]ar</p></tableCell></tableRow></table><p>baz</p>' );
 
-			expect( stringifyBlocks( doc.selection.getTopMostBlocks() ) ).to.deep.equal( [ 'p#bar' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#bar' ] );
 		} );
 
 		it( 'returns only selected blocks even if nested in other blocks (selection on the block)', () => {
@@ -1199,7 +1151,7 @@ describe( 'Selection', () => {
 
 			setData( model, '<table><tableRow><tableCell><p>foo</p>[<blk></blk><p>bar]</p></tableCell></tableRow></table>' );
 
-			expect( stringifyBlocks( doc.selection.getTopMostBlocks() ) ).to.deep.equal( [ 'blk', 'p#bar' ] );
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'blk', 'p#bar' ] );
 		} );
 	} );
 
@@ -1382,10 +1334,15 @@ describe( 'Selection', () => {
 		return Array.from( elements ).map( el => {
 			const name = el.name;
 
-			const firstChild = el.getChild( 0 );
-			const hasText = firstChild && firstChild.data;
+			let innerText = '';
 
-			return hasText ? `${ name }#${ firstChild.data }` : name;
+			for ( const child of el.getChildren() ) {
+				if ( child.is( 'text' ) ) {
+					innerText += child.data;
+				}
+			}
+
+			return innerText.length ? `${ name }#${ innerText }` : name;
 		} );
 	}
 } );

--- a/tests/model/selection.js
+++ b/tests/model/selection.js
@@ -1134,10 +1134,16 @@ describe( 'Selection', () => {
 			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'blk', 'p#bar' ] );
 		} );
 
-		it( 'returns only top most blocks', () => {
+		it( 'returns only top most blocks (multiple selected)', () => {
 			setData( model, '<p>[foo</p><table><tableRow><tableCell><p>bar</p></tableCell></tableRow></table><p>baz]</p>' );
 
 			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'p#foo', 'table', 'p#baz' ] );
+		} );
+
+		it( 'returns only top most block (one selected)', () => {
+			setData( model, '[<table><tableRow><tableCell><p>bar</p></tableCell></tableRow></table>]' );
+
+			expect( stringifyBlocks( doc.selection.getSelectedBlocks() ) ).to.deep.equal( [ 'table' ] );
 		} );
 
 		it( 'returns only selected blocks even if nested in other blocks', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove the `selection.getTopMostBlocks()`. Closes ckeditor/ckeditor5-widget#95. Closes ckeditor/ckeditor5-table#199.

BREAKING CHANGE: The `selection.getTopMostBlocks()` was removed from the public API. Use `selection.getSelectedBlocks()` instead.

BREAKING CHANGE: The `selection.getSelectedBlocks()` does not return blocks nested in other blocks now.

---

### Additional information

Changes in other repositories:
- indent: https://github.com/ckeditor/ckeditor5-indent/pull/17
- block-quote: https://github.com/ckeditor/ckeditor5-block-quote/pull/39

* After some tests & digging I came to mind that `getSelectedBlocks()` should work as `getTopMostBlock()` so it does not return blocks nested in other blocks but it will search for blocks if they are nested in other non-block elements.

* most of the tests were refactored from the old ones  - I've used the `element#contents` notation in order to properly check the cases.

I've requested you both SC & PK for reviews since I'd like to have double feedback :)
