### PR TITLE
i/6381: Created a single DataController#viewDocument. Used the document in Da…

### DIFF
--- a/src/controller/datacontroller.js
+++ b/src/controller/datacontroller.js
@@ -104,6 +104,24 @@ export default class DataController {
 			schema: model.schema
 		} );
 
+		/**
+		 * The view document used by the data controller.
+		 *
+		 * @readonly
+		 * @member {module:engine/view/document~Document}
+		 */
+		this.viewDocument = new ViewDocument( stylesProcessor );
+
+		/**
+		 * The view downcast writer just for data conversion purposes, i.e. to modify
+		 * the {@link #viewDocument}.
+		 *
+		 * @private
+		 * @readonly
+		 * @member {module:engine/view/downcastwriter~DowncastWriter}
+		 */
+		this._viewWriter = new ViewDowncastWriter( this.viewDocument );
+
 		// Define default converters for text and elements.
 		//
 		// Note that if there is no default converter for the element it will be skipped, for instance `<b>foo</b>` will be
@@ -188,20 +206,19 @@ export default class DataController {
 	 * @returns {module:engine/view/documentfragment~DocumentFragment} Output view DocumentFragment.
 	 */
 	toView( modelElementOrFragment ) {
+		const viewDocument = this.viewDocument;
+		const viewWriter = this._viewWriter;
+
 		// Clear bindings so the call to this method gives correct results.
 		this.mapper.clearBindings();
 
 		// First, convert elements.
 		const modelRange = ModelRange._createIn( modelElementOrFragment );
-		const viewDocument = new ViewDocument( this.stylesProcessor );
-
 		const viewDocumentFragment = new ViewDocumentFragment( viewDocument );
 
-		// Create separate ViewDowncastWriter just for data conversion purposes.
-		// We have no view controller and rendering do DOM in DataController so view.change() block is not used here.
-		const viewWriter = new ViewDowncastWriter( viewDocument );
 		this.mapper.bindElements( modelElementOrFragment, viewDocumentFragment );
 
+		// We have no view controller and rendering do DOM in DataController so view.change() block is not used here.
 		this.downcastDispatcher.convertInsert( modelRange, viewWriter );
 
 		if ( !modelElementOrFragment.is( 'documentFragment' ) ) {

--- a/tests/controller/datacontroller.js
+++ b/tests/controller/datacontroller.js
@@ -56,6 +56,13 @@ describe( 'DataController', () => {
 			expect( data.model ).to.equal( model );
 			expect( data.stylesProcessor ).to.equal( stylesProcessor );
 		} );
+
+		it( 'should create the #viewDocument property', () => {
+			const stylesProcessor = new StylesProcessor();
+			const data = new DataController( model, stylesProcessor );
+
+			expect( data.viewDocument ).to.be.instanceOf( ViewDocument );
+		} );
 	} );
 
 	describe( 'parse()', () => {
@@ -472,6 +479,13 @@ describe( 'DataController', () => {
 			schema.extend( 'div', { allowIn: '$root' } );
 
 			downcastHelpers.elementToElement( { model: 'paragraph', view: 'p' } );
+		} );
+
+		it( 'should use #viewDocument as a parent for returned document fragments', () => {
+			const modelElement = parseModel( '<div><paragraph>foo</paragraph></div>', schema );
+			const viewDocumentFragment = data.toView( modelElement );
+
+			expect( viewDocumentFragment.document ).to.equal( data.viewDocument );
 		} );
 
 		it( 'should convert a content of an element', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Created a single `DataController#viewDocument`. Used that document in `DataController#toView` instead of re-creating it each time the method is called. Closes ckeditor/ckeditor5#6381.

---

### Additional information

* [CI **and docs**](https://github.com/ckeditor/ckeditor5/compare/i/6381?expand=1)
* **exec `mrgit sync` after checking out the branch in `ckeditor5` to get changes in all repositories**, they are mostly one-liners and I'm lazy so I decided there's no need for separate PRs.
