### PR TITLE
Revert blocking selection change while composing on Android.

### DIFF
--- a/src/view/renderer.js
+++ b/src/view/renderer.js
@@ -770,7 +770,8 @@ export default class Renderer {
 	 */
 	_domSelectionNeedsUpdate( domSelection ) {
 		// Remain DOM selection untouched while composing. See #1782.
-		if ( this.isComposing ) {
+		// However, this fix, breaks track changes feature on Android. See #5638.
+		if ( this.isComposing && !env.isAndroid ) {
 			return false;
 		}
 

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -3709,6 +3709,11 @@ describe( 'Renderer', () => {
 
 		// #1782
 		it( 'should leave dom selection untouched while composing', () => {
+			// See #5638.
+			if ( env.isAndroid ) {
+				this.skip();
+			}
+
 			const { view: viewP, selection: newSelection } = parse( '<container:p>[]</container:p>' );
 
 			viewRoot._appendChild( viewP );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Revert blocking selection change while composing on Android. Closes #https://github.com/ckeditor/ckeditor5/issues/5638.

---

### Additional information

To be honest, I am not sure if it is a good way of solving this problem. We do not know the reason of it the the code became a bunch of `if`s. Alternatively, we could revert https://github.com/ckeditor/ckeditor5-engine/commit/c698683d614a93fc05b99912ecb05371bb65b33b until we find out why it causes issues on Android.