### PR TITLE
I/6529: Inline `is()` checks

### DIFF
--- a/src/model/documentfragment.js
+++ b/src/model/documentfragment.js
@@ -133,7 +133,7 @@ export default class DocumentFragment {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'documentFragment' || type == 'model:documentFragment';
+		return type === 'documentFragment' || type === 'model:documentFragment';
 	}
 
 	/**

--- a/src/model/documentselection.js
+++ b/src/model/documentselection.js
@@ -382,7 +382,7 @@ export default class DocumentSelection {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'selection' ||
+		return type === 'selection' ||
 			type == 'model:selection' ||
 			type == 'documentSelection' ||
 			type == 'model:documentSelection';

--- a/src/model/element.js
+++ b/src/model/element.js
@@ -117,10 +117,13 @@ export default class Element extends Node {
 	 */
 	is( type, name = null ) {
 		if ( !name ) {
-			return type == 'element' || type == this.name || type == 'node';
-		} else {
-			return type == 'element' && name == this.name;
+			return type === 'element' || type === 'model:element' ||
+				type === this.name || type === 'model:' + this.name ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === 'node' || type === 'model:node';
 		}
+
+		return name === this.name && ( type === 'element' || type === 'model:element' );
 	}
 
 	/**

--- a/src/model/element.js
+++ b/src/model/element.js
@@ -116,12 +116,10 @@ export default class Element extends Node {
 	 * @returns {Boolean}
 	 */
 	is( type, name = null ) {
-		const cutType = type.replace( /^model:/, '' );
-
 		if ( !name ) {
-			return cutType == 'element' || cutType == this.name || super.is( type );
+			return type == 'element' || type == this.name || type == 'node';
 		} else {
-			return cutType == 'element' && name == this.name;
+			return type == 'element' && name == this.name;
 		}
 	}
 

--- a/src/model/liveposition.js
+++ b/src/model/liveposition.js
@@ -80,7 +80,9 @@ export default class LivePosition extends Position {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'livePosition' || type == 'model:livePosition' || type == 'position' || type == 'model:position';
+		return type == 'livePosition' || type == 'model:livePosition' ||
+			// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+			type == 'position' || type == 'model:position';
 	}
 
 	/**

--- a/src/model/liveposition.js
+++ b/src/model/liveposition.js
@@ -80,7 +80,7 @@ export default class LivePosition extends Position {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'livePosition' || type == 'model:livePosition' || super.is( type );
+		return type == 'livePosition' || type == 'model:livePosition' || type == 'position' || type == 'model:position';
 	}
 
 	/**

--- a/src/model/liveposition.js
+++ b/src/model/liveposition.js
@@ -80,9 +80,9 @@ export default class LivePosition extends Position {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'livePosition' || type == 'model:livePosition' ||
+		return type === 'livePosition' || type === 'model:livePosition' ||
 			// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
-			type == 'position' || type == 'model:position';
+			type == 'position' || type === 'model:position';
 	}
 
 	/**

--- a/src/model/liverange.js
+++ b/src/model/liverange.js
@@ -57,7 +57,7 @@ export default class LiveRange extends Range {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'liveRange' || type == 'model:liveRange' || super.is( type );
+		return type == 'liveRange' || type == 'model:liveRange' || type == 'range' || type == 'model:range';
 	}
 
 	/**

--- a/src/model/liverange.js
+++ b/src/model/liverange.js
@@ -57,9 +57,9 @@ export default class LiveRange extends Range {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'liveRange' || type == 'model:liveRange' ||
+		return type === 'liveRange' || type === 'model:liveRange' ||
 			// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
-			type == 'range' || type == 'model:range';
+			type == 'range' || type === 'model:range';
 	}
 
 	/**

--- a/src/model/liverange.js
+++ b/src/model/liverange.js
@@ -57,7 +57,9 @@ export default class LiveRange extends Range {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'liveRange' || type == 'model:liveRange' || type == 'range' || type == 'model:range';
+		return type == 'liveRange' || type == 'model:liveRange' ||
+			// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+			type == 'range' || type == 'model:range';
 	}
 
 	/**

--- a/src/model/markercollection.js
+++ b/src/model/markercollection.js
@@ -463,7 +463,7 @@ class Marker {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'marker' || type == 'model:marker';
+		return type === 'marker' || type === 'model:marker';
 	}
 
 	/**

--- a/src/model/node.js
+++ b/src/model/node.js
@@ -431,7 +431,7 @@ export default class Node {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'node' || type == 'model:node';
+		return type === 'node' || type === 'model:node';
 	}
 
 	/**

--- a/src/model/node.js
+++ b/src/model/node.js
@@ -10,7 +10,6 @@
 import toMap from '@ckeditor/ckeditor5-utils/src/tomap';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import compareArrays from '@ckeditor/ckeditor5-utils/src/comparearrays';
-
 // To check if component is loaded more than once.
 import '@ckeditor/ckeditor5-utils/src/version';
 
@@ -500,11 +499,3 @@ export default class Node {
 		this._attrs.clear();
 	}
 }
-
-/**
- * The node's parent does not contain this node.
- *
- * This error may be thrown from corrupted trees.
- *
- * @error model-node-not-found-in-parent
- */

