### PR TITLE
Placeholder should not be visible in the read-only mode

### DIFF
--- a/theme/placeholder.css
+++ b/theme/placeholder.css
@@ -4,11 +4,19 @@
  */
 
 /* See ckeditor/ckeditor5#936. */
-.ck.ck-placeholder, .ck .ck-placeholder {
+.ck.ck-placeholder,
+.ck .ck-placeholder {
 	&::before {
 		content: attr(data-placeholder);
 
 		/* See ckeditor/ckeditor5#469. */
 		pointer-events: none;
+	}
+}
+
+/* See ckeditor/ckeditor5#1987. */
+.ck.ck-read-only .ck-placeholder {
+	&::before {
+		display: none;
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Placeholder should not be visible in the read-only mode. Closes https://github.com/ckeditor/ckeditor5/issues/1987.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
