### PR TITLE
T/404: Better handling of &nbsp; block filler.

### DIFF
--- a/src/dataprocessor/htmldataprocessor.js
+++ b/src/dataprocessor/htmldataprocessor.js
@@ -11,7 +11,6 @@
 
 import BasicHtmlWriter from './basichtmlwriter';
 import DomConverter from '../view/domconverter';
-import { NBSP_FILLER } from '../view/filler';
 
 /**
  * The HTML data processor class.
@@ -38,7 +37,7 @@ export default class HtmlDataProcessor {
 		 * @private
 		 * @member {module:engine/view/domconverter~DomConverter}
 		 */
-		this._domConverter = new DomConverter( { blockFiller: NBSP_FILLER } );
+		this._domConverter = new DomConverter( { blockFillerMode: 'nbsp' } );
 
 		/**
 		 * A basic HTML writer instance used to convert DOM elements to an HTML string.

--- a/src/dataprocessor/xmldataprocessor.js
+++ b/src/dataprocessor/xmldataprocessor.js
@@ -11,7 +11,6 @@
 
 import BasicHtmlWriter from './basichtmlwriter';
 import DomConverter from '../view/domconverter';
-import { NBSP_FILLER } from '../view/filler';
 
 /**
  * The XML data processor class.
@@ -54,7 +53,7 @@ export default class XmlDataProcessor {
 		 * @private
 		 * @member {module:engine/view/domconverter~DomConverter}
 		 */