--- a/src/model/position.js
+++ b/src/model/position.js
@@ -540,7 +540,7 @@ export default class Position {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'position' || type == 'model:position';
+		return type === 'position' || type === 'model:position';
 	}
 
 	/**

--- a/src/model/range.js
+++ b/src/model/range.js
@@ -158,7 +158,7 @@ export default class Range {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'range' || type == 'model:range';
+		return type === 'range' || type === 'model:range';
 	}
 
 	/**

--- a/src/model/rootelement.js
+++ b/src/model/rootelement.js
@@ -81,10 +81,18 @@ export default class RootElement extends Element {
 	 */
 	is( type, name ) {
 		if ( !name ) {
-			return type == 'rootElement' || type == 'element' || type == this.name || type == 'node';
-		} else {
-			return ( type == 'rootElement' && name == this.name ) || ( type === 'element' && name == this.name );
+			return type === 'rootElement' || type === 'model:rootElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === 'element' || type === 'model:element' ||
+				type === this.name || type === 'model:' + this.name ||
+				type === 'node' || type === 'model:node';
 		}
+
+		return name === this.name && (
+			type === 'rootElement' || type === 'model:rootElement' ||
+			// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+			type === 'element' || type === 'model:element'
+		);
 	}
 
 	/**
@@ -104,3 +112,4 @@ export default class RootElement extends Element {
 	// @if CK_DEBUG_ENGINE // 	console.log( 'ModelRootElement: ' + this );
 	// @if CK_DEBUG_ENGINE // }
 }
+

--- a/src/model/rootelement.js
+++ b/src/model/rootelement.js
@@ -80,11 +80,10 @@ export default class RootElement extends Element {
 	 * @returns {Boolean}
 	 */
 	is( type, name ) {
-		const cutType = type.replace( 'model:', '' );
 		if ( !name ) {
-			return cutType == 'rootElement' || super.is( type );
+			return type == 'rootElement' || type == 'element' || type == this.name || type == 'node';
 		} else {
-			return ( cutType == 'rootElement' && name == this.name ) || super.is( type, name );
+			return ( type == 'rootElement' && name == this.name ) || ( type === 'element' && name == this.name );
 		}
 	}
 

--- a/src/model/selection.js
+++ b/src/model/selection.js
@@ -632,7 +632,7 @@ export default class Selection {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'selection' || type == 'model:selection';
+		return type === 'selection' || type === 'model:selection';
 	}
 
 	/**

--- a/src/model/text.js
+++ b/src/model/text.js
@@ -82,7 +82,7 @@ export default class Text extends Node {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'text' || type == 'model:text' || super.is( type );
+		return type == 'text' || type == 'node';
 	}
 
 	/**

--- a/src/model/text.js
+++ b/src/model/text.js
@@ -82,7 +82,8 @@ export default class Text extends Node {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'text' || type == 'node';
+		return type === 'text' || type === 'model:text' ||
+			type === 'node' || type === 'model:node';
 	}
 
 	/**

--- a/src/model/text.js
+++ b/src/model/text.js
@@ -83,6 +83,7 @@ export default class Text extends Node {
 	 */
 	is( type ) {
 		return type === 'text' || type === 'model:text' ||
+			// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
 			type === 'node' || type === 'model:node';
 	}
 

