### PR TITLE
Fixed `view.Renderer` bug causing editor crash in some scenarios involving reusing DOM elements

### DIFF
--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -3217,6 +3217,24 @@ describe( 'Renderer', () => {
 
 				expect( domRoot.innerHTML ).to.equal( '<p><a href="#href">Foo<i>Bar</i></a></p>' );
 			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/6367.
+			it( 'should correctly handle moving a DOM element when rendering children', () => {
+				viewRoot._insertChild( 0, parse( 'y<attribute:span>x</attribute:span>' ) );
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const viewSpan = viewRoot._removeChildren( 1, 1 )[ 0 ];
+				viewRoot._insertChild( 0, viewSpan );
+				viewRoot._insertChild( 2, parse( '<attribute:strong>z</attribute:strong>' ) );
+
+				renderer.markToSync( 'children', viewRoot );
+
+				// This would throw without a fix.
+				renderer.render();
+
+				expect( domRoot.innerHTML ).to.equal( '<span>x</span>y<strong>z</strong>' );
+			} );
 		} );
 
 		describe( 'optimal (minimal) rendering – minimal children changes', () => {
@@ -3303,7 +3321,7 @@ describe( 'Renderer', () => {
 				expect( getMutationStats( observer.takeRecords() ) ).to.be.empty;
 			} );
 
-			it( 'should add and remove one', () => {
+			it( 'should remove and add one', () => {
 				viewRoot._appendChild( parse( '<container:p>1</container:p><container:p>2</container:p>' ) );
 
 				renderer.markToSync( 'children', viewRoot );
@@ -3317,8 +3335,8 @@ describe( 'Renderer', () => {
 				renderer.render();
 
 				expect( getMutationStats( observer.takeRecords() ) ).to.deep.equal( [
-					'added: 1, removed: 0',
-					'added: 0, removed: 1'
+					'added: 0, removed: 1',
+					'added: 1, removed: 0'
 				] );
 			} );
 
@@ -3450,7 +3468,7 @@ describe( 'Renderer', () => {
 					expect( getMutationStats( observer.takeRecords() ) ).to.be.empty;
 				} );
 
-				it( 'should add and remove one', () => {
+				it( 'should remove and add one', () => {
 					viewRoot._appendChild( parse( makeContainers( 151 ) ) );
 
 					renderer.markToSync( 'children', viewRoot );
@@ -3464,8 +3482,8 @@ describe( 'Renderer', () => {
 					renderer.render();
 
 					expect( getMutationStats( observer.takeRecords() ) ).to.deep.equal( [
-						'added: 1, removed: 0',
-						'added: 0, removed: 1'
+						'added: 0, removed: 1',
+						'added: 1, removed: 0'
 					] );
 				} );
 

--- a/tests/view/renderer.js
+++ b/tests/view/renderer.js
@@ -3245,6 +3245,29 @@ describe( 'Renderer', () => {
 
 				expect( domRoot.innerHTML ).to.equal( '<span>x</span>y<strong>z</strong>' );
 			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/6367, but more complex
+			it( 'should correctly handle moving a DOM element when rendering children (more complex case)', () => {
+				viewRoot._insertChild( 0,
+					parse( '1<attribute:span>2</attribute:span><attribute:span>3</attribute:span>4<attribute:span>5</attribute:span>' )
+				);
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const viewSpan5 = viewRoot._removeChildren( 4, 1 )[ 0 ];
+				const viewSpan2 = viewRoot._removeChildren( 1, 1 )[ 0 ];
+				viewRoot._insertChild( 0, viewSpan2 );
+				viewRoot._insertChild( 1, parse( '<attribute:strong>6</attribute:strong>' ) );
+				viewRoot._insertChild( 4, parse( '<attribute:strong>7</attribute:strong>' ) );
+				viewRoot._insertChild( 2, viewSpan5 );
+
+				renderer.markToSync( 'children', viewRoot );
+
+				// This would throw without a fix.
+				renderer.render();
+
+				expect( domRoot.innerHTML ).to.equal( '<span>2</span><strong>6</strong><span>5</span>1<span>3</span><strong>7</strong>4' );
+			} );
 		} );
 
 		describe( 'optimal (minimal) rendering – minimal children changes', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed `view.Renderer` bug causing editor crash in some scenarios involving reusing DOM elements. Closes ckeditor/ckeditor5#6092.

---

### Additional information

To fix the issue, I inverted the order in which the actions in `_updateChildren()` happen. Earlier, after getting a diff, actions were performed one after another, as in `diff` array. I've changed it, so now deletions are performed first and insertions later. This prevents the situation where we are inserting a child which is still in that parent (as described in the ticket).

There was an alternative solution, where instead I did `Array.from()` on `actualDomChildren` and then was updating `actualDomChildren` in the `diff` loop and then when delete action was handled, I was checking if the element was already in `actualDomChildren`.

I think that the solution from PR is safer, though.

I've added only one unit test to confirm that the solution is working. The test is a scenario described in https://github.com/ckeditor/ckeditor5/issues/6367. It tests exactly the described problem, that is, moving a DOM element "back".

The umbrella issue mentions a couple of issues.

I've tested:

* https://github.com/ckeditor/ckeditor5/issues/5910
* https://github.com/ckeditor/ckeditor5/issues/1579
* https://github.com/ckeditor/ckeditor5/issues/6367

I haven't tested:

* https://github.com/ckeditor/ckeditor5/issues/5601
* https://github.com/ckeditor/ckeditor5/issues/5843

TODO:

1. Please confirm that the fix works. It would be a good idea to try to test the cases I haven't checked.
2. Write more unit tests that would focus on the cases described in those issues.