### PR TITLE
Improved parseAttributes function performance

### DIFF
--- a/src/view/element.js
+++ b/src/view/element.js
@@ -10,7 +10,7 @@
 import Node from './node';
 import Text from './text';
 import TextProxy from './textproxy';
-import objectToMap from '@ckeditor/ckeditor5-utils/src/objecttomap';
+import toMap from '@ckeditor/ckeditor5-utils/src/tomap';
 import isIterable from '@ckeditor/ckeditor5-utils/src/isiterable';
 import Matcher from './matcher';
 import { isPlainObject } from 'lodash-es';
@@ -853,17 +853,13 @@ export default class Element extends Node {
 }
 
 // Parses attributes provided to the element constructor before they are applied to an element. If attributes are passed
-// as an object (instead of `Map`), the object is transformed to the map. Attributes with `null` value are removed.
+// as an object (instead of `Iterable`), the object is transformed to the map. Attributes with `null` value are removed.
 // Attributes with non-`String` value are converted to `String`.
 //
-// @param {Object|Map} attrs Attributes to parse.
+// @param {Object|Iterable} attrs Attributes to parse.
 // @returns {Map} Parsed attributes.
 function parseAttributes( attrs ) {
-	if ( attrs instanceof Map ) {
-		attrs = new Map( attrs );
-	} else {
-		attrs = objectToMap( attrs );
-	}
+	attrs = toMap( attrs );
 
 	for ( const [ key, value ] of attrs ) {
 		if ( value === null ) {

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -859,10 +859,10 @@ export default class Element extends Node {
 // @param {Object|Map} attrs Attributes to parse.
 // @returns {Map} Parsed attributes.
 function parseAttributes( attrs ) {
-	if ( isPlainObject( attrs ) ) {
-		attrs = objectToMap( attrs );
-	} else {
+	if ( attrs instanceof Map ) {
 		attrs = new Map( attrs );
+	} else {
+		attrs = objectToMap( attrs );
 	}
 
 	for ( const [ key, value ] of attrs ) {

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -13,7 +13,6 @@ import TextProxy from './textproxy';
 import toMap from '@ckeditor/ckeditor5-utils/src/tomap';
 import isIterable from '@ckeditor/ckeditor5-utils/src/isiterable';
 import Matcher from './matcher';
-import { isPlainObject } from 'lodash-es';
 import StylesMap from './stylesmap';
 
 // @if CK_DEBUG_ENGINE // const { convertMapToTags } = require( '../dev-utils/utils' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Improved `parseAttributes` function performance. This results with improved editor data processing speed. Closes ckeditor/ckeditor5#5854.

---

### Additional information

`parseAttributes` function suffered a copy'n'pasta from [utils' toMap function](https://github.com/ckeditor/ckeditor5-utils/blob/b57fc3f37e955e4acb3d0d94519a5b81876601a3/src/tomap.js#L24-L28). It required same adjustment as in ckeditor/ckeditor5-utils#323. Or even better to reuse `toMap` function, which is what this PR does.

A sub-pr of ckeditor/ckeditor5-utils#323.