### PR TITLE
6235: Background color normalizer should accept spaces in values.

### DIFF
--- a/src/view/styles/background.js
+++ b/src/view/styles/background.js
@@ -7,7 +7,7 @@
  * @module engine/view/styles/background
  */
 
-import { isAttachment, isColor, isPosition, isRepeat, isURL } from './utils';
+import { getShorthandValues, isAttachment, isColor, isPosition, isRepeat, isURL } from './utils';
 
 /**
  * Adds a background CSS styles processing rules.
@@ -46,7 +46,7 @@ export function addBackgroundRules( stylesProcessor ) {
 function normalizeBackground( value ) {
 	const background = {};
 
-	const parts = value.split( ' ' );
+	const parts = getShorthandValues( value );
 
 	for ( const part of parts ) {
 		if ( isRepeat( part ) ) {

--- a/tests/view/styles/background.js
+++ b/tests/view/styles/background.js
@@ -20,7 +20,6 @@ describe( 'Background styles normalization', () => {
 	} );
 
 	it( 'should normalize background', () => {
-		// TODO: border-box given only for coverage test.
 		styles.setTo( 'background:url("example.jpg") center #f00 repeat-y fixed border-box;' );
 
 		expect( styles.getNormalized( 'background' ) ).to.deep.equal( {
@@ -32,7 +31,27 @@ describe( 'Background styles normalization', () => {
 		} );
 	} );
 
-	// TODO: define what should happen with layers
+	it( 'should normalize background (color with spaces)', () => {
+		styles.setTo( 'background:url("example.jpg") center rgb(253, 253, 119) repeat-y fixed border-box;' );
+
+		expect( styles.getNormalized( 'background' ) ).to.deep.equal( {
+			attachment: 'fixed',
+			image: 'url("example.jpg")',
+			position: [ 'center' ],
+			repeat: [ 'repeat-y' ],
+			color: 'rgb(253, 253, 119)'
+		} );
+	} );
+
+	it( 'should normalize background (color only with spaces)', () => {
+		styles.setTo( 'background: rgb(253, 253, 119);' );
+
+		expect( styles.getNormalized( 'background' ) ).to.deep.equal( {
+			color: 'rgb(253, 253, 119)'
+		} );
+	} );
+
+	// Layers are not supported.
 	it.skip( 'should normalize background with layers', () => {
 		styles.setTo( 'background:url("test.jpg") repeat-y,#f00;' );
 
@@ -43,6 +62,12 @@ describe( 'Background styles normalization', () => {
 		styles.setTo( 'background-color:#f00;' );
 
 		expect( styles.getNormalized( 'background' ) ).to.deep.equal( { color: '#f00' } );
+	} );
+
+	it( 'should normalize background-color with rgb() value', () => {
+		styles.setTo( 'background-color:rgba(253, 253, 119, 1);' );
+
+		expect( styles.getNormalized( 'background' ) ).to.deep.equal( { color: 'rgba(253, 253, 119, 1)' } );
 	} );
 
 	it( 'should output inline background-color style', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Background color normalizer should accept spaces in values. Closes ckeditor/ckeditor5#6235.

---

### Additional information

- [ ] Some tests also added in the PR: https://github.com/ckeditor/ckeditor5-table/pull/243
