### PR TITLE
Rethrow original error in try-catch blocks when the `debug=true` mode is on

### DIFF
--- a/src/model/model.js
+++ b/src/model/model.js
@@ -173,6 +173,7 @@ export default class Model {
 			}
 		} catch ( err ) {
 			// @if CK_DEBUG // throw err;
+			/* istanbul ignore next */
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	}
@@ -226,6 +227,7 @@ export default class Model {
 			}
 		} catch ( err ) {
 			// @if CK_DEBUG // throw err;
+			/* istanbul ignore next */
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	}

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -172,6 +172,7 @@ export default class Model {
 				return callback( this._currentWriter );
 			}
 		} catch ( err ) {
+			// @if CK_DEBUG // throw err;
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	}
@@ -224,6 +225,7 @@ export default class Model {
 				this._runPendingChanges();
 			}
 		} catch ( err ) {
+			// @if CK_DEBUG // throw err;
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	}

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -481,6 +481,7 @@ export default class View {
 
 			return callbackResult;
 		} catch ( err ) {
+			// @if CK_DEBUG // throw err;
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	}

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -482,6 +482,7 @@ export default class View {
 			return callbackResult;
 		} catch ( err ) {
 			// @if CK_DEBUG // throw err;
+			/* istanbul ignore next */
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	}

--- a/tests/model/model.js
+++ b/tests/model/model.js
@@ -324,21 +324,14 @@ describe( 'Model', () => {
 			} );
 		} );
 
-		it( 'should catch a non-ckeditor error inside the `change()` block and throw the CKEditorError error outside of it', () => {
+		it( 'should rethrow native errors as they are in the dubug=true mode in the model.change() block', () => {
 			const error = new TypeError( 'foo' );
-			error.stack = 'bar';
 
-			expectToThrowCKEditorError( () => {
+			expect( () => {
 				model.change( () => {
 					throw error;
 				} );
-			}, /unexpected-error/, model, {
-				originalError: {
-					message: 'foo',
-					stack: 'bar',
-					name: 'TypeError'
-				}
-			} );
+			} ).to.throw( TypeError, /foo/ );
 		} );
 
 		it( 'should throw the original CKEditorError error if it was thrown inside the `change()` block', () => {
@@ -349,21 +342,14 @@ describe( 'Model', () => {
 			}, /foo/, null, { foo: 1 } );
 		} );
 
-		it( 'should catch a non-ckeditor error inside the `enqueueChange()` block and throw the CKEditorError error outside of it', () => {
+		it( 'should rethrow native errors as they are in the dubug=true mode in the enqueueChange() block', () => {
 			const error = new TypeError( 'foo' );
-			error.stack = 'bar';
 
-			expectToThrowCKEditorError( () => {
+			expect( () => {
 				model.enqueueChange( () => {
 					throw error;
 				} );
-			}, /unexpected-error/, model, {
-				originalError: {
-					message: 'foo',
-					stack: 'bar',
-					name: 'TypeError'
-				}
-			} );
+			} ).to.throw( TypeError, /foo/ );
 		} );
 
 		it( 'should throw the original CKEditorError error if it was thrown inside the `enqueueChange()` block', () => {

--- a/tests/view/view/view.js
+++ b/tests/view/view/view.js
@@ -804,21 +804,14 @@ describe( 'view', () => {
 			expect( result3 ).to.undefined;
 		} );
 
-		it( 'should catch native errors and wrap them into the CKEditorError errors', () => {
+		it( 'should rethrow native errors as they are in the dubug=true mode', () => {
 			const error = new TypeError( 'foo' );
-			error.stack = 'bar';
 
-			expectToThrowCKEditorError( () => {
+			expect( () => {
 				view.change( () => {
 					throw error;
 				} );
-			}, /unexpected-error/, view, {
-				originalError: {
-					message: 'foo',
-					stack: 'bar',
-					name: 'TypeError'
-				}
-			} );
+			} ).to.throw( TypeError, /foo/ );
 		} );
 
 		it( 'should rethrow custom CKEditorError errors', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Rethrown original error in try-catch blocks when the `debug=true` mode is on. Part of ckeditor/ckeditor5#5595.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
