### PR TITLE
Skip native DOM selection change in case of subsequent requests for the same fake selection

### DIFF
--- a/src/view/domconverter.js
+++ b/src/view/domconverter.js
@@ -106,8 +106,9 @@ export default class DomConverter {
 	}
 
 	/**
-	 * Binds given DOM element that represents fake selection to {@link module:engine/view/documentselection~DocumentSelection
-	 * document selection}. Document selection copy is stored and can be retrieved by
+	 * Binds given DOM element that represents fake selection to a **position** of a
+	 * {@link module:engine/view/documentselection~DocumentSelection document selection}.
+	 * Document selection copy is stored and can be retrieved by
 	 * {@link module:engine/view/domconverter~DomConverter#fakeSelectionToView} method.
 	 *
 	 * @param {HTMLElement} domElement

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -803,8 +803,20 @@ export default class Renderer {
 	 */
 	_fakeSelectionNeedsUpdate( domRoot ) {
 		const container = this._fakeSelectionContainer;
+		const domSelection = domRoot.ownerDocument.getSelection();
 
-		return !container || container.parentElement != domRoot || container.textContent !== this.selection.fakeSelectionLabel;
+		// Selection fakeselection needs to be updated if there's no fake selection container, or container
+		// currently sits in different root.
+		if ( !container || container.parentElement != domRoot ) {
+			return false;
+		}
+
+		// Make sure that the selection actually is within the fake selection.
+		if ( !domSelection.anchorNode.isSameNode( container ) ) {
+			return true;
+		}
+
+		return container.textContent !== this.selection.fakeSelectionLabel;
 	}
 
 	/**

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -691,29 +691,14 @@ export default class Renderer {
 	 */
 	_updateFakeSelection( domRoot ) {
 		const domDocument = domRoot.ownerDocument;
-		let container = this._fakeSelectionContainer;
+		// Create fake selection container if one does not exist.
+		const container = this._fakeSelectionContainer = this._fakeSelectionContainer || createFakeSelectionContainer( domDocument );
+
+		// Bind fake selection container with current selection.
+		this.domConverter.bindFakeSelection( container, this.selection );
 
 		if ( !this._fakeSelectionNeedsUpdate( domRoot ) ) {
-			// Container did not change, but the selection might point a different element with same fake selection.
-			// See https://github.com/ckeditor/ckeditor5-engine/pull/1792#issuecomment-529814641.
-			this.domConverter.bindFakeSelection( container, this.selection );
 			return;
-		}
-
-		// Create fake selection container if one does not exist.
-		if ( !container ) {
-			this._fakeSelectionContainer = container = domDocument.createElement( 'div' );
-
-			Object.assign( container.style, {
-				position: 'fixed',
-				top: 0,
-				left: '-9999px',
-				// See https://github.com/ckeditor/ckeditor5/issues/752.
-				width: '42px'
-			} );
-
-			// Fill it with a text node so we can update it later.
-			container.textContent = '\u00A0';
 		}
 
 		if ( !container.parentElement || container.parentElement != domRoot ) {
@@ -730,9 +715,6 @@ export default class Renderer {
 		domSelection.removeAllRanges();
 		domRange.selectNodeContents( container );
 		domSelection.addRange( domRange );
-
-		// Bind fake selection container with current selection.
-		this.domConverter.bindFakeSelection( container, this.selection );
 	}
 
 	/**
@@ -1004,4 +986,26 @@ function filterOutFakeSelectionContainer( domChildList, fakeSelectionContainer )
 	}
 
 	return childList;
+}
+
+// Creates a fake selection container for a given document.
+//
+// @private
+// @param {Document} domDocument
+// @returns {HTMLElement}
+function createFakeSelectionContainer( domDocument ) {
+	const container = domDocument.createElement( 'div' );
+
+	Object.assign( container.style, {
+		position: 'fixed',
+		top: 0,
+		left: '-9999px',
+		// See https://github.com/ckeditor/ckeditor5/issues/752.
+		width: '42px'
+	} );
+
+	// Fill it with a text node so we can update it later.
+	container.textContent = '\u00A0';
+
+	return container;
 }

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -711,6 +711,8 @@ export default class Renderer {
 
 		if ( !container.parentElement || container.parentElement != domRoot ) {
 			domRoot.appendChild( container );
+		} else if ( !this._fakeSelectionNeedsUpdate( domRoot ) ) {
+			return;
 		}
 
 		// Update contents.
@@ -790,6 +792,19 @@ export default class Renderer {
 
 		// Selections are not similar.
 		return true;
+	}
+
+	/**
+	 * Checks whether the fake selection needs to be updated.
+	 *
+	 * @private
+	 * @param {HTMLElement} domRoot A valid DOM root where a new fake selection container should be added.
+	 * @returns {Boolean}
+	 */
+	_fakeSelectionNeedsUpdate( domRoot ) {
+		const container = this._fakeSelectionContainer;
+
+		return !container || container.parentElement != domRoot || container.textContent !== this.selection.fakeSelectionLabel;
 	}
 
 	/**

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -690,12 +690,15 @@ export default class Renderer {
 	 * @param {HTMLElement} domRoot A valid DOM root where the fake selection container should be added.
 	 */
 	_updateFakeSelection( domRoot ) {
-		if ( !this._fakeSelectionNeedsUpdate( domRoot ) ) {
-			return;
-		}
-
 		const domDocument = domRoot.ownerDocument;
 		let container = this._fakeSelectionContainer;
+
+		if ( !this._fakeSelectionNeedsUpdate( domRoot ) ) {
+			// Container did not change, but the selection might point a different element with same fake selection.
+			// See https://github.com/ckeditor/ckeditor5-engine/pull/1792#issuecomment-529814641.
+			this.domConverter.bindFakeSelection( container, this.selection );
+			return;
+		}
 
 		// Create fake selection container if one does not exist.
 		if ( !container ) {

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -805,10 +805,10 @@ export default class Renderer {
 		const container = this._fakeSelectionContainer;
 		const domSelection = domRoot.ownerDocument.getSelection();
 
-		// Selection fakeselection needs to be updated if there's no fake selection container, or container
-		// currently sits in different root.
+		// Fake selection needs to be updated if there's no fake selection container, or the container currently sits
+		// in a different root.
 		if ( !container || container.parentElement != domRoot ) {
-			return false;
+			return true;
 		}
 
 		// Make sure that the selection actually is within the fake selection.

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -690,6 +690,10 @@ export default class Renderer {
 	 * @param {HTMLElement} domRoot A valid DOM root where the fake selection container should be added.
 	 */
 	_updateFakeSelection( domRoot ) {
+		if ( !this._fakeSelectionNeedsUpdate( domRoot ) ) {
+			return;
+		}
+
 		const domDocument = domRoot.ownerDocument;
 		let container = this._fakeSelectionContainer;
 
@@ -711,8 +715,6 @@ export default class Renderer {
 
 		if ( !container.parentElement || container.parentElement != domRoot ) {
 			domRoot.appendChild( container );
-		} else if ( !this._fakeSelectionNeedsUpdate( domRoot ) ) {
-			return;
 		}
 
 		// Update contents.
@@ -807,12 +809,12 @@ export default class Renderer {
 
 		// Fake selection needs to be updated if there's no fake selection container, or the container currently sits
 		// in a different root.
-		if ( !container || container.parentElement != domRoot ) {
+		if ( !container || container.parentElement !== domRoot ) {
 			return true;
 		}
 
 		// Make sure that the selection actually is within the fake selection.
-		if ( !domSelection.anchorNode.isSameNode( container ) ) {
+		if ( domSelection.anchorNode !== container && !container.contains( domSelection.anchorNode ) ) {
 			return true;
 		}
 

--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -698,10 +698,14 @@ export default class Renderer {
 	 */
 	_updateFakeSelection( domRoot ) {
 		const domDocument = domRoot.ownerDocument;
-		// Create fake selection container if one does not exist.
-		const container = this._fakeSelectionContainer = this._fakeSelectionContainer || createFakeSelectionContainer( domDocument );
 
-		// Bind fake selection container with current selection.
+		if ( !this._fakeSelectionContainer ) {
+			this._fakeSelectionContainer = createFakeSelectionContainer( domDocument );
+		}
+
+		const container = this._fakeSelectionContainer;
+
+		// Bind fake selection container with the current selection *position*.
 		this.domConverter.bindFakeSelection( container, this.selection );
 
 		if ( !this._fakeSelectionNeedsUpdate( domRoot ) ) {
@@ -712,10 +716,8 @@ export default class Renderer {
 			domRoot.appendChild( container );
 		}
 
-		// Update contents.
 		container.textContent = this.selection.fakeSelectionLabel || '\u00A0';
 
-		// Update selection.
 		const domSelection = domDocument.getSelection();
 		const domRange = domDocument.createRange();
 

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1804,6 +1804,20 @@ describe( 'Renderer', () => {
 				assertDomSelectionContents( domSelection, container, /^fake selection label$/ );
 			} );
 
+			it( 'doesn\'t render the same selection multiple times', () => {
+				const createRangeSpy = sinon.spy( domRoot.ownerDocument, 'createRange' );
+
+				const label = 'subsequent fake selection calls';
+				selection._setTo( selection.getRanges(), { fake: true, label } );
+				renderer.render();
+				selection._setTo( selection.getRanges(), { fake: true, label } );
+				renderer.render();
+				selection._setTo( selection.getRanges(), { fake: true, label } );
+				renderer.render();
+
+				expect( createRangeSpy.callCount ).to.be.equal( 1 );
+			} );
+
 			it( 'should render &nbsp; if no selection label is provided', () => {
 				selection._setTo( selection.getRanges(), { fake: true } );
 				renderer.render();

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1805,17 +1805,26 @@ describe( 'Renderer', () => {
 			} );
 
 			it( 'doesn\'t render the same selection multiple times', () => {
-				const createRangeSpy = sinon.spy( domRoot.ownerDocument, 'createRange' );
-
+				const createRangeSpy = sinon.spy( document, 'createRange' );
 				const label = 'subsequent fake selection calls';
-				selection._setTo( selection.getRanges(), { fake: true, label } );
-				renderer.render();
+
 				selection._setTo( selection.getRanges(), { fake: true, label } );
 				renderer.render();
 				selection._setTo( selection.getRanges(), { fake: true, label } );
 				renderer.render();
 
 				expect( createRangeSpy.callCount ).to.be.equal( 1 );
+			} );
+
+			it( 'different subsequent fake selections sets do change native selection', () => {
+				const createRangeSpy = sinon.spy( document, 'createRange' );
+
+				selection._setTo( selection.getRanges(), { fake: true, label: 'selection 1' } );
+				renderer.render();
+				selection._setTo( selection.getRanges(), { fake: true, label: 'selection 2' } );
+				renderer.render();
+
+				expect( createRangeSpy.callCount ).to.be.equal( 2 );
 			} );
 
 			it( 'should render &nbsp; if no selection label is provided', () => {

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -1848,11 +1848,6 @@ describe( 'Renderer', () => {
 
 					expect( createRangeSpy.callCount ).to.be.equal( 2 );
 				} );
-
-				it( '_fakeSelectionNeedsUpdate returns proper result when container is uninitialized', () => {
-					selection._setTo( selection.getRanges(), { fake: true, label: 'selection 1' } );
-					expect( renderer._fakeSelectionNeedsUpdate( domRoot ) ).to.be.true;
-				} );
 			} );
 
 			it( 'should render &nbsp; if no selection label is provided', () => {

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -20,7 +20,7 @@ import Renderer from '../../src/view/renderer';
 import DocumentFragment from '../../src/view/documentfragment';
 import DowncastWriter from '../../src/view/downcastwriter';
 
-import { parse, setData as setViewData, getData as getViewData } from '../../src/dev-utils/view';
+import { parse, stringify, setData as setViewData, getData as getViewData } from '../../src/dev-utils/view';
 import { INLINE_FILLER, INLINE_FILLER_LENGTH, isBlockFiller, BR_FILLER } from '../../src/view/filler';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import createViewRoot from './_utils/createroot';
@@ -1847,6 +1847,25 @@ describe( 'Renderer', () => {
 					renderer.render();
 
 					expect( createRangeSpy.callCount ).to.be.equal( 2 );
+				} );
+
+				it( 'correctly maps fake selection ', () => {
+					// See https://github.com/ckeditor/ckeditor5-engine/pull/1792#issuecomment-529814641
+					const label = 'subsequent fake selection calls';
+					const { view: newParagraph, selection: newSelection } = parse( '<container:p>[baz]</container:p>' );
+
+					viewRoot._appendChild( newParagraph );
+
+					selection._setTo( selection.getRanges(), { fake: true, label } );
+					renderer.render();
+
+					selection._setTo( newSelection.getRanges(), { fake: true, label } );
+					renderer.render();
+
+					const fakeSelectionContainer = domRoot.childNodes[ 1 ];
+					const mappedSelection = renderer.domConverter.fakeSelectionToView( fakeSelectionContainer );
+
+					expect( stringify( viewRoot, mappedSelection ) ).to.be.equal( '<div><p>foo bar</p><p>[baz]</p></div>' );
 				} );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improved performance when working with fake selections. Closes #1791.

---

### Additional information

This approach introduces one change. If there are two subsequent calls to create fake selection with exactly the same label, then there will be no `HTMLDocument.selectionchange` event (as this case will also be optimized). This might be a case when there are for instance two different widgets, but both have the same label (e.g. both have simply "Image widget").

In case the above case should be covered, the implementation should be more complex.