### PR TITLE
I/6152:  Added '`mouseup'`, `'mousemove'` and `'mouseleave'` events to `MouseObserver`. 

### DIFF
--- a/src/view/observer/mouseobserver.js
+++ b/src/view/observer/mouseobserver.js
@@ -21,7 +21,6 @@ export default class MouseObserver extends DomEventObserver {
 	constructor( view ) {
 		super( view );
 
-		// TODO: either enhance or new classes
 		this.domEventType = [ 'mousedown', 'mousemove', 'mouseup', 'mouseleave' ];
 	}
 

--- a/src/view/observer/mouseobserver.js
+++ b/src/view/observer/mouseobserver.js
@@ -21,7 +21,8 @@ export default class MouseObserver extends DomEventObserver {
 	constructor( view ) {
 		super( view );
 
-		this.domEventType = 'mousedown';
+		// TODO: either enhance or new classes
+		this.domEventType = [ 'mousedown', 'mousemove', 'mouseup', 'mouseleave' ];
 	}
 
 	onDomEvent( domEvent ) {

--- a/src/view/observer/mouseobserver.js
+++ b/src/view/observer/mouseobserver.js
@@ -18,12 +18,18 @@ import DomEventObserver from './domeventobserver';
  * @extends module:engine/view/observer/domeventobserver~DomEventObserver
  */
 export default class MouseObserver extends DomEventObserver {
+	/**
+	 * @inheritDoc
+	 */
 	constructor( view ) {
 		super( view );
 
 		this.domEventType = [ 'mousedown', 'mousemove', 'mouseup', 'mouseleave' ];
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	onDomEvent( domEvent ) {
 		this.fire( domEvent.type, domEvent );
 	}
@@ -39,5 +45,44 @@ export default class MouseObserver extends DomEventObserver {
  *
  * @see module:engine/view/observer/mouseobserver~MouseObserver
  * @event module:engine/view/document~Document#event:mousedown
+ * @param {module:engine/view/observer/domeventdata~DomEventData} data Event data.
+ */
+
+/**
+ * Fired when mouse button is released over one of the editables.
+ *
+ * Introduced by {@link module:engine/view/observer/mouseobserver~MouseObserver}.
+ *
+ * Note that this event is not available by default. To make it available {@link module:engine/view/observer/mouseobserver~MouseObserver}
+ * needs to be added to {@link module:engine/view/view~View} by a {@link module:engine/view/view~View#addObserver} method.
+ *
+ * @see module:engine/view/observer/mouseobserver~MouseObserver
+ * @event module:engine/view/document~Document#event:mouseup
+ * @param {module:engine/view/observer/domeventdata~DomEventData} data Event data.
+ */
+
+/**
+ * Fired when mouse is moved over one of the editables.
+ *
+ * Introduced by {@link module:engine/view/observer/mouseobserver~MouseObserver}.
+ *
+ * Note that this event is not available by default. To make it available {@link module:engine/view/observer/mouseobserver~MouseObserver}
+ * needs to be added to {@link module:engine/view/view~View} by a {@link module:engine/view/view~View#addObserver} method.
+ *
+ * @see module:engine/view/observer/mouseobserver~MouseObserver
+ * @event module:engine/view/document~Document#event:mousemove
+ * @param {module:engine/view/observer/domeventdata~DomEventData} data Event data.
+ */
+
+/**
+ * Fired when mouse is moved away from one of the editables.
+ *
+ * Introduced by {@link module:engine/view/observer/mouseobserver~MouseObserver}.
+ *
+ * Note that this event is not available by default. To make it available {@link module:engine/view/observer/mouseobserver~MouseObserver}
+ * needs to be added to {@link module:engine/view/view~View} by a {@link module:engine/view/view~View#addObserver} method.
+ *
+ * @see module:engine/view/observer/mouseobserver~MouseObserver
+ * @event module:engine/view/document~Document#event:mouseleave
  * @param {module:engine/view/observer/domeventdata~DomEventData} data Event data.
  */

--- a/tests/view/observer/mouseobserver.js
+++ b/tests/view/observer/mouseobserver.js
@@ -21,22 +21,29 @@ describe( 'MouseObserver', () => {
 		view.destroy();
 	} );
 
-	it( 'should define domEventType', () => {
-		expect( observer.domEventType ).to.equal( 'mousedown' );
+	it( 'should define domEventTypes', () => {
+		expect( observer.domEventType ).to.deep.equal( [
+			'mousedown',
+			'mousemove',
+			'mouseup',
+			'mouseleave'
+		] );
 	} );
 
 	describe( 'onDomEvent', () => {
-		it( 'should fire mousedown with the right event data', () => {
-			const spy = sinon.spy();
+		for ( const eventName of [ 'mousedown', 'mousemove', 'mouseup', 'mouseleave' ] ) {
+			it( `should fire ${ eventName } with the right event data`, () => {
+				const spy = sinon.spy();
 
-			viewDocument.on( 'mousedown', spy );
+				viewDocument.on( eventName, spy );
 
-			observer.onDomEvent( { type: 'mousedown', target: document.body } );
+				observer.onDomEvent( { type: eventName, target: document.body } );
 
-			expect( spy.calledOnce ).to.be.true;
+				expect( spy.calledOnce ).to.be.true;
 
-			const data = spy.args[ 0 ][ 1 ];
-			expect( data.domTarget ).to.equal( document.body );
-		} );
+				const data = spy.args[ 0 ][ 1 ];
+				expect( data.domTarget ).to.equal( document.body );
+			} );
+		}
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Enhancement: Added '`mouseup'`, `'mousemove'` and `'mouseleave'` events to `MouseObserver`. Closes ckeditor/ckeditor5#6152.

---

### Additional information

- This PR adds events required by table selection feature. At this stage, it is not required by its own.
- The events in table selection are used to:
    - '`mouseup'` - stop selecting table cells
    - `'mousemove'` - 
    - `'mouseleave'`