--- a/src/model/textproxy.js
+++ b/src/model/textproxy.js
@@ -178,7 +178,7 @@ export default class TextProxy {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'textProxy' || type == 'model:textProxy';
+		return type === 'textProxy' || type === 'model:textProxy';
 	}
 
 	/**

--- a/src/model/writer.js
+++ b/src/model/writer.js
@@ -1360,14 +1360,14 @@ export default class Writer {
 			const markerRange = marker.getRange();
 			let isAffected = false;
 
-			if ( type == 'move' ) {
+			if ( type === 'move' ) {
 				isAffected =
 					positionOrRange.containsPosition( markerRange.start ) ||
 					positionOrRange.start.isEqual( markerRange.start ) ||
 					positionOrRange.containsPosition( markerRange.end ) ||
 					positionOrRange.end.isEqual( markerRange.end );
 			} else {
-				// if type == 'merge'.
+				// if type === 'merge'.
 				const elementBefore = positionOrRange.nodeBefore;
 				const elementAfter = positionOrRange.nodeAfter;
 

--- a/src/view/attributeelement.js
+++ b/src/view/attributeelement.js
@@ -157,12 +157,10 @@ export default class AttributeElement extends Element {
 	 * @returns {Boolean}
 	 */
 	is( type, name = null ) {
-		const cutType = type && type.replace( /^view:/, '' );
-
 		if ( !name ) {
-			return cutType == 'attributeElement' || super.is( type );
+			return type == 'attributeElement' || type == 'element' || type == this.name || type == 'node';
 		} else {
-			return ( cutType == 'attributeElement' && name == this.name ) || super.is( type, name );
+			return ( type == 'attributeElement' && name == this.name ) || ( type == 'element' && name == this.name );
 		}
 	}
 

