### PR TITLE
I/6356: Extended `Model#deleteContent()` docs with an information about the `direction`

### DIFF
--- a/src/model/model.js
+++ b/src/model/model.js
@@ -438,6 +438,10 @@ export default class Model {
 	 * **Note:** if there is no valid position for the selection, the paragraph will always be created:
 	 *
 	 * `[<image src="foo.jpg"></image>]` -> `<paragraph>[]</paragraph>`.
+	 *
+	 * @param {'forward'|'backward'} [options.direction='backward'] The direction in which the content is being consumed.
+	 * Deleting backward corresponds to using the <kbd>Delete</kbd> key, while deleting content forward corresponds to
+	 * the <kbd>Shift</kbd>+<kbd>Delete</kbd> keystroke.
 	 */
 	deleteContent( selection, options ) {
 		deleteContent( this, selection, options );

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -440,8 +440,8 @@ export default class Model {
 	 * `[<image src="foo.jpg"></image>]` -> `<paragraph>[]</paragraph>`.
 	 *
 	 * @param {'forward'|'backward'} [options.direction='backward'] The direction in which the content is being consumed.
-	 * Deleting backward corresponds to using the <kbd>Delete</kbd> key, while deleting content forward corresponds to
-	 * the <kbd>Shift</kbd>+<kbd>Delete</kbd> keystroke.
+	 * Deleting backward corresponds to using the <kbd>Backspace</kbd> key, while deleting content forward corresponds to
+	 * the <kbd>Shift</kbd>+<kbd>Backspace</kbd> keystroke.
 	 */
 	deleteContent( selection, options ) {
 		deleteContent( this, selection, options );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Extended `Model#deleteContent()` docs with an information about the `direction` option (see ckeditor/ckeditor5#6356, ckeditor/ckeditor5#6355).

---

### Additional information

Part of: https://github.com/ckeditor/ckeditor5-table/pull/260.
