### PR TITLE
Introduced Model#createOperationFromJSON

### DIFF
--- a/src/model/model.js
+++ b/src/model/model.js
@@ -18,6 +18,7 @@ import ModelElement from './element';
 import ModelRange from './range';
 import ModelPosition from './position';
 import ModelSelection from './selection';
+import OperationFactory from './operation/operationfactory';
 
 import insertContent from './utils/insertcontent';
 import deleteContent from './utils/deletecontent';
@@ -753,6 +754,18 @@ export default class Model {
 	 */
 	createBatch( type ) {
 		return new Batch( type );
+	}
+
+	/**
+	 * Creates an `Operation` instance from a JSON object with the operation data (e.g. taken from a parsed JSON string).
+	 *
+	 * This is an alias for {@link module:engine/model/operation/operationfactory~OperationFactory#fromJSON}.
+	 *
+	 * @param {Object} json Deserialized JSON object.
+	 * @returns {module:engine/model/operation/operation~Operation}
+	 */
+	createOperationFromJSON( json ) {
+		return OperationFactory.fromJSON( json, this.document );
 	}
 
 	/**

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -757,7 +757,7 @@ export default class Model {
 	}
 
 	/**
-	 * Creates an `Operation` instance from a JSON object with the operation data (e.g. taken from a parsed JSON string).
+	 * Creates an operation instance from a JSON object (parsed JSON string).
 	 *
 	 * This is an alias for {@link module:engine/model/operation/operationfactory~OperationFactory#fromJSON}.
 	 *

--- a/src/model/operation/operationfactory.js
+++ b/src/model/operation/operationfactory.js
@@ -37,7 +37,7 @@ operations[ MergeOperation.className ] = MergeOperation;
  */
 export default class OperationFactory {
 	/**
-	 * Creates concrete `Operation` object from deserialized object, i.e. from parsed JSON string.
+	 * Creates an `Operation` instance from a JSON object with the operation data (e.g. taken from a parsed JSON string).
 	 *
 	 * @param {Object} json Deserialized JSON object.
 	 * @param {module:engine/model/document~Document} document Document on which this operation will be applied.

--- a/src/model/operation/operationfactory.js
+++ b/src/model/operation/operationfactory.js
@@ -37,7 +37,7 @@ operations[ MergeOperation.className ] = MergeOperation;
  */
 export default class OperationFactory {
 	/**
-	 * Creates an `Operation` instance from a JSON object with the operation data (e.g. taken from a parsed JSON string).
+	 * Creates an operation instance from a JSON object (parsed JSON string).
 	 *
 	 * @param {Object} json Deserialized JSON object.
 	 * @param {module:engine/model/document~Document} document Document on which this operation will be applied.

--- a/tests/model/model.js
+++ b/tests/model/model.js
@@ -11,6 +11,7 @@ import ModelPosition from '../../src/model/position';
 import ModelSelection from '../../src/model/selection';
 import ModelDocumentFragment from '../../src/model/documentfragment';
 import Batch from '../../src/model/batch';
+import NoOperation from '../../src/model/operation/nooperation';
 import { getData, setData, stringify } from '../../src/dev-utils/model';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
@@ -823,6 +824,18 @@ describe( 'Model', () => {
 			const batch = model.createBatch( 'transparent' );
 			expect( batch ).to.be.instanceof( Batch );
 			expect( batch.type ).to.equal( 'transparent' );
+		} );
+	} );
+
+	describe( 'createOperationFromJson()', () => {
+		it( 'should create operation from JSON', () => {
+			const operation = model.createOperationFromJSON( {
+				__className: 'NoOperation',
+				baseVersion: 0
+			} );
+
+			expect( operation ).to.instanceof( NoOperation );
+			expect( operation.baseVersion ).to.equal( 0 );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `Model#createOperationFromJSON` which is an alias for `OperationFactory#fromJSON`. Closes ckeditor/ckeditor5#6094.

---

### Additional information

I actually used `OperationFactory` inside `Model#createOperationFromJSON` -- less hassle and more backward compatible. If you don't like this solution, I can remove `OperationFactory` and fix related places (I think it was used in three places in our codebase).