--- a/src/view/attributeelement.js
+++ b/src/view/attributeelement.js
@@ -158,9 +158,17 @@ export default class AttributeElement extends Element {
 	 */
 	is( type, name = null ) {
 		if ( !name ) {
-			return type == 'attributeElement' || type == 'element' || type == this.name || type == 'node';
+			return type === 'attributeElement' || type === 'view:attributeElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === this.name || type === 'view:' + this.name ||
+				type === 'element' || type === 'view:element' ||
+				type === 'node' || type === 'view:node';
 		} else {
-			return ( type == 'attributeElement' && name == this.name ) || ( type == 'element' && name == this.name );
+			return name === this.name && (
+				type === 'attributeElement' || type === 'view:attributeElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === 'element' || type === 'view:element'
+			);
 		}
 	}
 

--- a/src/view/containerelement.js
+++ b/src/view/containerelement.js
@@ -84,9 +84,17 @@ export default class ContainerElement extends Element {
 	 */
 	is( type, name = null ) {
 		if ( !name ) {
-			return type == 'containerElement' || type == 'element' || type == this.name || type == 'node';
+			return type === 'containerElement' || type === 'view:containerElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === this.name || type === 'view:' + this.name ||
+				type === 'element' || type === 'view:element' ||
+				type === 'node' || type === 'view:node';
 		} else {
-			return ( type == 'containerElement' && name == this.name ) || ( type == 'element' && name == this.name );
+			return name === this.name && (
+				type === 'containerElement' || type === 'view:containerElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === 'element' || type === 'view:element'
+			);
 		}
 	}
 }

--- a/src/view/containerelement.js
+++ b/src/view/containerelement.js
@@ -83,11 +83,10 @@ export default class ContainerElement extends Element {
 	 * @returns {Boolean}
 	 */
 	is( type, name = null ) {
-		const cutType = type && type.replace( /^view:/, '' );
 		if ( !name ) {
-			return cutType == 'containerElement' || super.is( type );
+			return type == 'containerElement' || type == 'element' || type == this.name || type == 'node';
 		} else {
-			return ( cutType == 'containerElement' && name == this.name ) || super.is( type, name );
+			return ( type == 'containerElement' && name == this.name ) || ( type == 'element' && name == this.name );
 		}
 	}
 }

--- a/src/view/documentfragment.js
+++ b/src/view/documentfragment.js
@@ -118,7 +118,7 @@ export default class DocumentFragment {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'documentFragment' || type == 'view:documentFragment';
+		return type === 'documentFragment' || type === 'view:documentFragment';
 	}
 
 	/**

--- a/src/view/documentselection.js
+++ b/src/view/documentselection.js
@@ -292,7 +292,7 @@ export default class DocumentSelection {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'selection' ||
+		return type === 'selection' ||
 			type == 'documentSelection' ||
 			type == 'view:selection' ||
 			type == 'view:documentSelection';

--- a/src/view/editableelement.js
+++ b/src/view/editableelement.js
@@ -96,9 +96,19 @@ export default class EditableElement extends ContainerElement {
 	 */
 	is( type, name = null ) {
 		if ( !name ) {
-			return type == 'editableElement' || type == 'containerElement' || type == 'element' || type == this.name || type == 'node';
+			return type === 'editableElement' || type === 'view:editableElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === 'containerElement' || type === 'view:containerElement' ||
+				type === this.name || type === 'view:' + this.name ||
+				type === 'element' || type === 'view:element' ||
+				type === 'node' || type === 'view:node';
 		} else {
-			return name == this.name && ( type == 'editableElement' || type == 'containerElement' || type == 'element' );
+			return name === this.name && (
+				type === 'editableElement' || type === 'view:editableElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === 'containerElement' || type === 'view:containerElement' ||
+				type === 'element' || type === 'view:element'
+			);
 		}
 	}
 

--- a/src/view/editableelement.js
+++ b/src/view/editableelement.js
@@ -95,11 +95,10 @@ export default class EditableElement extends ContainerElement {
 	 * @returns {Boolean}
 	 */
 	is( type, name = null ) {
-		const cutType = type && type.replace( /^view:/, '' );
 		if ( !name ) {
-			return cutType == 'editableElement' || super.is( type );
+			return type == 'editableElement' || type == 'containerElement' || type == 'element' || type == this.name || type == 'node';
 		} else {
-			return ( cutType == 'editableElement' && name == this.name ) || super.is( type, name );
+			return name == this.name && ( type == 'editableElement' || type == 'containerElement' || type == 'element' );
 		}
 	}
 

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -176,11 +176,10 @@ export default class Element extends Node {
 	 * @returns {Boolean}
 	 */
 	is( type, name = null ) {
-		const cutType = type.replace( /^view:/, '' );
 		if ( !name ) {
-			return cutType == 'element' || cutType == this.name || super.is( type );
+			return type == 'element' || type == this.name || type == 'node' || type == 'view:node';
 		} else {
-			return cutType == 'element' && name == this.name;
+			return type == 'element' && name == this.name;
 		}
 	}
 

--- a/src/view/element.js
+++ b/src/view/element.js
@@ -177,9 +177,12 @@ export default class Element extends Node {
 	 */
 	is( type, name = null ) {
 		if ( !name ) {
-			return type == 'element' || type == this.name || type == 'node' || type == 'view:node';
+			return type === this.name || type === 'view:' + this.name ||
+				type === 'element' || type === 'view:element' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === 'node' || type === 'view:node';
 		} else {
-			return type == 'element' && name == this.name;
+			return name === this.name && ( type === 'element' || type === 'view:element' );
 		}
 	}
 

--- a/src/view/emptyelement.js
+++ b/src/view/emptyelement.js
@@ -75,9 +75,16 @@ export default class EmptyElement extends Element {
 	 */
 	is( type, name = null ) {
 		if ( !name ) {
-			return type == 'emptyElement' || type == 'element' || type == this.name || type == 'node';
+			return type === 'emptyElement' || type === 'view:emptyElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === this.name || type === 'view:' + this.name ||
+				type === 'element' || type === 'view:element' ||
+				type === 'node' || type === 'view:node';
 		} else {
-			return ( type == 'emptyElement' && name == this.name ) || ( type == 'element' && name == this.name );
+			return name === this.name && (
+				type === 'emptyElement' || type === 'view:emptyElement' ||
+				type === 'element' || type === 'view:element'
+			);
 		}
 	}
 

--- a/src/view/emptyelement.js
+++ b/src/view/emptyelement.js
@@ -74,11 +74,10 @@ export default class EmptyElement extends Element {
 	 * @returns {Boolean}
 	 */
 	is( type, name = null ) {
-		const cutType = type.replace( /^view:/, '' );
 		if ( !name ) {
-			return cutType == 'emptyElement' || super.is( type );
+			return type == 'emptyElement' || type == 'element' || type == this.name || type == 'node';
 		} else {
-			return ( cutType == 'emptyElement' && name == this.name ) || super.is( type, name );
+			return ( type == 'emptyElement' && name == this.name ) || ( type == 'element' && name == this.name );
 		}
 	}
 

--- a/src/view/node.js
+++ b/src/view/node.js
@@ -339,7 +339,7 @@ export default class Node {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'node' || type == 'view:node';
+		return type === 'node' || type === 'view:node';
 	}
 
 	/**

--- a/src/view/position.js
+++ b/src/view/position.js
@@ -222,7 +222,7 @@ export default class Position {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'position' || type == 'view:position';
+		return type === 'position' || type === 'view:position';
 	}
 
 	/**

--- a/src/view/range.js
+++ b/src/view/range.js
@@ -449,7 +449,7 @@ export default class Range {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'range' || type == 'view:range';
+		return type === 'range' || type === 'view:range';
 	}
 
 	/**

--- a/src/view/rooteditableelement.js
+++ b/src/view/rooteditableelement.js
@@ -69,11 +69,21 @@ export default class RootEditableElement extends EditableElement {
 	 */
 	is( type, name = null ) {
 		if ( !name ) {
-			return type == 'rootElement' || type == 'editableElement' || type == 'containerElement' || type == 'element' ||
-				type == this.name || type == 'node';
+			return type === 'rootElement' || type === 'view:rootElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === 'editableElement' || type === 'view:editableElement' ||
+				type === 'containerElement' || type === 'view:containerElement' ||
+				type === this.name || type === 'view:' + this.name ||
+				type === 'element' || type === 'view:element' ||
+				type === 'node' || type === 'view:node';
 		} else {
-			return name == this.name &&
-				( type == 'rootElement' || type == 'editableElement' || type == 'containerElement' || type == 'element' );
+			return name === this.name && (
+				type === 'rootElement' || type === 'view:rootElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === 'editableElement' || type === 'view:editableElement' ||
+				type === 'containerElement' || type === 'view:containerElement' ||
+				type === 'element' || type === 'view:element'
+			);
 		}
 	}
 

--- a/src/view/rooteditableelement.js
+++ b/src/view/rooteditableelement.js
@@ -68,11 +68,12 @@ export default class RootEditableElement extends EditableElement {
 	 * @returns {Boolean}
 	 */
 	is( type, name = null ) {
-		const cutType = type.replace( /^view:/, '' );
 		if ( !name ) {
-			return cutType == 'rootElement' || super.is( type );
+			return type == 'rootElement' || type == 'editableElement' || type == 'containerElement' || type == 'element' ||
+				type == this.name || type == 'node';
 		} else {
-			return ( cutType == 'rootElement' && name == this.name ) || super.is( type, name );
+			return name == this.name &&
+				( type == 'rootElement' || type == 'editableElement' || type == 'containerElement' || type == 'element' );
 		}
 	}
 

--- a/src/view/selection.js
+++ b/src/view/selection.js
@@ -590,7 +590,7 @@ export default class Selection {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'selection' || type == 'view:selection';
+		return type === 'selection' || type === 'view:selection';
 	}
 
 	/**

--- a/src/view/text.js
+++ b/src/view/text.js
@@ -60,7 +60,7 @@ export default class Text extends Node {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'text' || type == 'view:text' || super.is( type );
+		return type === 'text' || type === 'view:text' || super.is( type );
 	}
 
 	/**

--- a/src/view/text.js
+++ b/src/view/text.js
@@ -60,7 +60,9 @@ export default class Text extends Node {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type === 'text' || type === 'view:text' || super.is( type );
+		return type === 'text' || type === 'view:text' ||
+			// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+			type === 'node' || type === 'view:node';
 	}
 
 	/**

--- a/src/view/textproxy.js
+++ b/src/view/textproxy.js
@@ -156,7 +156,7 @@ export default class TextProxy {
 	 * @returns {Boolean}
 	 */
 	is( type ) {
-		return type == 'textProxy' || type == 'view:textProxy';
+		return type === 'textProxy' || type === 'view:textProxy';
 	}
 
 	/**

--- a/src/view/uielement.js
+++ b/src/view/uielement.js
@@ -87,11 +87,10 @@ export default class UIElement extends Element {
 	 * @returns {Boolean}
 	 */
 	is( type, name = null ) {
-		const cutType = type.replace( /^view:/, '' );
 		if ( !name ) {
-			return cutType == 'uiElement' || super.is( type );
+			return type == 'uiElement' || type == 'element' || type == this.name || type == 'node';
 		} else {
-			return ( cutType == 'uiElement' && name == this.name ) || super.is( type, name );
+			return ( type == 'uiElement' && name == this.name ) || ( type == 'element' && name == this.name );
 		}
 	}
 

--- a/src/view/uielement.js
+++ b/src/view/uielement.js
@@ -88,9 +88,16 @@ export default class UIElement extends Element {
 	 */
 	is( type, name = null ) {
 		if ( !name ) {
-			return type == 'uiElement' || type == 'element' || type == this.name || type == 'node';
+			return type === 'uiElement' || type === 'view:uiElement' ||
+				// From super.is(). This is highly utilised method and cannot call super. See ckeditor/ckeditor5#6529.
+				type === this.name || type === 'view:' + this.name ||
+				type === 'element' || type === 'view:element' ||
+				type === 'node' || type === 'view:node';
 		} else {
-			return ( type == 'uiElement' && name == this.name ) || ( type == 'element' && name == this.name );
+			return name === this.name && (
+				type === 'uiElement' || type === 'view:uiElement' ||
+				type === 'element' || type === 'view:element'
+			);
 		}
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Inline calls to parent class in models and views `is()` checks to improve editor performance. Closes ckeditor/ckeditor5#6529.

---

### Additional information

That's a lot of changes but fortunately tests were very helpful here.

The API remained the same.
