### PR TITLE
I/6501: Handle intersecting ranges when fixing graveyard selection

### DIFF
--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -1137,9 +1137,9 @@ class LiveSelection extends Selection {
 		liveRange.detach();
 
 		// If nearest valid selection range has been found - add it in the place of old range.
-		// If range is intersecting with other selection ranges then it is probably due to contents
+		// If range is equal to any other selection ranges then it is probably due to contents
 		// of a multi-range selection being removed. See ckeditor/ckeditor5#6501.
-		if ( selectionRange && !isRangeIntersectingWithSelection( selectionRange, this ) ) {
+		if ( selectionRange && !isRangeCollidingWithSelection( selectionRange, this ) ) {
 			// Check the range, convert it to live range, bind events, etc.
 			const newRange = this._prepareRange( selectionRange );
 
@@ -1192,7 +1192,7 @@ function clearAttributesStoredInElement( model, batch ) {
 	}
 }
 
-// Checks if range intersects with any of selection ranges.
-function isRangeIntersectingWithSelection( range, selection ) {
-	return !selection._ranges.every( selectionRange => !range.isIntersecting( selectionRange ) );
+// Checks if range collides with any of selection ranges.
+function isRangeCollidingWithSelection( range, selection ) {
+	return !selection._ranges.every( selectionRange => !range.isEqual( selectionRange ) );
 }

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -1137,7 +1137,7 @@ class LiveSelection extends Selection {
 		liveRange.detach();
 
 		// If nearest valid selection range has been found - add it in the place of old range.
-		if ( selectionRange ) {
+		if ( selectionRange && !isIntersecting( this._ranges, selectionRange ) ) {
 			// Check the range, convert it to live range, bind events, etc.
 			const newRange = this._prepareRange( selectionRange );
 
@@ -1189,4 +1189,16 @@ function clearAttributesStoredInElement( model, batch ) {
 			} );
 		}
 	}
+}
+
+// Checks if range intersects with any given ranges.
+function isIntersecting( ranges, selectionRange ) {
+	for ( let i = 0; i < ranges.length; i++ ) {
+		if ( selectionRange.isIntersecting( ranges[ i ] ) ) {
+			// It is also fine - as we can have multiple ranges in the selection.
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -1137,14 +1137,16 @@ class LiveSelection extends Selection {
 		liveRange.detach();
 
 		// If nearest valid selection range has been found - add it in the place of old range.
-		if ( selectionRange && !isIntersecting( this._ranges, selectionRange ) ) {
+		// If range is intersecting with other selection ranges then it is probably due to contents
+		// of a multi-range selection being removed. See ckeditor/ckeditor5#6501.
+		if ( selectionRange && !isRangeIntersectingWithSelection( selectionRange, this ) ) {
 			// Check the range, convert it to live range, bind events, etc.
 			const newRange = this._prepareRange( selectionRange );
 
 			// Add new range in the place of old range.
 			this._ranges.splice( index, 0, newRange );
 		}
-		// If nearest valid selection range cannot be found - just removing the old range is fine.
+		// If nearest valid selection range cannot be found or is intersecting with other selection ranges removing the old range is fine.
 	}
 }
 
@@ -1164,7 +1166,6 @@ function getAttrsIfCharacter( node ) {
 
 // Removes selection attributes from element which is not empty anymore.
 //
-// @private
 // @param {module:engine/model/model~Model} model
 // @param {module:engine/model/batch~Batch} batch
 function clearAttributesStoredInElement( model, batch ) {
@@ -1191,14 +1192,7 @@ function clearAttributesStoredInElement( model, batch ) {
 	}
 }
 
-// Checks if range intersects with any given ranges.
-function isIntersecting( ranges, selectionRange ) {
-	for ( let i = 0; i < ranges.length; i++ ) {
-		if ( selectionRange.isIntersecting( ranges[ i ] ) ) {
-			// It is also fine - as we can have multiple ranges in the selection.
-			return true;
-		}
-	}
-
-	return false;
+// Checks if range intersects with any of selection ranges.
+function isRangeIntersectingWithSelection( range, selection ) {
+	return !selection._ranges.every( selectionRange => !range.isIntersecting( selectionRange ) );
 }

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -1779,7 +1779,7 @@ describe( 'DocumentSelection', () => {
 				expect( selection.getFirstPosition().path ).to.deep.equal( [ 0, 0 ] );
 			} );
 
-			it( 'does not break if multi-range selection is inside text nodes', () => {
+			it( 'handles multi-range selection in a text node by merging it into one range (resulting in collapsed ranges)', () => {
 				const ranges = [
 					new Range( new Position( root, [ 1, 1 ] ), new Position( root, [ 1, 2 ] ) ),
 					new Range( new Position( root, [ 1, 3 ] ), new Position( root, [ 1, 4 ] ) )
@@ -1796,12 +1796,12 @@ describe( 'DocumentSelection', () => {
 					)
 				);
 
-				expect( selection.rangeCount ).to.equal( 2 );
+				expect( selection.rangeCount ).to.equal( 1 );
 				expect( selection.getFirstPosition().path ).to.deep.equal( [ 1, 1 ] );
 				expect( selection.getLastPosition().path ).to.deep.equal( [ 1, 1 ] );
 			} );
 
-			it( 'does not break if multi-range selection is set on object nodes and resulting ranges will intersect', () => {
+			it( 'handles multi-range selection on object nodes by merging it into one range (resulting in non-collapsed ranges)', () => {
 				model.schema.register( 'outer', {
 					isObject: true
 				} );

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -1778,6 +1778,28 @@ describe( 'DocumentSelection', () => {
 				// Now it's clear that it's the default range.
 				expect( selection.getFirstPosition().path ).to.deep.equal( [ 0, 0 ] );
 			} );
+
+			it( 'does not break if multi-range selection is moved (inside text nodes - resulting ranges are collapsed)', () => {
+				const ranges = [
+					new Range( new Position( root, [ 1, 1 ] ), new Position( root, [ 1, 2 ] ) ),
+					new Range( new Position( root, [ 1, 3 ] ), new Position( root, [ 1, 4 ] ) )
+				];
+
+				selection._setTo( ranges );
+
+				model.applyOperation(
+					new MoveOperation(
+						new Position( root, [ 1, 1 ] ),
+						4,
+						new Position( doc.graveyard, [ 0 ] ),
+						doc.version
+					)
+				);
+
+				expect( selection.rangeCount ).to.equal( 2 );
+				expect( selection.getFirstPosition().path ).to.deep.equal( [ 1, 1 ] );
+				expect( selection.getLastPosition().path ).to.deep.equal( [ 1, 1 ] );
+			} );
 		} );
 
 		it( '`DocumentSelection#change:range` event should be fire once even if selection contains multi-ranges', () => {

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -1779,7 +1779,7 @@ describe( 'DocumentSelection', () => {
 				expect( selection.getFirstPosition().path ).to.deep.equal( [ 0, 0 ] );
 			} );
 
-			it( 'does not break if multi-range selection is moved (inside text nodes - resulting ranges are collapsed)', () => {
+			it( 'does not break if multi-range selection is inside text nodes', () => {
 				const ranges = [
 					new Range( new Position( root, [ 1, 1 ] ), new Position( root, [ 1, 2 ] ) ),
 					new Range( new Position( root, [ 1, 3 ] ), new Position( root, [ 1, 4 ] ) )
@@ -1799,6 +1799,41 @@ describe( 'DocumentSelection', () => {
 				expect( selection.rangeCount ).to.equal( 2 );
 				expect( selection.getFirstPosition().path ).to.deep.equal( [ 1, 1 ] );
 				expect( selection.getLastPosition().path ).to.deep.equal( [ 1, 1 ] );
+			} );
+
+			it( 'does not break if multi-range selection is set on object nodes and resulting ranges will intersect', () => {
+				model.schema.register( 'outer', {
+					isObject: true
+				} );
+				model.schema.register( 'inner', {
+					isObject: true,
+					allowIn: 'outer'
+				} );
+
+				root._removeChildren( 0, root.childCount );
+				root._insertChild( 0, [
+					new Element( 'outer', [], [ new Element( 'inner' ), new Element( 'inner' ), new Element( 'inner' ) ] )
+				] );
+
+				const ranges = [
+					new Range( new Position( root, [ 0, 0 ] ), new Position( root, [ 0, 1 ] ) ),
+					new Range( new Position( root, [ 0, 1 ] ), new Position( root, [ 0, 2 ] ) )
+				];
+
+				selection._setTo( ranges );
+
+				model.applyOperation(
+					new MoveOperation(
+						new Position( root, [ 0, 0 ] ),
+						2,
+						new Position( doc.graveyard, [ 0 ] ),
+						doc.version
+					)
+				);
+
+				expect( selection.rangeCount ).to.equal( 1 );
+				expect( selection.getFirstPosition().path ).to.deep.equal( [ 0, 0 ] );
+				expect( selection.getLastPosition().path ).to.deep.equal( [ 0, 1 ] );
 			} );
 		} );
 

--- a/tests/model/documentselection.js
+++ b/tests/model/documentselection.js
@@ -1710,7 +1710,7 @@ describe( 'DocumentSelection', () => {
 		} );
 
 		describe( 'MoveOperation to graveyard', () => {
-			it( 'fix selection range if it ends up in graveyard #1', () => {
+			it( 'fix selection range if it ends up in graveyard - collapsed selection', () => {
 				selection._setTo( new Position( root, [ 1, 3 ] ) );
 
 				model.applyOperation(
@@ -1725,7 +1725,7 @@ describe( 'DocumentSelection', () => {
 				expect( selection.getFirstPosition().path ).to.deep.equal( [ 1, 2 ] );
 			} );
 
-			it( 'fix selection range if it ends up in graveyard #2', () => {
+			it( 'fix selection range if it ends up in graveyard - text from non-collapsed selection is moved', () => {
 				selection._setTo( [ new Range( new Position( root, [ 1, 2 ] ), new Position( root, [ 1, 4 ] ) ) ] );
 
 				model.applyOperation(
@@ -1740,7 +1740,7 @@ describe( 'DocumentSelection', () => {
 				expect( selection.getFirstPosition().path ).to.deep.equal( [ 1, 2 ] );
 			} );
 
-			it( 'fix selection range if it ends up in graveyard #3', () => {
+			it( 'fix selection range if it ends up in graveyard - parent of non-collapsed selection is moved', () => {
 				selection._setTo( [ new Range( new Position( root, [ 1, 1 ] ), new Position( root, [ 1, 2 ] ) ) ] );
 
 				model.applyOperation(
@@ -1755,7 +1755,7 @@ describe( 'DocumentSelection', () => {
 				expect( selection.getFirstPosition().path ).to.deep.equal( [ 0, 6 ] );
 			} );
 
-			it( 'fix selection range if it ends up in graveyard #4 - whole content removed', () => {
+			it( 'fix selection range if it ends up in graveyard - whole content removed', () => {
 				model.applyOperation(
 					new MoveOperation(
 						new Position( root, [ 0 ] ),

--- a/tests/model/range.js
+++ b/tests/model/range.js
@@ -156,6 +156,13 @@ describe( 'Range', () => {
 			const otherRange = new Range( new Position( otherRoot, [ 0 ] ), new Position( otherRoot, [ 1, 4 ] ) );
 			expect( range.isIntersecting( otherRange ) ).to.be.false;
 		} );
+
+		it( 'should return false if ranges are collapsed and equal', () => {
+			range = new Range( new Position( root, [ 1, 1 ] ) );
+			const otherRange = new Range( new Position( otherRoot, [ 1, 1 ] ) );
+
+			expect( range.isIntersecting( otherRange ) ).to.be.false;
+		} );
 	} );
 
 	describe( 'static constructors', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Intersecting ranges resulting when fixing graveyard selection no longer breaks the editor. Closes ckeditor/ckeditor5#6501. Closes ckeditor/ckeditor5#6382.

---

### Additional information

PR to merge together: ckeditor/ckeditor5-table#293.

Well, it looks like intersecting ranges will be created on such modifications as in tables: multi-range selection set on table cells and their parent is removed. This would result in many ranges being fixed to the same range (thus intersecting with any other fixed range).

As with other ranges/positions fixes, I am not sure if I have a broad view of this problem. The proposed solution fixes this case and does not break other CKEditor 5 tests buuuut we do not have every case tested.