-		this._domConverter = new DomConverter( { blockFiller: NBSP_FILLER } );
+		this._domConverter = new DomConverter( { blockFillerMode: 'nbsp' } );
 
 		/**
 		 * A basic HTML writer instance used to convert DOM elements to an XML string.

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -387,15 +387,7 @@ export default class DomConverter {
 	 */
 	domToView( domNode, options = {} ) {
 		if ( isBlockFiller( domNode, this.blockFillerMode ) ) {
-			const isSingle = domNode.parentNode && domNode.parentNode.childNodes.length <= 1;
-
-			if ( isText( domNode ) ) {
-				if ( isSingle && _hasDomParentOfType( domNode, this.blockElements ) ) {
-					return null;
-				}
-			} else {
-				return null;
-			}
+			return null;
 		}
 
 		// When node is inside UIElement return that UIElement as it's view representation.

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -67,7 +67,7 @@ export default class DomConverter {
 		 * The mode of a block filler used by DOM converter.
 		 *
 		 * @readonly
-		 * @member {String} module:engine/view/domconverter~DomConverter#blockFillerMode
+		 * @member {'br'|'nbsp'} module:engine/view/domconverter~DomConverter#blockFillerMode
 		 */
 		this.blockFillerMode = options.blockFillerMode || 'br';
 

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -50,7 +50,7 @@ export default class DomConverter {
 	 * Creates DOM converter.
 	 *
 	 * @param {Object} options Object with configuration options.
-	 * @param {module:engine/view/filler~blockFillerMode} [options.blockFillerMode='br'] Type of a block filler w
+	 * @param {module:engine/view/filler~BlockFillerMode} [options.blockFillerMode='br'] Type of a block filler w
 	 */
 	constructor( options = {} ) {
 		// Using WeakMap prevent memory leaks: when the converter will be destroyed all referenced between View and DOM
@@ -67,7 +67,7 @@ export default class DomConverter {
 		 * The mode of a block filler used by DOM converter.
 		 *
 		 * @readonly
-		 * @member {String} module:engine/view/domconverter~DomConverter#blockFillerMode
+		 * @member {String} module:engine/view/domconverter~DomConverter#BlockFillerMode
 		 */
 		this.blockFillerMode = options.blockFillerMode || 'br';
 

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -371,7 +371,17 @@ export default class DomConverter {
 	 */
 	domToView( domNode, options = {} ) {
 		if ( isBlockFiller( domNode, this.blockFiller ) ) {
-			return null;
+			const isSingle = domNode.parentNode && domNode.parentNode.childNodes.length <= 1;
+
+			if ( isSingle && _hasDomParentOfType( domNode, this.blockElements ) ) {
+				return null;
+			}
+
+			// if ( isText( domNode ) ) {
+			//
+			// } else {
+			// 	return null;
+			// }
 		}
 
 		// When node is inside UIElement return that UIElement as it's view representation.

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -67,7 +67,7 @@ export default class DomConverter {
 		 * The mode of a block filler used by DOM converter.
 		 *
 		 * @readonly
-		 * @member {String} module:engine/view/domconverter~DomConverter#BlockFillerMode
+		 * @member {String} module:engine/view/domconverter~DomConverter#blockFillerMode
 		 */
 		this.blockFillerMode = options.blockFillerMode || 'br';
 

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -16,7 +16,7 @@ import ViewRange from './range';
 import ViewSelection from './selection';
 import ViewDocumentFragment from './documentfragment';
 import ViewTreeWalker from './treewalker';
-import { BR_FILLER, getDataWithoutFiller, INLINE_FILLER_LENGTH, isBlockFiller, isInlineFiller, startsWithFiller } from './filler';
+import { BR_FILLER, INLINE_FILLER_LENGTH, isBlockFiller, isInlineFiller, startsWithFiller, getDataWithoutFiller } from './filler';
 
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import indexOf from '@ckeditor/ckeditor5-utils/src/dom/indexof';
@@ -79,14 +79,6 @@ export default class DomConverter {
 		 * @member {Array.<String>} module:engine/view/domconverter~DomConverter#blockElements
 		 */
 		this.blockElements = [ 'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
-
-		/**
-		 * Tag names of DOM `Element`s which are considered inline elements.
-		 *
-		 * @readonly
-		 * @member {Array.<String>} module:engine/view/domconverter~DomConverter#inlineElements
-		 */
-		this.inlineElements = [ 'span', 'strong', 'i', 'b', 'a' ];
 
 		/**
 		 * DOM to View mapping.
@@ -378,7 +370,7 @@ export default class DomConverter {
 	 * or `null` if DOM node is a {@link module:engine/view/filler filler} or the given node is an empty text node.
 	 */
 	domToView( domNode, options = {} ) {
-		if ( isNegligibleBlockFiller( domNode, this.blockFiller, this.inlineElements, this.blockElements ) ) {
+		if ( isBlockFiller( domNode, this.blockFiller ) ) {
 			return null;
 		}
 
@@ -1203,35 +1195,4 @@ function forEachDomNodeAncestor( node, callback ) {
 		callback( node );
 		node = node.parentNode;
 	}
-}
-
-// Checks if given node is negligible and should be removed.
-// The negligible block fillers are:
-// - &nbsp; between block nodes
-// - single &nbsp; in blocks
-// - &nbsp; between blocks
-//
-// The relevant block fillers are:
-// - &nbsp; between inline elements
-// - &nbsp; inside inline elements
-function isNegligibleBlockFiller( domNode, blockFiller, inlineElements ) {
-	if ( !isBlockFiller( domNode, blockFiller ) ) {
-		return false;
-	}
-
-	const isSingleDomNode = !domNode.parentNode || domNode.parentNode.childNodes.length === 1;
-
-	if ( isSingleDomNode ) {
-		// Single DOM nodes are negligible - unless they are in inline element.
-		return !isInlineElement( domNode.parentNode, inlineElements );
-	}
-
-	const prevIsInline = isInlineElement( domNode.previousSibling, inlineElements );
-	const nextIsInline = isInlineElement( domNode.nextSibling, inlineElements );
-
-	return !( prevIsInline || nextIsInline );
-}
-
-function isInlineElement( domNode, types ) {
-	return domNode && types.includes( domNode.tagName.toLowerCase() );
 }

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -50,7 +50,7 @@ export default class DomConverter {
 	 * Creates DOM converter.
 	 *
 	 * @param {Object} options Object with configuration options.
-	 * @param {module:engine/view/filler~BlockFillerMode} [options.blockFillerMode='br'] Type of a block filler w
+	 * @param {module:engine/view/filler~BlockFillerMode} [options.blockFillerMode='br'] The type of the block filler to use.
 	 */
 	constructor( options = {} ) {
 		// Using WeakMap prevent memory leaks: when the converter will be destroyed all referenced between View and DOM

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -50,7 +50,7 @@ export default class DomConverter {
 	 * Creates DOM converter.
 	 *
 	 * @param {Object} options Object with configuration options.
-	 * @param {Function} [options.blockFillerMode='br'] Block filler mode - either 'br' or 'nbsp'.
+	 * @param {module:engine/view/filler~blockFillerMode} [options.blockFillerMode='br'] Type of a block filler w
 	 */
 	constructor( options = {} ) {
 		// Using WeakMap prevent memory leaks: when the converter will be destroyed all referenced between View and DOM
@@ -64,21 +64,12 @@ export default class DomConverter {
 		// I've been here. Seen stuff. Afraid of code now.
 
 		/**
+		 * The mode of a block filler used by DOM converter.
 		 *
 		 * @readonly
 		 * @member {String} module:engine/view/domconverter~DomConverter#blockFillerMode
 		 */
 		this.blockFillerMode = options.blockFillerMode || 'br';
-
-		/**
-		 * Block {@link module:engine/view/filler filler} creator, which is used to create all block fillers during the
-		 * view to DOM conversion and to recognize block fillers during the DOM to view conversion.
-		 *
-		 * @readonly
-		 * @private
-		 * @member {Function} module:engine/view/domconverter~DomConverter#blockFiller
-		 */
-		this._blockFiller = this.blockFillerMode == 'br' ? BR_FILLER : NBSP_FILLER;
 
 		/**
 		 * Tag names of DOM `Element`s which are considered pre-formatted elements.
@@ -95,6 +86,16 @@ export default class DomConverter {
 		 * @member {Array.<String>} module:engine/view/domconverter~DomConverter#blockElements
 		 */
 		this.blockElements = [ 'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
+
+		/**
+		 * Block {@link module:engine/view/filler filler} creator, which is used to create all block fillers during the
+		 * view to DOM conversion and to recognize block fillers during the DOM to view conversion.
+		 *
+		 * @readonly
+		 * @private
+		 * @member {Function} module:engine/view/domconverter~DomConverter#_blockFiller
+		 */
+		this._blockFiller = this.blockFillerMode == 'br' ? BR_FILLER : NBSP_FILLER;
 
 		/**
 		 * DOM to View mapping.

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -373,15 +373,13 @@ export default class DomConverter {
 		if ( isBlockFiller( domNode, this.blockFiller ) ) {
 			const isSingle = domNode.parentNode && domNode.parentNode.childNodes.length <= 1;
 
-			if ( isSingle && _hasDomParentOfType( domNode, this.blockElements ) ) {
+			if ( isText( domNode ) ) {
+				if ( isSingle && _hasDomParentOfType( domNode, this.blockElements ) ) {
+					return null;
+				}
+			} else {
 				return null;
 			}
-
-			// if ( isText( domNode ) ) {
-			//
-			// } else {
-			// 	return null;
-			// }
 		}
 
 		// When node is inside UIElement return that UIElement as it's view representation.

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -7,7 +7,7 @@
  * @module engine/view/domconverter
  */
 
-/* globals window, document, Node, NodeFilter, Text */
+/* globals document, Node, NodeFilter, Text */
 
 import ViewText from './text';
 import ViewElement from './element';
@@ -26,7 +26,7 @@ import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
 import { isElement } from 'lodash-es';
 
 // eslint-disable-next-line new-cap
-const BR_FILLER_REF = BR_FILLER( window.document );
+const BR_FILLER_REF = BR_FILLER( document );
 
 /**
  * DomConverter is a set of tools to do transformations between DOM nodes and view nodes. It also handles
@@ -48,16 +48,6 @@ export default class DomConverter {
 	 * @param {module:engine/view/filler~BlockFillerMode} [options.blockFillerMode='br'] The type of the block filler to use.
 	 */
 	constructor( options = {} ) {
-		// Using WeakMap prevent memory leaks: when the converter will be destroyed all referenced between View and DOM
-		// will be removed. Also because it is a *Weak*Map when both view and DOM elements will be removed referenced
-		// will be also removed, isn't it brilliant?
-		//
-		// Yes, PJ. It is.
-		//
-		// You guys so smart.
-		//
-		// I've been here. Seen stuff. Afraid of code now.
-
 		/**
 		 * The mode of a block filler used by DOM converter.
 		 *
@@ -67,7 +57,7 @@ export default class DomConverter {
 		this.blockFillerMode = options.blockFillerMode || 'br';
 
 		/**
-		 * Tag names of DOM `Element`s which are considered pre-formatted elements.
+		 * Elements which are considered pre-formatted elements.
 		 *
 		 * @readonly
 		 * @member {Array.<String>} module:engine/view/domconverter~DomConverter#preElements
@@ -75,12 +65,17 @@ export default class DomConverter {
 		this.preElements = [ 'pre' ];
 
 		/**
-		 * Tag names of DOM `Element`s which are considered block elements.
+		 * Elements which are considered block elements (and hence should be filled with a
+		 * {@link ~isBlockFiller block filler}).
+		 *
+		 * Whether an element is considered a block element also affects handling of trailing whitespaces.
+		 *
+		 * You can extend this array if you introduce support for block elements which are not yet recognized here.
 		 *
 		 * @readonly
 		 * @member {Array.<String>} module:engine/view/domconverter~DomConverter#blockElements
 		 */
-		this.blockElements = [ 'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
+		this.blockElements = [ 'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'dd', 'dt', 'figcaption' ];
 
 		/**
 		 * Block {@link module:engine/view/filler filler} creator, which is used to create all block fillers during the

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -378,7 +378,7 @@ export default class DomConverter {
 	 * or `null` if DOM node is a {@link module:engine/view/filler filler} or the given node is an empty text node.
 	 */
 	domToView( domNode, options = {} ) {
-		if ( isNegligibleBlockFiller( domNode, this.blockFiller, this.inlineElements ) ) {
+		if ( isNegligibleBlockFiller( domNode, this.blockFiller, this.inlineElements, this.blockElements ) ) {
 			return null;
 		}
 
@@ -1208,7 +1208,8 @@ function forEachDomNodeAncestor( node, callback ) {
 // Checks if given node is negligible and should be removed.
 // The negligible block fillers are:
 // - &nbsp; between block nodes
-// - single &nbsp; in block (ie inside <p>);
+// - single &nbsp; in blocks
+// - &nbsp; between blocks
 //
 // The relevant block fillers are:
 // - &nbsp; between inline elements

--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -370,7 +370,7 @@ export default class DomConverter {
 	 * or `null` if DOM node is a {@link module:engine/view/filler filler} or the given node is an empty text node.
 	 */
 	domToView( domNode, options = {} ) {
-		if ( isBlockFiller( domNode, this.blockFiller ) ) {
+		if ( isBlockFiller( domNode, this.blockFiller ) && isFooBar( domNode, this.blockElements ) ) {
 			return null;
 		}
 
@@ -1195,4 +1195,8 @@ function forEachDomNodeAncestor( node, callback ) {
 		callback( node );
 		node = node.parentNode;
 	}
+}
+
+function isFooBar( domNode, blockElements ) {
+	return !_hasDomParentOfType( domNode, blockElements ) || ( !domNode.parentNode || domNode.parentNode.childNodes.length === 1 );
 }

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -140,7 +140,9 @@ export function isBlockFiller( domNode, blockFiller ) {
 		templateBlockFillers.set( blockFiller, templateBlockFiller );
 	}
 
-	return domNode.isEqualNode( templateBlockFiller );
+	const isFiller = domNode.isEqualNode( templateBlockFiller );
+
+	return isText( templateBlockFiller ) ? isFiller && !hasInlineSibling( domNode ) : isFiller;
 }
 
 /**
@@ -167,4 +169,81 @@ function jumpOverInlineFiller( evt, data ) {
 			}
 		}
 	}
+}
+
+// Checks if domNode has inline sibling.
+//
+// @param {Node} domNode DOM node.
+// @returns {Boolean}
+function hasInlineSibling( domNode ) {
+	const hasParent = !!domNode.parentNode;
+
+	if ( !hasParent || domNode.parentNode.childNodes.length <= 1 ) {
+		return false;
+	}
+
+	const prevIsInline = isInlineElement( domNode.previousSibling );
+	const nextIsInline = isInlineElement( domNode.nextSibling );
+
+	return prevIsInline || nextIsInline;
+}
+
+// Tag names of DOM `Element`s which are considered block elements.
+// todo which other inline elements to include?
+// - abbr
+// - acronym
+// - audio (if it has visible controls)
+// - bdi
+// - bdo
+// - big
+// - br
+// - button
+// - canvas
+// - cite
+// - code
+// - data
+// - datalist
+// - del
+// - dfn
+// - em
+// - embed
+// - iframe
+// - img
+// - input
+// - ins
+// - kbd
+// - label
+// - map
+// - mark
+// - meter
+// - noscript
+// - object
+// - output
+// - picture
+// - progress
+// - q
+// - ruby
+// - s
+// - samp
+// - script
+// - select
+// - slot
+// - small
+// - strong
+// - sub
+// - sup
+// - svg
+// - template
+// - textarea
+// - time
+// - u
+// - tt
+// - var
+// - video
+// - wbr
+const inlineElements = [ 'a', 'b', 'span', 'i', 'span' ];
+
+// Checks if passed domNode is considered inline.
+function isInlineElement( domNode ) {
+	return domNode && inlineElements.includes( domNode.nodeName.toLowerCase() );
 }

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -212,7 +212,6 @@ function hasInlineSiblingOrParent( domNode ) {
 // - datalist
 // - del
 // - dfn
-// - em
 // - embed
 // - iframe
 // - img
@@ -230,7 +229,6 @@ function hasInlineSiblingOrParent( domNode ) {
 // - progress
 // - q
 // - ruby
-// - s
 // - samp
 // - script
 // - select
@@ -243,12 +241,11 @@ function hasInlineSiblingOrParent( domNode ) {
 // - template
 // - textarea
 // - time
-// - u
 // - tt
 // - var
 // - video
 // - wbr
-const inlineElements = [ 'a', 'b', 'span', 'i', 'span' ];
+const inlineElements = [ 'a', 'b', 'em', 'i', 's', 'span', 'u' ];
 
 // Checks if passed domNode is considered inline.
 function isInlineElement( domNode ) {

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -136,7 +136,7 @@ export function getDataWithoutFiller( domText ) {
  * @returns {Boolean} True if a node is considered a block filler for given mode.
  */
 export function isBlockFiller( domNode, mode ) {
-	return mode == 'br' ? domNode.isEqualNode( BR_FILLER_REF ) : isNbspFillerFiller( domNode );
+	return mode == 'br' ? domNode.isEqualNode( BR_FILLER_REF ) : isNbspBlockFiller( domNode );
 }
 
 /**
@@ -171,7 +171,7 @@ function jumpOverInlineFiller( evt, data ) {
 //
 // @param {Node} domNode DOM node.
 // @returns {Boolean}
-function isNbspFillerFiller( domNode ) {
+function isNbspBlockFiller( domNode ) {
 	const isNBSP = isText( domNode ) && domNode.data == '\u00A0';
 
 	return isNBSP && hasBlockParent( domNode ) && domNode.parentNode.childNodes.length === 1;

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -142,7 +142,7 @@ export function isBlockFiller( domNode, blockFiller ) {
 
 	const isFiller = domNode.isEqualNode( templateBlockFiller );
 
-	return isText( templateBlockFiller ) ? isFiller && !hasInlineSibling( domNode ) : isFiller;
+	return isText( templateBlockFiller ) ? isFiller && !hasInlineSiblingOrParent( domNode ) : isFiller;
 }
 
 /**
@@ -175,11 +175,18 @@ function jumpOverInlineFiller( evt, data ) {
 //
 // @param {Node} domNode DOM node.
 // @returns {Boolean}
-function hasInlineSibling( domNode ) {
+function hasInlineSiblingOrParent( domNode ) {
 	const hasParent = !!domNode.parentNode;
 
-	if ( !hasParent || domNode.parentNode.childNodes.length <= 1 ) {
+
+	if ( !hasParent ) {
 		return false;
+	}
+
+	const isSingleNode = hasParent && domNode.parentNode.childNodes.length <= 1;
+
+	if ( isSingleNode ) {
+		return isInlineElement( domNode.parentNode );
 	}
 
 	const prevIsInline = isInlineElement( domNode.previousSibling );

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -140,9 +140,7 @@ export function isBlockFiller( domNode, blockFiller ) {
 		templateBlockFillers.set( blockFiller, templateBlockFiller );
 	}
 
-	const isFiller = domNode.isEqualNode( templateBlockFiller );
-
-	return isText( templateBlockFiller ) ? isFiller && !hasInlineSiblingOrParent( domNode ) : isFiller;
+	return domNode.isEqualNode( templateBlockFiller );
 }
 
 /**
@@ -169,84 +167,4 @@ function jumpOverInlineFiller( evt, data ) {
 			}
 		}
 	}
-}
-
-// Checks if domNode has inline sibling.
-//
-// @param {Node} domNode DOM node.
-// @returns {Boolean}
-function hasInlineSiblingOrParent( domNode ) {
-	const hasParent = !!domNode.parentNode;
-
-	if ( !hasParent ) {
-		return false;
-	}
-
-	const isSingleNode = hasParent && domNode.parentNode.childNodes.length <= 1;
-
-	if ( isSingleNode ) {
-		return isInlineElement( domNode.parentNode );
-	}
-
-	const prevIsInline = isInlineElement( domNode.previousSibling );
-	const nextIsInline = isInlineElement( domNode.nextSibling );
-
-	return prevIsInline || nextIsInline;
-}
-
-// Tag names of DOM `Element`s which are considered block elements.
-// todo which other inline elements to include?
-// - abbr
-// - acronym
-// - audio (if it has visible controls)
-// - bdi
-// - bdo
-// - big
-// - br
-// - button
-// - canvas
-// - cite
-// - code
-// - data
-// - datalist
-// - del
-// - dfn
-// - embed
-// - iframe
-// - img
-// - input
-// - ins
-// - kbd
-// - label
-// - map
-// - mark
-// - meter
-// - noscript
-// - object
-// - output
-// - picture
-// - progress
-// - q
-// - ruby
-// - samp
-// - script
-// - select
-// - slot
-// - small
-// - strong
-// - sub
-// - sup
-// - svg
-// - template
-// - textarea
-// - time
-// - tt
-// - var
-// - video
-// - wbr
-const inlineElements = [ 'a', 'b', 'em', 'i', 's', 'span', 'u' ];
-
-// Checks if passed domNode is considered inline.
-function isInlineElement( domNode ) {
-	return domNode && inlineElements.includes( domNode.nodeName.toLowerCase() );
 }

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -178,7 +178,6 @@ function jumpOverInlineFiller( evt, data ) {
 function hasInlineSiblingOrParent( domNode ) {
 	const hasParent = !!domNode.parentNode;
 
-
 	if ( !hasParent ) {
 		return false;
 	}

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -132,7 +132,9 @@ const templateBlockFillers = new WeakMap();
  * @param {Function} blockFiller Block filler creator.
  * @returns {Boolean} True if text node contains only {@link module:engine/view/filler~INLINE_FILLER inline filler}.
  */
-export function isBlockFiller( domNode, blockFiller ) {
+export function isBlockFiller( domNode, blockFillerMode ) {
+	const blockFiller = blockFillerMode == 'br' ? BR_FILLER : NBSP_FILLER;
+
 	let templateBlockFiller = templateBlockFillers.get( blockFiller );
 
 	if ( !templateBlockFiller ) {

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -68,13 +68,17 @@ export const NBSP_FILLER = domDocument => domDocument.createTextNode( '\u00A0' )
 export const INLINE_FILLER_LENGTH = 7;
 
 /**
- * Inline filler which is sequence of the zero width spaces.
+ * Inline filler which is a sequence of the zero width spaces.
  */
-export let INLINE_FILLER = '';
+export const INLINE_FILLER = ( () => {
+	let inlineFiller = '';
 
-for ( let i = 0; i < INLINE_FILLER_LENGTH; i++ ) {
-	INLINE_FILLER += '\u200b';
-}
+	for ( let i = 0; i < INLINE_FILLER_LENGTH; i++ ) {
+		inlineFiller += '\u200b';
+	}
+
+	return inlineFiller;
+} )(); // Usu IIF so the INLINE_FILLER appears as a constant in the docs.
 
 /**
  * Checks if the node is a text node which starts with the {@link module:engine/view/filler~INLINE_FILLER inline filler}.
@@ -129,10 +133,10 @@ export function getDataWithoutFiller( domText ) {
  *		isBlockFiller( brFillerInstance, 'br' ); // true
  *		isBlockFiller( brFillerInstance, 'nbsp' ); // false
  *
- * **Note:**: For 'nbsp' mode the method also checks context of a node so it cannot be a detached node.
+ * **Note:**: For the `'nbsp'` mode the method also checks context of a node so it cannot be a detached node.
  *
  * @param {Node} domNode DOM node to check.
- * @param {module:engine/view/filler~blockFillerMode} mode Mode of a block filler.
+ * @param {module:engine/view/filler~BlockFillerMode} mode Mode of a block filler.
  * @returns {Boolean} True if a node is considered a block filler for given mode.
  */
 export function isBlockFiller( domNode, mode ) {
@@ -198,5 +202,5 @@ function hasBlockParent( domNode ) {
  * * `br` - for `<br>` block filler used in editing view,
  * * `nbsp` - for `&nbsp;` block fillers used in the data.
  *
- * @typedef {String} module:engine/view/filler~blockFillerMode
+ * @typedef {String} module:engine/view/filler~BlockFillerMode
  */

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window */
-
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
 
@@ -37,6 +35,15 @@ import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
  */
 
 /**
+ * Non-breaking space filler creator. This is a function which creates `&nbsp;` text node.
+ * It defines how the filler is created.
+ *
+ * @see module:engine/view/filler~BR_FILLER
+ * @function
+ */
+export const NBSP_FILLER = domDocument => domDocument.createTextNode( '\u00A0' );
+
+/**
  * `<br>` filler creator. This is a function which creates `<br data-cke-filler="true">` element.
  * It defines how the filler is created.
  *
@@ -49,18 +56,6 @@ export const BR_FILLER = domDocument => {
 
 	return fillerBr;
 };
-
-// eslint-disable-next-line new-cap
-const BR_FILLER_REF = BR_FILLER( window.document );
-
-/**
- * Non-breaking space filler creator. This is a function which creates `&nbsp;` text node.
- * It defines how the filler is created.
- *
- * @see module:engine/view/filler~BR_FILLER
- * @function
- */
-export const NBSP_FILLER = domDocument => domDocument.createTextNode( '\u00A0' );
 
 /**
  * Length of the {@link module:engine/view/filler~INLINE_FILLER INLINE_FILLER}.
@@ -127,23 +122,6 @@ export function getDataWithoutFiller( domText ) {
 }
 
 /**
- * Checks if the node is an instance of the block filler of the given type.
- *
- *		const brFillerInstance = BR_FILLER( document );
- *		isBlockFiller( brFillerInstance, 'br' ); // true
- *		isBlockFiller( brFillerInstance, 'nbsp' ); // false
- *
- * **Note:**: For the `'nbsp'` mode the method also checks context of a node so it cannot be a detached node.
- *
- * @param {Node} domNode DOM node to check.
- * @param {module:engine/view/filler~BlockFillerMode} mode Mode of a block filler.
- * @returns {Boolean} True if a node is considered a block filler for given mode.
- */
-export function isBlockFiller( domNode, mode ) {
-	return mode == 'br' ? domNode.isEqualNode( BR_FILLER_REF ) : isNbspBlockFiller( domNode );
-}
-
-/**
  * Assign key observer which move cursor from the end of the inline filler to the beginning of it when
  * the left arrow is pressed, so the filler does not break navigation.
  *
@@ -168,39 +146,3 @@ function jumpOverInlineFiller( evt, data ) {
 		}
 	}
 }
-
-// Checks if given node is a nbsp block filler.
-//
-// A &nbsp; is a block filler only if it is a single child of a block element.
-//
-// @param {Node} domNode DOM node.
-// @returns {Boolean}
-function isNbspBlockFiller( domNode ) {
-	const isNBSP = isText( domNode ) && domNode.data == '\u00A0';
-
-	return isNBSP && hasBlockParent( domNode ) && domNode.parentNode.childNodes.length === 1;
-}
-
-// Name of DOM nodes that are considered a block.
-const blockElements = [ 'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
-
-// Checks if domNode has block parent.
-//
-// @param {Node} domNode DOM node.
-// @returns {Boolean}
-function hasBlockParent( domNode ) {
-	const parent = domNode.parentNode;
-
-	return parent && parent.tagName && blockElements.includes( parent.tagName.toLowerCase() );
-}
-
-/**
- * Enum representing type of the block filler.
- *
- * Possible values:
- *
- * * `br` - for `<br>` block filler used in editing view,
- * * `nbsp` - for `&nbsp;` block fillers used in the data.
- *
- * @typedef {String} module:engine/view/filler~BlockFillerMode
- */

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -6,7 +6,6 @@
 /* globals window */
 
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
-import getAncestors from '@ckeditor/ckeditor5-utils/src/dom/getancestors';
 import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
 
 /**

--- a/src/view/filler.js
+++ b/src/view/filler.js
@@ -140,10 +140,8 @@ export function isBlockFiller( domNode, blockFillerMode ) {
 	}
 
 	const isNBSP = isText( domNode ) && domNode.data == '\u00A0';
-	const isInsideBlockNode = _hasDomParentOfType( domNode, [ 'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ] );
-	const isSingle = !!domNode.parentNode && domNode.parentNode.childNodes.length === 1;
 
-	return isNBSP && isSingle && isInsideBlockNode;
+	return isNBSP && hasBlockParent( domNode ) && domNode.parentNode.childNodes.length === 1;
 }
 
 /**
@@ -172,12 +170,10 @@ function jumpOverInlineFiller( evt, data ) {
 	}
 }
 
-function _hasDomParentOfType( node, types, boundaryParent ) {
-	let parents = getAncestors( node );
+const blockElements = [ 'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
 
-	if ( boundaryParent ) {
-		parents = parents.slice( parents.indexOf( boundaryParent ) + 1 );
-	}
+function hasBlockParent( node ) {
+	const parent = node.parentNode;
 
-	return parents.some( parent => parent.tagName && types.includes( parent.tagName.toLowerCase() ) );
+	return parent && parent.tagName && blockElements.includes( parent.tagName.toLowerCase() );
 }

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -583,7 +583,7 @@ export default class Renderer {
 	_diffNodeLists( actualDomChildren, expectedDomChildren ) {
 		actualDomChildren = filterOutFakeSelectionContainer( actualDomChildren, this._fakeSelectionContainer );
 
-		return diff( actualDomChildren, expectedDomChildren, sameNodes.bind( null, this.domConverter.blockFiller ) );
+		return diff( actualDomChildren, expectedDomChildren, sameNodes.bind( null, this.domConverter.blockFillerMode ) );
 	}
 
 	/**
@@ -910,11 +910,11 @@ function areSimilar( node1, node2 ) {
 //		* Two block filler elements.
 //
 // @private
-// @param {Function} blockFiller Block filler creator function, see {@link module:engine/view/domconverter~DomConverter#blockFiller}.
+// @param {String} blockFillerMode Block filler mode, see {@link module:engine/view/domconverter~DomConverter#blockFillerMode}.
 // @param {Node} node1
 // @param {Node} node2
 // @returns {Boolean}
-function sameNodes( blockFiller, actualDomChild, expectedDomChild ) {
+function sameNodes( blockFillerMode, actualDomChild, expectedDomChild ) {
 	// Elements.
 	if ( actualDomChild === expectedDomChild ) {
 		return true;
@@ -924,8 +924,8 @@ function sameNodes( blockFiller, actualDomChild, expectedDomChild ) {
 		return actualDomChild.data === expectedDomChild.data;
 	}
 	// Block fillers.
-	else if ( isBlockFiller( actualDomChild, blockFiller ) &&
-		isBlockFiller( expectedDomChild, blockFiller ) ) {
+	else if ( isBlockFiller( actualDomChild, blockFillerMode ) &&
+		isBlockFiller( expectedDomChild, blockFillerMode ) ) {
 		return true;
 	}
 

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -11,7 +11,7 @@
 
 import ViewText from './text';
 import ViewPosition from './position';
-import { INLINE_FILLER, INLINE_FILLER_LENGTH, startsWithFiller, isInlineFiller, isBlockFiller } from './filler';
+import { INLINE_FILLER, INLINE_FILLER_LENGTH, startsWithFiller, isInlineFiller } from './filler';
 
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import diff from '@ckeditor/ckeditor5-utils/src/diff';
@@ -590,7 +590,7 @@ export default class Renderer {
 	_diffNodeLists( actualDomChildren, expectedDomChildren ) {
 		actualDomChildren = filterOutFakeSelectionContainer( actualDomChildren, this._fakeSelectionContainer );
 
-		return diff( actualDomChildren, expectedDomChildren, sameNodes.bind( null, this.domConverter.blockFillerMode ) );
+		return diff( actualDomChildren, expectedDomChildren, sameNodes.bind( null, this.domConverter ) );
 	}
 
 	/**
@@ -926,7 +926,7 @@ function areSimilar( node1, node2 ) {
 // @param {Node} node1
 // @param {Node} node2
 // @returns {Boolean}
-function sameNodes( blockFillerMode, actualDomChild, expectedDomChild ) {
+function sameNodes( domConverter, actualDomChild, expectedDomChild ) {
 	// Elements.
 	if ( actualDomChild === expectedDomChild ) {
 		return true;
@@ -936,8 +936,8 @@ function sameNodes( blockFillerMode, actualDomChild, expectedDomChild ) {
 		return actualDomChild.data === expectedDomChild.data;
 	}
 	// Block fillers.
-	else if ( isBlockFiller( actualDomChild, blockFillerMode ) &&
-		isBlockFiller( expectedDomChild, blockFillerMode ) ) {
+	else if ( domConverter.isBlockFiller( actualDomChild ) &&
+		domConverter.isBlockFiller( expectedDomChild ) ) {
 		return true;
 	}
 

--- a/tests/dataprocessor/htmldataprocessor.js
+++ b/tests/dataprocessor/htmldataprocessor.js
@@ -59,33 +59,32 @@ describe( 'HtmlDataProcessor', () => {
 			} );
 		}
 
-		// Uncomment this test after fixing #404.
-		// describe( 'https://github.com/ckeditor/ckeditor5-clipboard/issues/2#issuecomment-310417731 + #404', () => {
-		// 	it( 'does not lose whitespaces in Chrome\'s paste-like content', () => {
-		// 		const fragment = dataProcessor.toView(
-		// 			'<meta charset=\'utf-8\'>' +
-		// 			'<span>This is the<span>\u00a0</span></span>' +
-		// 			'<a href="url">third developer preview</a>' +
-		// 			'<span><span>\u00a0</span>of<span>\u00a0</span></span>' +
-		// 			'<strong>CKEditor\u00a05</strong>' +
-		// 			'<span>.</span>'
-		// 		);
+		describe( 'https://github.com/ckeditor/ckeditor5-clipboard/issues/2#issuecomment-310417731 + #404', () => {
+			it( 'does not lose whitespaces in Chrome\'s paste-like content', () => {
+				const fragment = dataProcessor.toView(
+					'<meta charset=\'utf-8\'>' +
+					'<span>This is the<span>\u00a0</span></span>' +
+					'<a href="url">third developer preview</a>' +
+					'<span><span>\u00a0</span>of<span>\u00a0</span></span>' +
+					'<strong>CKEditor\u00a05</strong>' +
+					'<span>.</span>'
+				);
 
-		// 		expect( stringify( fragment ) ).to.equal(
-		// 			'<span>This is the<span>\u00a0</span></span>' +
-		// 			'<a href="url">third developer preview</a>' +
-		// 			'<span><span>\u00a0</span>of<span>\u00a0</span></span>' +
-		// 			'<strong>CKEditor\u00a05</strong>' +
-		// 			'<span>.</span>'
-		// 		);
+				expect( stringify( fragment ) ).to.equal(
+					'<span>This is the<span>\u00a0</span></span>' +
+					'<a href="url">third developer preview</a>' +
+					'<span><span>\u00a0</span>of<span>\u00a0</span></span>' +
+					'<strong>CKEditor\u00a05</strong>' +
+					'<span>.</span>'
+				);
 
-		// 		// Just to be sure... stringify() uses conversion and the browser extensively,
-		// 		// so it's not entirely safe.
-		// 		expect( fragment.getChild( 0 ).getChild( 1 ).getChild( 0 ).data ).to.equal( '\u00a0' );
-		// 		expect( fragment.getChild( 2 ).getChild( 0 ).getChild( 0 ).data ).to.equal( '\u00a0' );
-		// 		expect( fragment.getChild( 2 ).getChild( 2 ).getChild( 0 ).data ).to.equal( '\u00a0' );
-		// 	} );
-		// } );
+				// Just to be sure... stringify() uses conversion and the browser extensively,
+				// so it's not entirely safe.
+				expect( fragment.getChild( 0 ).getChild( 1 ).getChild( 0 ).data ).to.equal( '\u00a0' );
+				expect( fragment.getChild( 2 ).getChild( 0 ).getChild( 0 ).data ).to.equal( '\u00a0' );
+				expect( fragment.getChild( 2 ).getChild( 2 ).getChild( 0 ).data ).to.equal( '\u00a0' );
+			} );
+		} );
 	} );
 
 	describe( 'toData()', () => {

--- a/tests/view/domconverter/dom-to-view.js
+++ b/tests/view/domconverter/dom-to-view.js
@@ -9,7 +9,7 @@ import ViewElement from '../../../src/view/element';
 import ViewDocumentSelection from '../../../src/view/documentselection';
 import DomConverter from '../../../src/view/domconverter';
 import ViewDocumentFragment from '../../../src/view/documentfragment';
-import { INLINE_FILLER, INLINE_FILLER_LENGTH, NBSP_FILLER } from '../../../src/view/filler';
+import { INLINE_FILLER, INLINE_FILLER_LENGTH, NBSP_FILLER, BR_FILLER } from '../../../src/view/filler';
 
 import { parse, stringify } from '../../../src/dev-utils/view';
 
@@ -157,7 +157,8 @@ describe( 'DomConverter', () => {
 		} );
 
 		it( 'should return null for block filler', () => {
-			const domFiller = converter.blockFiller( document );
+			// eslint-disable-next-line new-cap
+			const domFiller = BR_FILLER( document );
 
 			expect( converter.domToView( domFiller ) ).to.be.null;
 		} );
@@ -682,7 +683,8 @@ describe( 'DomConverter', () => {
 		} );
 
 		it( 'should skip filler', () => {
-			const domFiller = converter.blockFiller( document );
+			// eslint-disable-next-line new-cap
+			const domFiller = BR_FILLER( document );
 			const domP = createElement( document, 'p', null, domFiller );
 
 			const viewChildren = Array.from( converter.domChildrenToView( domP ) );
@@ -761,7 +763,7 @@ describe( 'DomConverter', () => {
 		} );
 
 		it( 'should converter position inside block filler', () => {
-			const converter = new DomConverter( { blockFiller: NBSP_FILLER } );
+			const converter = new DomConverter( { blockFillerMode: 'nbsp' } );
 			const domFiller = NBSP_FILLER( document ); // eslint-disable-line new-cap
 			const domP = createElement( document, 'p', null, domFiller );
 

--- a/tests/view/domconverter/dom-to-view.js
+++ b/tests/view/domconverter/dom-to-view.js
@@ -9,7 +9,7 @@ import ViewElement from '../../../src/view/element';
 import ViewDocumentSelection from '../../../src/view/documentselection';
 import DomConverter from '../../../src/view/domconverter';
 import ViewDocumentFragment from '../../../src/view/documentfragment';
-import { INLINE_FILLER, INLINE_FILLER_LENGTH, NBSP_FILLER, BR_FILLER } from '../../../src/view/filler';
+import { BR_FILLER, INLINE_FILLER, INLINE_FILLER_LENGTH, NBSP_FILLER } from '../../../src/view/filler';
 
 import { parse, stringify } from '../../../src/dev-utils/view';
 

--- a/tests/view/domconverter/domconverter.js
+++ b/tests/view/domconverter/domconverter.js
@@ -10,7 +10,7 @@ import ViewEditable from '../../../src/view/editableelement';
 import ViewDocument from '../../../src/view/document';
 import ViewUIElement from '../../../src/view/uielement';
 import ViewContainerElement from '../../../src/view/containerelement';
-import { BR_FILLER, NBSP_FILLER, INLINE_FILLER, INLINE_FILLER_LENGTH } from '../../../src/view/filler';
+import { INLINE_FILLER, INLINE_FILLER_LENGTH } from '../../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
@@ -24,13 +24,13 @@ describe( 'DomConverter', () => {
 	} );
 
 	describe( 'constructor()', () => {
-		it( 'should create converter with BR block filler by default', () => {
-			expect( converter.blockFiller ).to.equal( BR_FILLER );
+		it( 'should create converter with BR block filler mode by default', () => {
+			expect( converter.blockFillerMode ).to.equal( 'br' );
 		} );
 
-		it( 'should create converter with defined block filler', () => {
-			converter = new DomConverter( { blockFiller: NBSP_FILLER } );
-			expect( converter.blockFiller ).to.equal( NBSP_FILLER );
+		it( 'should create converter with defined block mode filler', () => {
+			converter = new DomConverter( { blockFillerMode: 'nbsp' } );
+			expect( converter.blockFillerMode ).to.equal( 'nbsp' );
 		} );
 	} );
 

--- a/tests/view/domconverter/domconverter.js
+++ b/tests/view/domconverter/domconverter.js
@@ -10,7 +10,7 @@ import ViewEditable from '../../../src/view/editableelement';
 import ViewDocument from '../../../src/view/document';
 import ViewUIElement from '../../../src/view/uielement';
 import ViewContainerElement from '../../../src/view/containerelement';
-import { INLINE_FILLER, INLINE_FILLER_LENGTH } from '../../../src/view/filler';
+import { BR_FILLER, INLINE_FILLER, INLINE_FILLER_LENGTH, NBSP_FILLER } from '../../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
@@ -287,6 +287,74 @@ describe( 'DomConverter', () => {
 
 				const sel2 = domSelection( domUiDeepSpan, 1, domFillerTextNode, INLINE_FILLER_LENGTH );
 				expect( converter.isDomSelectionCorrect( sel2 ) ).to.be.false;
+			} );
+		} );
+	} );
+
+	describe( 'isBlockFiller()', () => {
+		describe( 'mode "nbsp"', () => {
+			beforeEach( () => {
+				converter = new DomConverter( { blockFillerMode: 'nbsp' } );
+			} );
+
+			it( 'should return true if the node is an instance of the NBSP block filler', () => {
+				converter = new DomConverter( { blockFillerMode: 'nbsp' } );
+				const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+				// NBSP must be check inside a context.
+				const context = document.createElement( 'div' );
+				context.appendChild( nbspFillerInstance );
+
+				expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.true;
+			} );
+
+			it( 'should return false if the node is an instance of the BR block filler', () => {
+				const brFillerInstance = BR_FILLER( document ); // eslint-disable-line new-cap
+
+				expect( converter.isBlockFiller( brFillerInstance ) ).to.be.false;
+			} );
+
+			it( 'should return false if the nbsp filler is inside context', () => {
+				converter = new DomConverter( { blockFillerMode: 'nbsp' } );
+				const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+				// NBSP must be check inside a context.
+				const context = document.createElement( 'div' );
+				context.appendChild( nbspFillerInstance );
+				// eslint-disable-next-line new-cap
+				context.appendChild( NBSP_FILLER( document ) );
+
+				expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
+			} );
+
+			it( 'should return false for inline filler', () => {
+				expect( converter.isBlockFiller( document.createTextNode( INLINE_FILLER ) ) ).to.be.false;
+			} );
+		} );
+
+		describe( 'mode "br"', () => {
+			beforeEach( () => {
+				converter = new DomConverter( { blockFillerMode: 'br' } );
+			} );
+
+			it( 'should return true if the node is an instance of the BR block filler', () => {
+				const brFillerInstance = BR_FILLER( document ); // eslint-disable-line new-cap
+
+				expect( converter.isBlockFiller( brFillerInstance ) ).to.be.true;
+				// Check it twice to ensure that caching breaks nothing.
+				expect( converter.isBlockFiller( brFillerInstance ) ).to.be.true;
+			} );
+
+			it( 'should return false if the node is an instance of the NBSP block filler', () => {
+				converter = new DomConverter( { blockFillerMode: 'br' } );
+				const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+				// NBSP must be check inside a context.
+				const context = document.createElement( 'div' );
+				context.appendChild( nbspFillerInstance );
+
+				expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
+			} );
+
+			it( 'should return false for inline filler', () => {
+				expect( converter.isBlockFiller( document.createTextNode( INLINE_FILLER ) ) ).to.be.false;
 			} );
 		} );
 	} );

--- a/tests/view/domconverter/view-to-dom.js
+++ b/tests/view/domconverter/view-to-dom.js
@@ -634,7 +634,7 @@ describe( 'DomConverter', () => {
 			const domChildren = Array.from( converter.viewChildrenToDom( viewP, document ) );
 
 			expect( domChildren.length ).to.equal( 1 );
-			expect( isBlockFiller( domChildren[ 0 ], converter.blockFiller ) ).to.be.true;
+			expect( isBlockFiller( domChildren[ 0 ], converter.blockFillerMode ) ).to.be.true;
 		} );
 
 		it( 'should add filler according to fillerPositionOffset', () => {
@@ -644,7 +644,7 @@ describe( 'DomConverter', () => {
 			const domChildren = Array.from( converter.viewChildrenToDom( viewP, document ) );
 
 			expect( domChildren.length ).to.equal( 2 );
-			expect( isBlockFiller( domChildren[ 0 ], converter.blockFiller ) ).to.be.true;
+			expect( isBlockFiller( domChildren[ 0 ], converter.blockFillerMode ) ).to.be.true;
 			expect( domChildren[ 1 ].data ).to.equal( 'foo' );
 		} );
 

--- a/tests/view/domconverter/view-to-dom.js
+++ b/tests/view/domconverter/view-to-dom.js
@@ -13,7 +13,7 @@ import ViewAttributeElement from '../../../src/view/attributeelement';
 import ViewEmptyElement from '../../../src/view/emptyelement';
 import DomConverter from '../../../src/view/domconverter';
 import ViewDocumentFragment from '../../../src/view/documentfragment';
-import { INLINE_FILLER, INLINE_FILLER_LENGTH, isBlockFiller } from '../../../src/view/filler';
+import { INLINE_FILLER, INLINE_FILLER_LENGTH } from '../../../src/view/filler';
 
 import { parse } from '../../../src/dev-utils/view';
 
@@ -634,7 +634,7 @@ describe( 'DomConverter', () => {
 			const domChildren = Array.from( converter.viewChildrenToDom( viewP, document ) );
 
 			expect( domChildren.length ).to.equal( 1 );
-			expect( isBlockFiller( domChildren[ 0 ], converter.blockFillerMode ) ).to.be.true;
+			expect( converter.isBlockFiller( domChildren[ 0 ] ) ).to.be.true;
 		} );
 
 		it( 'should add filler according to fillerPositionOffset', () => {
@@ -644,7 +644,7 @@ describe( 'DomConverter', () => {
 			const domChildren = Array.from( converter.viewChildrenToDom( viewP, document ) );
 
 			expect( domChildren.length ).to.equal( 2 );
-			expect( isBlockFiller( domChildren[ 0 ], converter.blockFillerMode ) ).to.be.true;
+			expect( converter.isBlockFiller( domChildren[ 0 ] ) ).to.be.true;
 			expect( domChildren[ 1 ].data ).to.equal( 'foo' );
 		} );
 

--- a/tests/view/domconverter/whitespace-handling-integration.js
+++ b/tests/view/domconverter/whitespace-handling-integration.js
@@ -8,7 +8,6 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
 
 import { getData } from '../../../src/dev-utils/model';
-import TableEditing from '@ckeditor/ckeditor5-table/src/tableediting';
 
 // NOTE:
 // dev utils' setData() loses white spaces so don't use it for tests here!!!
@@ -21,7 +20,7 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 	describe( 'normalizing whitespaces around block boundaries (#822)', () => {
 		beforeEach( () => {
 			return VirtualTestEditor
-				.create( { plugins: [ Paragraph, TableEditing ] } )
+				.create( { plugins: [ Paragraph ] } )
 				.then( newEditor => {
 					editor = newEditor;
 
@@ -117,18 +116,20 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 		} );
 
 		it( 'nbsp between blocks is not ignored (different blocks)', () => {
-			editor.setData( '<table><tr><td>foo</td></tr></table>&nbsp;<p>bar</p>' );
+			editor.model.schema.register( 'block', { inheritAllFrom: '$block' } );
+			editor.conversion.elementToElement( { model: 'block', view: 'block' } );
+			editor.setData( '<block>foo</block>&nbsp;<p>bar</p>' );
 
 			expect( getData( editor.model, { withoutSelection: true } ) )
 				.to.equal(
-					'<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>' +
+					'<block>foo</block>' +
 					'<paragraph> </paragraph>' +
 					'<paragraph>bar</paragraph>'
 				);
 
 			expect( editor.getData() )
 				.to.equal(
-					'<figure class="table"><table><tbody><tr><td>foo</td></tr></tbody></table></figure>' +
+					'<block>foo</block>' +
 					'<p>&nbsp;</p>' +
 					'<p>bar</p>'
 				);

--- a/tests/view/domconverter/whitespace-handling-integration.js
+++ b/tests/view/domconverter/whitespace-handling-integration.js
@@ -13,7 +13,7 @@ import { getData } from '../../../src/dev-utils/model';
 // dev utils' setData() loses white spaces so don't use it for tests here!!!
 // https://github.com/ckeditor/ckeditor5-engine/issues/1428
 
-describe.only( 'DomConverter – whitespace handling – integration', () => {
+describe( 'DomConverter – whitespace handling – integration', () => {
 	let editor;
 
 	// See https://github.com/ckeditor/ckeditor5-engine/issues/822.

--- a/tests/view/domconverter/whitespace-handling-integration.js
+++ b/tests/view/domconverter/whitespace-handling-integration.js
@@ -183,7 +183,7 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 			expect( editor.getData() ).to.equal( '<p>foo</p><p>bar</p>' );
 		} );
 
-		it( 'nbsp between inline elements inside blocks are not ignored', () => {
+		it( 'nbsp between inline elements is not ignored', () => {
 			editor.setData( '<p><b>foo</b>&nbsp;<b>bar</b></p>' );
 
 			expect( getData( editor.model, { withoutSelection: true } ) )
@@ -192,13 +192,22 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 			expect( editor.getData() ).to.equal( '<p><b>foo</b>&nbsp;<b>bar</b></p>' );
 		} );
 
-		it( 'nbsp inside inline element is not ignored', () => {
-			editor.setData( '<p>Foo<b>&nbsp;</b></p>' );
+		it( 'nbsp before inline element is not ignored', () => {
+			editor.setData( '<p>&nbsp;<b>bar</b></p>' );
 
 			expect( getData( editor.model, { withoutSelection: true } ) )
-				.to.equal( '<paragraph>Foo<$text bold="true"> </$text></paragraph>' );
+				.to.equal( '<paragraph> <$text bold="true">bar</$text></paragraph>' );
 
-			expect( editor.getData() ).to.equal( '<p>Foo<b>&nbsp;</b></p>' );
+			expect( editor.getData() ).to.equal( '<p>&nbsp;<b>bar</b></p>' );
+		} );
+
+		it( 'nbsp after inline element is not ignored', () => {
+			editor.setData( '<p><b>bar</b>&nbsp;</p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph><$text bold="true">bar</$text> </paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p><b>bar</b>&nbsp;</p>' );
 		} );
 	} );
 

--- a/tests/view/domconverter/whitespace-handling-integration.js
+++ b/tests/view/domconverter/whitespace-handling-integration.js
@@ -13,7 +13,7 @@ import { getData } from '../../../src/dev-utils/model';
 // dev utils' setData() loses white spaces so don't use it for tests here!!!
 // https://github.com/ckeditor/ckeditor5-engine/issues/1428
 
-describe( 'DomConverter – whitespace handling – integration', () => {
+describe.only( 'DomConverter – whitespace handling – integration', () => {
 	let editor;
 
 	// See https://github.com/ckeditor/ckeditor5-engine/issues/822.
@@ -26,12 +26,6 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 
 					editor.model.schema.extend( '$text', { allowAttributes: [ 'bold' ] } );
 					editor.conversion.attributeToElement( { model: 'bold', view: 'b' } );
-
-					editor.model.schema.register( 'blockQuote', {
-						allowWhere: '$block',
-						allowContentOf: '$root'
-					} );
-					editor.conversion.elementToElement( { model: 'blockQuote', view: 'blockquote' } );
 				} );
 		} );
 
@@ -111,31 +105,14 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 			expect( editor.getData() ).to.equal( '<p>foo</p><p>bar</p>' );
 		} );
 
-		it( 'nbsp between blocks is ignored #1', () => {
+		// Controversial result. See https://github.com/ckeditor/ckeditor5-engine/issues/987.
+		it( 'nbsp between blocks is not ignored', () => {
 			editor.setData( '<p>foo</p>&nbsp;<p>bar</p>' );
 
 			expect( getData( editor.model, { withoutSelection: true } ) )
 				.to.equal( '<paragraph>foo</paragraph><paragraph>bar</paragraph>' );
 
 			expect( editor.getData() ).to.equal( '<p>foo</p><p>bar</p>' );
-		} );
-
-		it( 'nbsp between blocks is ignored #2', () => {
-			editor.setData( '<table>foo</table>&nbsp;<p>bar</p>' );
-
-			expect( getData( editor.model, { withoutSelection: true } ) )
-				.to.equal( '<paragraph>foo</paragraph><paragraph>bar</paragraph>' );
-
-			expect( editor.getData() ).to.equal( '<p>foo</p><p>bar</p>' );
-		} );
-
-		it( 'nbsp between blocks is ignored #3', () => {
-			editor.setData( '<blockquote>foo</blockquote>&nbsp;<blockquote>bar</blockquote>' );
-
-			expect( getData( editor.model, { withoutSelection: true } ) )
-				.to.equal( '<blockQuote><paragraph>foo</paragraph></blockQuote><blockQuote><paragraph>bar</paragraph></blockQuote>' );
-
-			expect( editor.getData() ).to.equal( '<blockquote><p>foo</p></blockquote><blockquote><p>bar</p></blockquote>' );
 		} );
 
 		it( 'new lines inside blocks are ignored', () => {

--- a/tests/view/domconverter/whitespace-handling-integration.js
+++ b/tests/view/domconverter/whitespace-handling-integration.js
@@ -129,7 +129,7 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 			expect( editor.getData() ).to.equal( '<p>foo</p><p>bar</p>' );
 		} );
 
-		it( 'nbsp between blocks is ignored #2', () => {
+		it( 'nbsp between blocks is ignored #3', () => {
 			editor.setData( '<blockquote>foo</blockquote>&nbsp;<blockquote>bar</blockquote>' );
 
 			expect( getData( editor.model, { withoutSelection: true } ) )
@@ -190,6 +190,15 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 				.to.equal( '<paragraph><$text bold="true">foo</$text>\u00A0<$text bold="true">bar</$text></paragraph>' );
 
 			expect( editor.getData() ).to.equal( '<p><b>foo</b>&nbsp;<b>bar</b></p>' );
+		} );
+
+		it( 'nbsp inside inline element is not ignored', () => {
+			editor.setData( '<p>Foo<b>&nbsp;</b></p>' );
+
+			expect( getData( editor.model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>Foo<$text bold="true"> </$text></paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>Foo<b>&nbsp;</b></p>' );
 		} );
 	} );
 

--- a/tests/view/filler.js
+++ b/tests/view/filler.js
@@ -23,7 +23,7 @@ describe( 'filler', () => {
 		} );
 	} );
 
-	describe( 'startsWithFiller', () => {
+	describe( 'startsWithFiller()', () => {
 		it( 'should be true for node which contains only filler', () => {
 			const node = document.createTextNode( INLINE_FILLER );
 
@@ -67,7 +67,7 @@ describe( 'filler', () => {
 		} );
 	} );
 
-	describe( 'getDataWithoutFiller', () => {
+	describe( 'getDataWithoutFiller()', () => {
 		it( 'should return data without filler', () => {
 			const node = document.createTextNode( INLINE_FILLER + 'foo' );
 
@@ -87,7 +87,7 @@ describe( 'filler', () => {
 		} );
 	} );
 
-	describe( 'isInlineFiller', () => {
+	describe( 'isInlineFiller()', () => {
 		it( 'should be true for inline filler', () => {
 			const node = document.createTextNode( INLINE_FILLER );
 
@@ -123,7 +123,7 @@ describe( 'filler', () => {
 		} );
 	} );
 
-	describe( 'isBlockFiller', () => {
+	describe( 'isBlockFiller()', () => {
 		it( 'should return true if the node is an instance of the BR block filler', () => {
 			const brFillerInstance = BR_FILLER( document ); // eslint-disable-line new-cap
 
@@ -134,10 +134,26 @@ describe( 'filler', () => {
 
 		it( 'should return true if the node is an instance of the NBSP block filler', () => {
 			const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+			// NBSP must be check inside a context.
+			const context = document.createElement( 'div' );
+			context.appendChild( nbspFillerInstance );
 
 			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.true;
 			// Check it twice to ensure that caching breaks nothing.
 			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.true;
+		} );
+
+		it( 'should return false if the nbsp filler is inside context', () => {
+			const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+			// NBSP must be check inside a context.
+			const context = document.createElement( 'div' );
+			context.appendChild( nbspFillerInstance );
+			// eslint-disable-next-line new-cap
+			context.appendChild( NBSP_FILLER( document ) );
+
+			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.false;
+			// Check it twice to ensure that caching breaks nothing.
+			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.false;
 		} );
 
 		it( 'should return false for inline filler', () => {

--- a/tests/view/filler.js
+++ b/tests/view/filler.js
@@ -127,22 +127,22 @@ describe( 'filler', () => {
 		it( 'should return true if the node is an instance of the BR block filler', () => {
 			const brFillerInstance = BR_FILLER( document ); // eslint-disable-line new-cap
 
-			expect( isBlockFiller( brFillerInstance, BR_FILLER ) ).to.be.true;
+			expect( isBlockFiller( brFillerInstance, 'br' ) ).to.be.true;
 			// Check it twice to ensure that caching breaks nothing.
-			expect( isBlockFiller( brFillerInstance, BR_FILLER ) ).to.be.true;
+			expect( isBlockFiller( brFillerInstance, 'br' ) ).to.be.true;
 		} );
 
 		it( 'should return true if the node is an instance of the NBSP block filler', () => {
 			const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
 
-			expect( isBlockFiller( nbspFillerInstance, NBSP_FILLER ) ).to.be.true;
+			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.true;
 			// Check it twice to ensure that caching breaks nothing.
-			expect( isBlockFiller( nbspFillerInstance, NBSP_FILLER ) ).to.be.true;
+			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.true;
 		} );
 
 		it( 'should return false for inline filler', () => {
-			expect( isBlockFiller( document.createTextNode( INLINE_FILLER ), BR_FILLER ) ).to.be.false;
-			expect( isBlockFiller( document.createTextNode( INLINE_FILLER ), NBSP_FILLER ) ).to.be.false;
+			expect( isBlockFiller( document.createTextNode( INLINE_FILLER ), 'br' ) ).to.be.false;
+			expect( isBlockFiller( document.createTextNode( INLINE_FILLER ), 'nbsp' ) ).to.be.false;
 		} );
 	} );
 } );

--- a/tests/view/filler.js
+++ b/tests/view/filler.js
@@ -6,14 +6,11 @@
 /* globals document */
 
 import {
-	BR_FILLER,
-	NBSP_FILLER,
 	INLINE_FILLER_LENGTH,
 	INLINE_FILLER,
 	startsWithFiller,
 	isInlineFiller,
 	getDataWithoutFiller,
-	isBlockFiller
 } from '../../src/view/filler';
 
 describe( 'filler', () => {
@@ -120,45 +117,6 @@ describe( 'filler', () => {
 			expect( isInlineFiller( node ) ).to.be.true;
 
 			document.body.removeChild( iframe );
-		} );
-	} );
-
-	describe( 'isBlockFiller()', () => {
-		it( 'should return true if the node is an instance of the BR block filler', () => {
-			const brFillerInstance = BR_FILLER( document ); // eslint-disable-line new-cap
-
-			expect( isBlockFiller( brFillerInstance, 'br' ) ).to.be.true;
-			// Check it twice to ensure that caching breaks nothing.
-			expect( isBlockFiller( brFillerInstance, 'br' ) ).to.be.true;
-		} );
-
-		it( 'should return true if the node is an instance of the NBSP block filler', () => {
-			const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
-			// NBSP must be check inside a context.
-			const context = document.createElement( 'div' );
-			context.appendChild( nbspFillerInstance );
-
-			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.true;
-			// Check it twice to ensure that caching breaks nothing.
-			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.true;
-		} );
-
-		it( 'should return false if the nbsp filler is inside context', () => {
-			const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
-			// NBSP must be check inside a context.
-			const context = document.createElement( 'div' );
-			context.appendChild( nbspFillerInstance );
-			// eslint-disable-next-line new-cap
-			context.appendChild( NBSP_FILLER( document ) );
-
-			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.false;
-			// Check it twice to ensure that caching breaks nothing.
-			expect( isBlockFiller( nbspFillerInstance, 'nbsp' ) ).to.be.false;
-		} );
-
-		it( 'should return false for inline filler', () => {
-			expect( isBlockFiller( document.createTextNode( INLINE_FILLER ), 'br' ) ).to.be.false;
-			expect( isBlockFiller( document.createTextNode( INLINE_FILLER ), 'nbsp' ) ).to.be.false;
 		} );
 	} );
 } );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -21,7 +21,7 @@ import DocumentFragment from '../../src/view/documentfragment';
 import DowncastWriter from '../../src/view/downcastwriter';
 
 import { parse, setData as setViewData, getData as getViewData } from '../../src/dev-utils/view';
-import { INLINE_FILLER, INLINE_FILLER_LENGTH, isBlockFiller, BR_FILLER } from '../../src/view/filler';
+import { BR_FILLER, INLINE_FILLER, INLINE_FILLER_LENGTH } from '../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import createViewRoot from './_utils/createroot';
 import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
@@ -804,7 +804,7 @@ describe( 'Renderer', () => {
 			// Step 3: Check whether in the first paragraph there's a <br> filler and that
 			// in the second one there are two <b> tags.
 			expect( domP.childNodes.length ).to.equal( 1 );
-			expect( isBlockFiller( domP.childNodes[ 0 ], 'br' ) ).to.be.true;
+			expect( domConverter.isBlockFiller( domP.childNodes[ 0 ] ) ).to.be.true;
 
 			expect( domP2.childNodes.length ).to.equal( 2 );
 			expect( domP2.childNodes[ 0 ].tagName.toLowerCase() ).to.equal( 'b' );
@@ -886,7 +886,7 @@ describe( 'Renderer', () => {
 			const domP = domRoot.childNodes[ 0 ];
 
 			expect( domP.childNodes.length ).to.equal( 1 );
-			expect( isBlockFiller( domP.childNodes[ 0 ], 'br' ) ).to.be.true;
+			expect( domConverter.isBlockFiller( domP.childNodes[ 0 ] ) ).to.be.true;
 
 			expect( domSelection.rangeCount ).to.equal( 1 );
 			expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domP );
@@ -925,7 +925,7 @@ describe( 'Renderer', () => {
 			const domP = domRoot.childNodes[ 0 ];
 
 			expect( domP.childNodes.length ).to.equal( 1 );
-			expect( isBlockFiller( domP.childNodes[ 0 ], 'br' ) ).to.be.true;
+			expect( domConverter.isBlockFiller( domP.childNodes[ 0 ] ) ).to.be.true;
 
 			expect( domSelection.rangeCount ).to.equal( 1 );
 			expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domP );

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -804,7 +804,7 @@ describe( 'Renderer', () => {
 			// Step 3: Check whether in the first paragraph there's a <br> filler and that
 			// in the second one there are two <b> tags.
 			expect( domP.childNodes.length ).to.equal( 1 );
-			expect( isBlockFiller( domP.childNodes[ 0 ], BR_FILLER ) ).to.be.true;
+			expect( isBlockFiller( domP.childNodes[ 0 ], 'br' ) ).to.be.true;
 
 			expect( domP2.childNodes.length ).to.equal( 2 );
 			expect( domP2.childNodes[ 0 ].tagName.toLowerCase() ).to.equal( 'b' );
@@ -886,7 +886,7 @@ describe( 'Renderer', () => {
 			const domP = domRoot.childNodes[ 0 ];
 
 			expect( domP.childNodes.length ).to.equal( 1 );
-			expect( isBlockFiller( domP.childNodes[ 0 ], BR_FILLER ) ).to.be.true;
+			expect( isBlockFiller( domP.childNodes[ 0 ], 'br' ) ).to.be.true;
 
 			expect( domSelection.rangeCount ).to.equal( 1 );
 			expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domP );
@@ -925,7 +925,7 @@ describe( 'Renderer', () => {
 			const domP = domRoot.childNodes[ 0 ];
 
 			expect( domP.childNodes.length ).to.equal( 1 );
-			expect( isBlockFiller( domP.childNodes[ 0 ], BR_FILLER ) ).to.be.true;
+			expect( isBlockFiller( domP.childNodes[ 0 ], 'br' ) ).to.be.true;
 
 			expect( domSelection.rangeCount ).to.equal( 1 );
 			expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domP );

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -18,7 +18,6 @@ import ViewRange from '../../../src/view/range';
 import ViewElement from '../../../src/view/element';
 import ViewPosition from '../../../src/view/position';
 import ViewSelection from '../../../src/view/selection';
-import { isBlockFiller } from '../../../src/view/filler';
 
 import count from '@ckeditor/ckeditor5-utils/src/count';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
@@ -565,7 +564,7 @@ describe( 'view', () => {
 			view.forceRender();
 
 			expect( domDiv.childNodes.length ).to.equal( 1 );
-			expect( isBlockFiller( domDiv.childNodes[ 0 ], 'br' ) ).to.be.true;
+			expect( view.domConverter.isBlockFiller( domDiv.childNodes[ 0 ] ) ).to.be.true;
 
 			view.destroy();
 			domDiv.remove();

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -18,7 +18,7 @@ import ViewRange from '../../../src/view/range';
 import ViewElement from '../../../src/view/element';
 import ViewPosition from '../../../src/view/position';
 import ViewSelection from '../../../src/view/selection';
-import { isBlockFiller, BR_FILLER } from '../../../src/view/filler';
+import { isBlockFiller } from '../../../src/view/filler';
 
 import count from '@ckeditor/ckeditor5-utils/src/count';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
@@ -565,7 +565,7 @@ describe( 'view', () => {
 			view.forceRender();
 
 			expect( domDiv.childNodes.length ).to.equal( 1 );
-			expect( isBlockFiller( domDiv.childNodes[ 0 ], BR_FILLER ) ).to.be.true;
+			expect( isBlockFiller( domDiv.childNodes[ 0 ], 'br' ) ).to.be.true;
 
 			view.destroy();
 			domDiv.remove();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Remove only real block fillers on DOM to view conversion. Closes #404. 

---

### Additional information

ATM this PR fixes all the issues addressed with handling `&nbsp;` in the data. I'm not however 100% satisfied with this solution because of a need to handle `<br data-cke-filler="true">` in editing differently than `&nbsp;` in data pipeline.

For editing pipeline the `isBlockFiller()` is pretty straight forward as we check `node.isEqualNode()` wchich compares two DOM nodes by theirs attributes. However for `&nbsp;` we compare `Text` elements by string equality. In `&nbsp;` case we need to detect if the block filler belongs to data or is it negligible in given context.

The other solution that came to my mind is to allow passing a `isBlockFiller()` check to  `DOMConverter` along with `blockFiller` option thus explicitly changing the `DOMConverter` for editing and data pipelines. The drawback is that you have to remember to pass this method when not using deafult block filler (`<br>`).

* After some testing (including PFO compatibility issues) I think that the current solution is OK.
* I've also fixed some tests that were incorrectly implemented (didn't test what they claimed in the description)
- I've hardcoded a short list of inline elements that are recognized in `<b>&npbsp</b>` and `<b>foo</b>&nbsp;<i>bar</i>` cases but this is to be extended before merging.

ps.: ~Some tests in PFO are failing - I'll be investigating this.~

I've added a sub-pr for PFO: https://github.com/ckeditor/ckeditor5-paste-from-office/pull/81 (branch `t/ckeditor5-engine/404`.

Requires: https://github.com/ckeditor/ckeditor5-utils/pull/302.