### PR TITLE
ckeditor5-dev/i/611: Fixed stylelint errors related to colors and indentation

### DIFF
--- a/tests/manual/nestededitable.css
+++ b/tests/manual/nestededitable.css
@@ -7,11 +7,11 @@
 @import "@ckeditor/ckeditor5-theme-lark/theme/mixins/_shadow.css";
 
 figure {
-	background-color: #f3f3f3;
+	background-color: hsl(0, 0%, 95.3%);
 	padding: 10px;
 
 	& figcaption {
-		background: white;
+		background: hsl(0, 0%, 100%);
 		outline: none;
 
 		&.focused {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed stylelint errors related to colors and indentation (see ckeditor/ckeditor5-dev#611).
