### PR TITLE
Mutations in UIElements should not be propagated / force render

### DIFF
--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -244,7 +244,7 @@ export default class MutationObserver extends Observer {
 			}
 		}
 
-		// In case only non-relevant mutations were recorded it skips the event & force render (#5600).
+		// In case only non-relevant mutations were recorded it skips the event and force render (#5600).
 		if ( viewMutations.length ) {
 			this.document.fire( 'mutations', viewMutations, viewSelection );
 

--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -244,11 +244,14 @@ export default class MutationObserver extends Observer {
 			}
 		}
 
-		this.document.fire( 'mutations', viewMutations, viewSelection );
+		// In case only non-relevant mutations were recorded it skip event / force render for the sake of performance (#5600).
+		if ( viewMutations.length ) {
+			this.document.fire( 'mutations', viewMutations, viewSelection );
 
-		// If nothing changes on `mutations` event, at this point we have "dirty DOM" (changed) and de-synched
-		// view (which has not been changed). In order to "reset DOM" we render the view again.
-		this.view.forceRender();
+			// If nothing changes on `mutations` event, at this point we have "dirty DOM" (changed) and de-synched
+			// view (which has not been changed). In order to "reset DOM" we render the view again.
+			this.view.forceRender();
+		}
 
 		function sameNodes( child1, child2 ) {
 			// First level of comparison (array of children vs array of children) – use the Lodash's default behavior.

--- a/src/view/observer/mutationobserver.js
+++ b/src/view/observer/mutationobserver.js
@@ -244,7 +244,7 @@ export default class MutationObserver extends Observer {
 			}
 		}
 
-		// In case only non-relevant mutations were recorded it skip event / force render for the sake of performance (#5600).
+		// In case only non-relevant mutations were recorded it skips the event & force render (#5600).
 		if ( viewMutations.length ) {
 			this.document.fire( 'mutations', viewMutations, viewSelection );
 

--- a/src/view/uielement.js
+++ b/src/view/uielement.js
@@ -123,6 +123,9 @@ export default class UIElement extends Element {
 	 *			return domElement;
 	 *		};
 	 *
+	 * If you wish to trigger render of entire editor UI you should call {@link module:core/editor/editorui~EditorUI#update} method
+	 * after rendering your UI element.
+	 *
 	 * @param {Document} domDocument
 	 * @returns {HTMLElement}
 	 */

--- a/src/view/uielement.js
+++ b/src/view/uielement.js
@@ -123,7 +123,8 @@ export default class UIElement extends Element {
 	 *			return domElement;
 	 *		};
 	 *
-	 * If you wish to trigger render of entire editor UI you should call {@link module:core/editor/editorui~EditorUI#update} method
+	 * If changes in your UI element should trigger some editor UI update you should call
+	 * the {@link module:core/editor/editorui~EditorUI#update `editor.ui.update()`} method
 	 * after rendering your UI element.
 	 *
 	 * @param {Document} domDocument

--- a/tests/view/observer/mutationobserver.js
+++ b/tests/view/observer/mutationobserver.js
@@ -528,6 +528,7 @@ describe( 'MutationObserver', () => {
 	} );
 
 	describe( 'UIElement integration', () => {
+		const renderStub = sinon.stub();
 		function createUIElement( name ) {
 			const element = new UIElement( name );
 
@@ -540,8 +541,6 @@ describe( 'MutationObserver', () => {
 
 			return element;
 		}
-
-		const renderStub = sinon.stub();
 
 		beforeEach( () => {
 			const uiElement = createUIElement( 'div' );

--- a/tests/view/observer/mutationobserver.js
+++ b/tests/view/observer/mutationobserver.js
@@ -404,7 +404,7 @@ describe( 'MutationObserver', () => {
 
 		mutationObserver.flush();
 
-		expect( lastMutations.length ).to.equal( 0 );
+		expect( lastMutations ).to.be.null;
 	} );
 
 	it( 'should ignore mutation with bogus br inserted on the end of the paragraph with text', () => {
@@ -417,7 +417,7 @@ describe( 'MutationObserver', () => {
 
 		mutationObserver.flush();
 
-		expect( lastMutations.length ).to.equal( 0 );
+		expect( lastMutations ).to.be.null;
 	} );
 
 	it( 'should ignore mutation with bogus br inserted on the end of the paragraph while processing text mutations', () => {
@@ -449,7 +449,7 @@ describe( 'MutationObserver', () => {
 
 		mutationObserver.flush();
 
-		expect( lastMutations.length ).to.equal( 0 );
+		expect( lastMutations ).to.be.null;
 	} );
 
 	// This case is more tricky than the previous one because DOMConverter will return a different
@@ -541,11 +541,15 @@ describe( 'MutationObserver', () => {
 			return element;
 		}
 
+		const renderStub = sinon.stub();
+
 		beforeEach( () => {
 			const uiElement = createUIElement( 'div' );
 			viewRoot._appendChild( uiElement );
 
 			view.forceRender();
+			renderStub.reset();
+			view.on( 'render', renderStub );
 		} );
 
 		it( 'should not collect text mutations from UIElement', () => {
@@ -553,7 +557,15 @@ describe( 'MutationObserver', () => {
 
 			mutationObserver.flush();
 
-			expect( lastMutations.length ).to.equal( 0 );
+			expect( lastMutations ).to.be.null;
+		} );
+
+		it( 'should not cause a render from UIElement', () => {
+			domEditor.childNodes[ 2 ].childNodes[ 0 ].data = 'foom';
+
+			mutationObserver.flush();
+
+			expect( renderStub.callCount ).to.be.equal( 0 );
 		} );
 
 		it( 'should not collect child mutations from UIElement', () => {
@@ -562,7 +574,16 @@ describe( 'MutationObserver', () => {
 
 			mutationObserver.flush();
 
-			expect( lastMutations.length ).to.equal( 0 );
+			expect( lastMutations ).to.be.null;
+		} );
+
+		it( 'should not cause a render when UIElement gets a child', () => {
+			const span = document.createElement( 'span' );
+			domEditor.childNodes[ 2 ].appendChild( span );
+
+			mutationObserver.flush();
+
+			expect( renderStub.callCount ).to.be.equal( 0 );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Change in UIElement view will no longer force a view render nor will it trigger mutations event on the document. Closes ckeditor/ckeditor5#5600.

---

### Additional information

The tests are passing, but this change needs to be carefully tested manually.

* image resize doesn't play well with it (toolbar is stuck in place during resize) - that's fine as we're going to hide it during resize (ckeditor/ckeditor5#5964)

I suggest few testing scenario:

* image style (aligning them, making sure that the toolbar moves properly)
* inline toolbar for table
* Cloud Features that use inline toolbar
* not sure if it might get with toolbar rotator?

Also it's good that we'll be able to merge it at the beginning of iteration, so there's a bigger chance that we'll catch nuances if any appear.